### PR TITLE
Fetch the latest Node.js without any 3rd party interferences

### DIFF
--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -18,7 +18,7 @@ echo '                       \$$$$$$  |'
 echo '                        \______/'
 echo -e "\e[0m"
 
-# Define the tested version of node. 
+# Define the tested version of Node.js. 
 NODE_TESTED="v5.1.0"
 
 #Determine which Pi is running.
@@ -39,7 +39,7 @@ function command_exists () { type "$1" &> /dev/null ;}
 echo -e "\e[96mInstalling helper tools ...\e[90m"
 sudo apt-get install curl wget git build-essential unzip || exit
 
-# Check if we need to install or upgrade node.
+# Check if we need to install or upgrade Node.js.
 echo -e "\e[96mCheck current Node installation ...\e[0m"
 NODE_INSTALL=false
 if command_exists node; then
@@ -60,29 +60,33 @@ if command_exists node; then
 		fi
 
     else
-    	echo -e "\e[92mNo Node upgrade nessecery.\e[0m"
+    	echo -e "\e[92mNo Node.js upgrade nessecery.\e[0m"
 	fi
 
 else
-	echo -e "\e[93mNode is not installed.\e[0m";
+	echo -e "\e[93mNode.js is not installed.\e[0m";
 	NODE_INSTALL=true
 fi
 
 # Install or upgare node if nessecery.
 if $NODE_INSTALL; then
 	
+	echo -e "\e[96mInstalling Node.js ...\e[90m"
+
 	#Fetch the latest version of Node.js from the selected branch
 	#The NODE_STABLE_BRANCH variable will need to be manually adjusted when a new branch is released. (e.g. 7.x)
 	#Only tested (stable) versions are recommended as newer versions could break MagicMirror.
+	
 	NODE_STABLE_BRANCH="6.x"
 	curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
 	sudo apt-get install -y nodejs
+	echo -e "\e[92mNode.js installation Done!\e[0m"
 fi
 
 #Install magic mirror
 cd ~
 if [ -d "$HOME/MagicMirror" ] ; then
-	echo -e "\e[93mIt seems like MagicMirror is allready installed."
+	echo -e "\e[93mIt seems like MagicMirror is already installed."
 	echo -e "To prevent overwriting, the installer will be aborted."
 	echo -e "Please rename the \e[1m~/MagicMirror\e[0m\e[93m folder and try again.\e[0m"
 	echo ""
@@ -109,6 +113,6 @@ else
 fi
 
 echo " "
-echo -e "\e[92mWe're ready! Run \e[1m\e[97mDISPLAY=:0 npm start\e[0m\e[92m from the ~/MagicMirror directory to start your MagicMirror."
+echo -e "\e[92mWe're ready! Run \e[1m\e[97mDISPLAY=:0 npm start\e[0m\e[92m from the ~/MagicMirror directory to start your MagicMirror.\e[0m"
 echo " "
 echo " "

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -70,47 +70,13 @@ fi
 
 # Install or upgare node if nessecery.
 if $NODE_INSTALL; then
-
-	echo -e "\e[96mStart Node download ...\e[0m"
-
-	#Fetch the latest version of Node.js.
-	#TODO: Is there a native way to fetch the latest node version?
-	echo -e "\e[39mRetrieving latest node version."
-	NODE_LATEST=$(curl -l http://api.jordidepoortere.com/nodejs-latest/ 2> /dev/null) 
-
-	if [ "$NODE_LATEST" == "" ]; then
-		echo -e "\e[91mCould not retreive latest node version."
-		echo -e "\e[91mPlease try again or open an issue on GitHub."
-		exit
-	fi
-
-	echo -e "Latest node version: \e[1m$NODE_LATEST\e[0m"
-
-	#Construct the download URL.
-	DOWNLOAD_URL="https://nodejs.org/dist/latest/node-$NODE_LATEST-linux-$ARM.tar.gz" 
-
-	#Create Download Directory
-	rm -Rf ~/.MagicMirrorNodeInstaller || exit
-	mkdir ~/.MagicMirrorNodeInstaller || exit
-	cd  ~/.MagicMirrorNodeInstaller || exit
-
-	#Download Installer
-	echo -e "\e[39mDownloading node ... \e[90m"
-	if wget $DOWNLOAD_URL --no-verbose --show-progress; then
-		echo -e "\e[39mDownload complete."
-	else
-		echo -e "\e[91mCould not download node."
-		exit;
-	fi
-
-	#Unpack and copy.
-	echo -e "\e[96mStart Node installation ...\e[90m"
-	tar xvf node-$NODE_LATEST-linux-$ARM.tar.gz || exit
-	cd node* || exit
-	sudo cp -R * /usr/local || exit
-
-	#Cleanup
-	rm -Rf ~/.MagicMirrorNodeInstaller || exit
+	
+	#Fetch the latest version of Node.js from the selected branch
+	#The NODE_STABLE_BRANCH variable will need to be manually adjusted when a new branch is released. (e.g. 7.x)
+	#Only tested (stable) versions are recommended as newer versions could break MagicMirror.
+	NODE_STABLE_BRANCH="6.x"
+	curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
+	sudo apt-get install -y nodejs
 fi
 
 #Install magic mirror


### PR DESCRIPTION
This will get the latest Node.js from the selected branch.
I do recommend only using a stable and tested version as newer ones might break MM.
Branch can be changed by simply editing the **NODE_STABLE_BRANCH** variable.
Currently set to _6.x_ but can easily be changed to _4.x, 5.x_ or anything else desired.
(This will still need to be manually edited if you wish to upgrade to a newer Node.js version in the future (e.g. _7.x_, but it is less frequent than doing so for each minor release)

By using this setup script, Node.js will be downloaded from the official repository provided by NodeSource.

I've also fixed some typo's in the installer script.