### PR TITLE
Initial config and oauth trial

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,11 +31,19 @@
 <script src="js/rrule.js"></script>
 <script src="js/version/version.js"></script>
 <script src="js/calendar/calendar.js"></script>
+<script src="https://apis.google.com/js/client.js?onload=checkAuth"></script>
 <script src="js/compliments/compliments.js"></script>
 <script src="js/weather/weather.js"></script>
 <script src="js/time/time.js"></script>
 <script src="js/news/news.js"></script>
 <script src="js/main.js?nocache=<?php echo md5(microtime()) ?>"></script>
+<div id="authorize-div" style="display: none">
+    <span>Authorize access to Google Calendar API</span>
+    <!--Button for the user to click to initiate auth sequence -->
+    <button id="authorize-button" onclick="calendar.handleAuthClick(event)">
+        Authorize
+    </button>
+</div>
 <!-- <script src="js/socket.io.min.js"></script> -->
 <?php  include(dirname(__FILE__).'/controllers/modules.php');?>
 </body>

--- a/js/config.js
+++ b/js/config.js
@@ -9,7 +9,7 @@ var config = {
         //change weather params here:
         //units: metric or imperial
         params: {
-            q: 'Baarn,Netherlands',
+            q: 'Baarn,Netherlands'
             units: 'metric',
             // if you want a different lang for the weather that what is set above, change it here
             lang: 'nl',
@@ -36,17 +36,30 @@ var config = {
         ]
     },
     calendar: {
-        maximumEntries: 10, // Total Maximum Entries
+        maximumEntries: 10, //Total Maximum Entries
 		displaySymbol: true,
 		defaultSymbol: 'calendar', // Fontawsome Symbol see http://fontawesome.io/cheatsheet/
+        // In order to fetch geegle calendar events on calendars that are shared you will need to use the google API
+        // to use the API you will need an API Client ID.
+        // the instructions are here: https://developers.google.com/google-apps/calendar/quickstart/js
+        // if you want to be able to access the calendar from another machine then you will also need to register the pi's
+        // local address not just localhost.
+        // Your Client ID can be retrieved from your project in the Google
+        // Developer Console, https://console.developers.google.com
+        // un comment googleCalendarApiId if you want to use it
+        //googleCalendarApiId: 'YOUR_API_CLIENT_ID',
         urls: [
-		{
-			symbol: 'calendar-plus-o', 
-			url: 'https://p01-calendarws.icloud.com/ca/subscribe/1/n6x7Farxpt7m9S8bHg1TGArSj7J6kanm_2KEoJPL5YIAk3y70FpRo4GyWwO-6QfHSY5mXtHcRGVxYZUf7U3HPDOTG5x0qYnno1Zr_VuKH2M'
-		},
-		{
-			symbol: 'soccer-ball-o',
-			url: 'https://www.google.com/calendar/ical/akvbisn5iha43idv0ktdalnor4%40group.calendar.google.com/public/basic.ics',
+        {
+            symbol: 'calendar-plus-o',
+            // googleOauthApi is a boolean to indicate which calendars should use the api instead of pulling the ics
+            googleOauthApi: false,
+            //if using the goodle api use the calendar ID instead of the ical url
+            url: 'https://p01-calendarws.icloud.com/ca/subscribe/1/n6x7Farxpt7m9S8bHg1TGArSj7J6kanm_2KEoJPL5YIAk3y70FpRo4GyWwO-6QfHSY5mXtHcRGVxYZUf7U3HPDOTG5x0qYnno1Zr_VuKH2M',
+        },
+        {
+            symbol: 'soccer-ball-o',
+            googleOauthApi: false,
+            url: 'https://www.google.com/calendar/ical/akvbisn5iha43idv0ktdalnor4%40group.calendar.google.com/public/basic.ics',
 		},
 		// {
 			// symbol: 'mars',

--- a/js/main.js
+++ b/js/main.js
@@ -26,9 +26,9 @@ function roundVal(temp)
 
 jQuery(document).ready(function($) {
 
-	var eventList = [];
+    var eventList = [];
 
-	var lastCompliment;
+    var lastCompliment;
 	var compliment;
 
     moment.locale(config.lang);
@@ -49,7 +49,7 @@ jQuery(document).ready(function($) {
 
 	time.init();
 
-	calendar.init();
+	//calendar.init();
 
 	compliments.init();
 


### PR DESCRIPTION
If you aren't the owner of a Google calendar then the private address is not available to you to download the ics.  Using Oauth2 and the Google Api you can achieve the same read permissions you would normally have.

I've added support for using the Google Api to allow use of shared Google calendars with the Magic Mirror.

Note: there are changes to the config.js  users should back up their old config and port their changes to the new one.

fixes #91 Google Calendar not working.