### PR TITLE
Update calendar.js

### DIFF
--- a/js/calendar/calendar.js
+++ b/js/calendar/calendar.js
@@ -79,7 +79,7 @@ calendar.processEvents = function (url, events) {
 				this.eventList.push({'description':e.SUMMARY,'seconds':seconds,'days':time_string,'url': url, symbol: this.calendarSymbol});
 			}
 			e.seconds = seconds;
-		} else if  (endSeconds >= 0) {
+		} else if  (endSeconds > 0) {
 			// TODO: Replace with better lang handling
 			if (endSeconds <= 60*60*5 || endSeconds >= 60*60*24*2) {
 				var time_string = this.shortRunningText + ' ' + moment(endDate).fromNow(true);


### PR DESCRIPTION
endSeconds >= 0 shows me calendar entries which are 0 seconds long. E. g. entries from '24.01.2009 10:00' to '24.01.2009 10:00'. So I get them still displayed, even though they ended years ago. 

endSeconds > 0 fixed that for me.