### PR TITLE
Remove static date, replace with today + 1 year

### DIFF
--- a/js/calendar/calendar.js
+++ b/js/calendar/calendar.js
@@ -63,15 +63,17 @@ calendar.updateData = function (callback) {
 				}
 				e.seconds = seconds;
 			}
-			
+
 			// Special handling for rrule events
 			if (e.RRULE) {
 				var options = new RRule.parseString(e.RRULE);
 				options.dtstart = e.startDate;
 				var rule = new RRule(options);
-				
-				// TODO: don't use fixed end date here, use something like now() + 1 year
-				var dates = rule.between(new Date(), new Date(2016,11,31), true, function (date, i){return i < 10});
+
+        var oneYear = new Date();
+        oneYear.setFullYear(oneYear.getFullYear() + 1);
+
+				var dates = rule.between(new Date(), oneYear, true, function (date, i){return i < 10});
 				for (date in dates) {
 					var dt = new Date(dates[date]);
 					var days = moment(dt).diff(moment(), 'days');
@@ -84,7 +86,7 @@ calendar.updateData = function (callback) {
 							var time_string = moment(dt).calendar()
 						}
 						this.eventList.push({'description':e.SUMMARY,'seconds':seconds,'days':time_string});
-					}           
+					}
 				}
 			}
 		};


### PR DESCRIPTION
The fixed date `new Date(2016,11,31)` in `js/calendar/calendar.js` will mean that events with repetition dates won't appear past November 31, 2016 when that date eventually comes around. This change changes the window to `today + 1 year`.