### PR TITLE
Hopefully better version check.

### DIFF
--- a/controllers/hash.php
+++ b/controllers/hash.php
@@ -1,7 +1,34 @@
 <?php
+function getHash() {
+	$hash = exec('git rev-parse HEAD', $output, $returncode);
+	if ($returncode == 0) {
+		return '0-'.$hash;
+	}
+	// No git for php? Let's try parsing git structures
+	$file = dirname(str_replace('\\','/',__DIR__))."/.git/HEAD";
+	if (is_file($file)) {
+		$refOrCommit = file_get_contents($file);
+		if ($refOrCommit !== false && $refOrCommit !== null) {
+			if (strpos($refOrCommit, 'ref') !== false) {
+				list($ref, $head) = explode(' ', $refOrCommit);
+				$head = trim($head);
+				$file = dirname(str_replace('\\','/',__DIR__))."/.git/$head";
+				return '1-'.trim(file_get_contents($file));
+			} else {
+				return '2-'.trim($refOrCommit);
+			}
+		}
+		return 'static-version-sorry-no-auto-detect-of-changes';
+	}
+}
+
+if (str_replace('\\','/',__FILE__) == $_SERVER['SCRIPT_FILENAME']) {
+	header('Content-Type: application/json');
 	echo json_encode(
 	  array(
-	    "gitHash" => trim(`git rev-parse HEAD`)
+		"gitHash" => getHash(),
 	  )
 	);
-?>
+} else
+	echo getHash();
+

--- a/controllers/hash.php
+++ b/controllers/hash.php
@@ -2,24 +2,10 @@
 function getHash() {
 	$hash = exec('git rev-parse HEAD', $output, $returncode);
 	if ($returncode == 0) {
-		return '0-'.$hash;
+		return '0-'.trim($hash);
 	}
-	// No git for php? Let's try parsing git structures
-	$file = dirname(str_replace('\\','/',__DIR__))."/.git/HEAD";
-	if (is_file($file)) {
-		$refOrCommit = file_get_contents($file);
-		if ($refOrCommit !== false && $refOrCommit !== null) {
-			if (strpos($refOrCommit, 'ref') !== false) {
-				list($ref, $head) = explode(' ', $refOrCommit);
-				$head = trim($head);
-				$file = dirname(str_replace('\\','/',__DIR__))."/.git/$head";
-				return '1-'.trim(file_get_contents($file));
-			} else {
-				return '2-'.trim($refOrCommit);
-			}
-		}
-		return 'static-version-sorry-no-auto-detect-of-changes';
-	}
+	// No git for php?
+	return 'static-version-sorry-no-auto-detect-of-changes';
 }
 
 if (str_replace('\\','/',__FILE__) == $_SERVER['SCRIPT_FILENAME']) {

--- a/index.php
+++ b/index.php
@@ -7,7 +7,7 @@
 	<link rel="stylesheet" type="text/css" href="css/weather-icons.css">
 	<link rel="stylesheet" type="text/css" href="css/font-awesome.css">
 	<script type="text/javascript">
-		var gitHash = '<?php echo trim(`git rev-parse HEAD`) ?>';
+		var gitHash = '<?php include('controllers/hash.php') ?>';
 	</script>
 	<meta name="google" value="notranslate" />
 	<meta http-equiv="Content-type" content="text/html; charset=utf-8" />


### PR DESCRIPTION
Works on Windows to where by default php cannot use git. Uses .git filestructure then. If that fails to, return some static text