### PR TITLE
Italian translation

### DIFF
--- a/translations/it.json
+++ b/translations/it.json
@@ -1,0 +1,27 @@
+{
+  /* GENERAL */
+  "LOADING": "Caricamento in corso &hellip;",
+
+  /* CALENDAR */
+  "TODAY": "Oggi",
+  "TOMORROW": "Domani",
+  "RUNNING": "Termina entro",
+  "EMPTY": "Nessun evento in arrivo.",
+
+  /* WEATHER */
+  "N": 		"N",
+  "NNE": 	"NNE",
+  "ENE": 	"ENE",
+  "E":		"E",
+  "ESE": 	"ESE",
+  "SE": 	"SE",
+  "SSE": 	"SSE",
+  "S": 		"S",
+  "SSW": 	"SSW",
+  "SW": 	"SW",
+  "WSW": 	"WSW",
+  "W": 		"W",
+  "WNW": 	"WNW",
+  "NW": 	"NW",
+  "NNW": 	"NNW"
+}

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -12,4 +12,5 @@ var translations = {
 	"fr" : "translations/fr.json",
 	"fy" : "translations/fy.json",
 	"es" : "translations/es.json",
+	"it" : "translations/it.json",
 };


### PR DESCRIPTION
Fixed the previous translation. Does the code of the modules take its translated strings from the MagicMirror/translations directory?