### PR TITLE
Switched to $.getJSON for auto-parsing to fix versions reloading

### DIFF
--- a/js/version/version.js
+++ b/js/version/version.js
@@ -8,20 +8,14 @@ var version = {
  */
 version.checkVersion = function () {
 
-	$.ajax({
-		type: 'GET',
-		url: 'controllers/hash.php',
-		success: function (data) {
+  $.getJSON('controllers/hash.php')
+    .success(function(data) {
 			// The githash variable is located in index.php
 			if (data && data.gitHash !== gitHash) {
 				window.location.reload();
 				window.location.href = window.location.href;
-			}
-		},
-		error: function () {
-
-		}
-	});
+      }
+    });
 
 }
 


### PR DESCRIPTION
Fixes #35 (at least mechanically, doesn't address larger questions about how to handle live reloading).

$.ajax() returns data in a string, which would always return undefined when asking for data.gitHash. Switching to $.getJSON() corrects this.