### PR TITLE
Fix Issue #95: "Openweather shows previous day's forecast, and it's wrong

### DIFF
--- a/js/weather/weather.js
+++ b/js/weather/weather.js
@@ -129,7 +129,11 @@ weather.updateWeatherForecast = function () {
 			for (var i = 0, count = data.list.length; i < count; i++) {
 
 				var _forecast = data.list[i];
-				
+
+				//don't show yesterday's forecast; each date, .dt is 12p local;
+				var _12hours = 60 * 60 * 12 * 1000;
+				if (_forecast.dt < Math.floor((Date.now() - _12hours) / 1000)) continue;
+
 				if (this.orientation == 'vertical') {
 					_forecastHtml2 = '';
 					_forecastHtml3 = '';


### PR DESCRIPTION
This is a fix for issue #95 
