### PR TITLE
Fix URL for Pi installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Electron, the app wrapper around MagicMirror², only supports the Raspberry Pi 2
 
 Execute the following command on your Raspberry Pi to install MagicMirror²:
 ````
-curl -sL https://raw.githubusercontent.com/MichMich/MagicMirror/master/installers/raspberry.sh | bash
+curl -sL https://raw.githubusercontent.com/MichMich/MagicMirror/v2.0.0/installers/raspberry.sh | bash
 ````
 
 #### Manual Installation


### PR DESCRIPTION
Adjust readme to show proper command for raspberry pi installer script as the URL changed after move of v2 in github.