### PR TITLE
Add optional wind direction in currentweather module

### DIFF
--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -14,7 +14,7 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
-			appid: 'abcde12345abcde12345abcde12345ab', //openweathermap.org API key.
+			appid: 'abcde12345abcde12345abcde12345ab' //openweathermap.org API key.
 		}
 	}
 ]

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -15,7 +15,7 @@ modules: [
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
 			appid: 'abcde12345abcde12345abcde12345ab', //openweathermap.org API key.
-			showWindDirection: true
+			showWindDirection: true,
 		}
 	}
 ]

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -14,7 +14,8 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
-			appid: 'abcde12345abcde12345abcde12345ab' //openweathermap.org API key.
+			appid: 'abcde12345abcde12345abcde12345ab', //openweathermap.org API key.
+			showWindDirection: true
 		}
 	}
 ]
@@ -86,6 +87,13 @@ The following properties can be configured:
 		<tr>
 			<td><code>showPeriodUpper</code></td>
 			<td>Show the period (AM/PM) with 12 hour format as uppercase<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>showWindDirection</code></td>
+			<td>Show the wind direction next to the wind speed.<br>
 				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
 				<br><b>Default value:</b> <code>false</code>
 			</td>

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -15,7 +15,6 @@ modules: [
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
 			appid: 'abcde12345abcde12345abcde12345ab', //openweathermap.org API key.
-			showWindDirection: true,
 		}
 	}
 ]

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -19,7 +19,7 @@ Module.register("currentweather",{
 		timeFormat: config.timeFormat,
 		showPeriod: true,
 		showPeriodUpper: false,
-		showDirection: false,
+		showWindDirection: false,
 		lang: config.language,
 
 		initialLoadDelay: 0, // 0 seconds delay
@@ -115,7 +115,7 @@ Module.register("currentweather",{
 		windSpeed.innerHTML = " " + this.windSpeed;
 		small.appendChild(windSpeed);
 	
-		if (this.config.showDirection) {
+		if (this.config.showWindDirection) {
 			var windDirection = document.createElement("span");
 			windDirection.innerHTML = " " + this.windDirection;
 			small.appendChild(windDirection);

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -19,6 +19,7 @@ Module.register("currentweather",{
 		timeFormat: config.timeFormat,
 		showPeriod: true,
 		showPeriodUpper: false,
+		showDirection: false,
 		lang: config.language,
 
 		initialLoadDelay: 0, // 0 seconds delay
@@ -68,6 +69,7 @@ Module.register("currentweather",{
 		moment.locale(config.language);
 
 		this.windSpeed = null;
+		this.windDirection = null;
 		this.sunriseSunsetTime = null;
 		this.sunriseSunsetIcon = null;
 		this.temperature = null;
@@ -112,6 +114,10 @@ Module.register("currentweather",{
 		var windSpeed = document.createElement("span");
 		windSpeed.innerHTML = " " + this.windSpeed;
 		small.appendChild(windSpeed);
+		
+		var windDirection = document.createElement("span");
+		windDirection.innerHTML = " " + this.windDirection;
+		small.appendChild(windDirection);
 
 		var spacer = document.createElement("span");
 		spacer.innerHTML = "&nbsp;";
@@ -198,6 +204,9 @@ Module.register("currentweather",{
 	processWeather: function(data) {
 		this.temperature = this.roundValue(data.main.temp);
 		this.windSpeed = this.ms2Beaufort(this.roundValue(data.wind.speed));
+		if (this.showDirection) {
+			this.windDirection = this.deg2Cardinal(data.wind.deg);
+		} else {}
 		this.weatherType = this.config.iconTable[data.weather[0].icon];
 
 		var now = new Date();
@@ -274,6 +283,44 @@ Module.register("currentweather",{
 	 *
 	 * return number - Rounded Temperature.
 	 */
+	 
+	deg2Card: function(deg) {
+                if (deg>11.25 && deg<33.75){
+                        return "NNE";
+                }else if (deg>33.75 && deg<56.25){
+                        return "ENE";
+                }else if (deg>56.25 && deg<78.75){
+                        return "E";
+                }else if (deg>78.75 && deg<101.25){
+                        return "ESE";
+                }else if (deg>101.25 && deg<123.75){
+                        return "ESE";
+                }else if (deg>123.75 && deg<146.25){
+                        return "SE";
+                }else if (deg>146.25 && deg<168.75){
+                        return "SSE";
+                }else if (deg>168.75 && deg<191.25){
+                        return "S";
+                }else if (deg>191.25 && deg<213.75){
+                        return "SSW";
+                }else if (deg>213.75 && deg<236.25){
+                        return "SW";
+                }else if (deg>236.25 && deg<258.75){
+                        return "WSW";
+                }else if (deg>258.75 && deg<281.25){
+                        return "W";
+                }else if (deg>281.25 && deg<303.75){
+                        return "WNW";
+                }else if (deg>303.75 && deg<326.25){
+                        return "NW";
+                }else if (deg>326.25 && deg<348.75){
+                        return "NNW";
+                }else{
+                         return "N";
+                }
+	}
+
+	 
 	roundValue: function(temperature) {
 		return parseFloat(temperature).toFixed(1);
 	}

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -19,7 +19,7 @@ Module.register("currentweather",{
 		timeFormat: config.timeFormat,
 		showPeriod: true,
 		showPeriodUpper: false,
-		showDirection: false,
+		showDirection: true,
 		lang: config.language,
 
 		initialLoadDelay: 0, // 0 seconds delay
@@ -110,15 +110,17 @@ Module.register("currentweather",{
 		var windIcon = document.createElement("span");
 		windIcon.className = "wi wi-strong-wind dimmed";
 		small.appendChild(windIcon);
-
+		
 		var windSpeed = document.createElement("span");
 		windSpeed.innerHTML = " " + this.windSpeed;
 		small.appendChild(windSpeed);
 		
-		var windDirection = document.createElement("span");
-		windDirection.innerHTML = " " + this.windDirection;
-		small.appendChild(windDirection);
-
+		if (this.showDirection) {
+			var windDirection = document.createElement("span");
+			windDirection.innerHTML = " " + this.windDirection;
+			small.appendChild(windDirection);
+		}
+		
 		var spacer = document.createElement("span");
 		spacer.innerHTML = "&nbsp;";
 		small.appendChild(spacer);
@@ -318,7 +320,7 @@ Module.register("currentweather",{
                 }else{
                          return "N";
                 }
-	}
+	},
 
 	 
 	roundValue: function(temperature) {

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -284,7 +284,7 @@ Module.register("currentweather",{
 	 * return number - Rounded Temperature.
 	 */
 	 
-	deg2Card: function(deg) {
+	deg2Cardinal: function(deg) {
                 if (deg>11.25 && deg<33.75){
                         return "NNE";
                 }else if (deg>33.75 && deg<56.25){

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -19,7 +19,7 @@ Module.register("currentweather",{
 		timeFormat: config.timeFormat,
 		showPeriod: true,
 		showPeriodUpper: false,
-		showDirection: true,
+		showDirection: false,
 		lang: config.language,
 
 		initialLoadDelay: 0, // 0 seconds delay
@@ -114,13 +114,12 @@ Module.register("currentweather",{
 		var windSpeed = document.createElement("span");
 		windSpeed.innerHTML = " " + this.windSpeed;
 		small.appendChild(windSpeed);
-		
-		if (this.showDirection) {
+	
+		if (this.config.showDirection) {
 			var windDirection = document.createElement("span");
 			windDirection.innerHTML = " " + this.windDirection;
 			small.appendChild(windDirection);
 		}
-		
 		var spacer = document.createElement("span");
 		spacer.innerHTML = "&nbsp;";
 		small.appendChild(spacer);
@@ -206,9 +205,7 @@ Module.register("currentweather",{
 	processWeather: function(data) {
 		this.temperature = this.roundValue(data.main.temp);
 		this.windSpeed = this.ms2Beaufort(this.roundValue(data.wind.speed));
-		if (this.showDirection) {
-			this.windDirection = this.deg2Cardinal(data.wind.deg);
-		} else {}
+		this.windDirection = this.deg2Cardinal(data.wind.deg);
 		this.weatherType = this.config.iconTable[data.weather[0].icon];
 
 		var now = new Date();


### PR DESCRIPTION
Optionally add the wind direction (pulled from Openweather API) next to the wind speed in the current weather module. It is turned off by default but by adding the option "showWindDirection" in config.js it can be turned on.