### PR TITLE
Norwegian translations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,9 @@
+> Please send your PR's the develop branch. 
+> Don't forget to add the change to changelog.md.
+
 * Does the pull request solve a **related** issue? [yes | no]
 * If so, can you reference the issue?
 * What does the pull request accomplish? (please list)
-* If it has major visual changes please add screenshots.
+* If it includes major visual changes please add screenshots.
 
-DON'T FORGET TO ADD THE CHANGE TO CHANGELOG.md!
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.1] - 2016-05-19
+### Added
+- Norwegian Translation
+
 ## [2.0.1] - 2016-05-18
 ### Added
 - Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.0.1] - 2016-05-19
+## [2.0.2] - 2016-05-20
 ### Added
-- Norwegian Translation
+- Norwegian Translations (nb and nn)
 
 ## [2.0.1] - 2016-05-18
 ### Added

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -3,7 +3,7 @@
   "LOADING": "Laster &hellip;",
 
   /* CALENDAR */
-  "TODAY": "Idag",
+  "TODAY": "I dag",
   "TOMORROW": "I morgen",
   "RUNNING": "Slutter om",
   "EMPTY": "Ingen kommende arrangementer.",

--- a/translations/nn.json
+++ b/translations/nn.json
@@ -1,0 +1,27 @@
+{
+  /* GENERAL */
+  "LOADING": "Lastar &hellip;",
+
+  /* CALENDAR */
+  "TODAY": "I dag",
+  "TOMORROW": "I morgon",
+  "RUNNING": "Sluttar om",
+  "EMPTY": "Ingen komande hendingar.",
+
+  /* WEATHER */
+  "N": 		"N",
+  "NNE": 	"NNA",
+  "ENE": 	"ANA",
+  "E":		"A",
+  "ESE": 	"ASA",
+  "SE": 	"SA",
+  "SSE": 	"SSA",
+  "S": 		"S",
+  "SSW": 	"SSV",
+  "SW": 	"SV",
+  "WSW": 	"VSV",
+  "W": 		"V",
+  "WNW": 	"VNV",
+  "NW": 	"NV",
+  "NNW": 	"NNV"
+}

--- a/translations/no.json
+++ b/translations/no.json
@@ -1,0 +1,27 @@
+{
+  /* GENERAL */
+  "LOADING": "Laster &hellip;",
+
+  /* CALENDAR */
+  "TODAY": "Idag",
+  "TOMORROW": "I morgen",
+  "RUNNING": "Slutter om",
+  "EMPTY": "Ingen kommende arrangementer.",
+
+  /* WEATHER */
+  "N": 		"N",
+  "NNE": 	"NNØ",
+  "ENE": 	"ØNØ",
+  "E":		"Ø",
+  "ESE": 	"ØSØ",
+  "SE": 	"SØ",
+  "SSE": 	"SSØ",
+  "S": 		"S",
+  "SSW": 	"SSV",
+  "SW": 	"SV",
+  "WSW": 	"VSV",
+  "W": 		"V",
+  "WNW": 	"VNV",
+  "NW": 	"NV",
+  "NNW": 	"NNV"
+}

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -12,5 +12,5 @@ var translations = {
 	"fr" : "translations/fr.json",
 	"fy" : "translations/fy.json",
 	"es" : "translations/es.json",
-	"it" : "translations/it.json",
+	"no" : "translations/no.json",	
 };

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -12,5 +12,6 @@ var translations = {
 	"fr" : "translations/fr.json",
 	"fy" : "translations/fy.json",
 	"es" : "translations/es.json",
-	"no" : "translations/no.json",	
+	"nb" : "translations/nb.json",
+	"nn" : "translations/nn.json",	
 };


### PR DESCRIPTION
Removed my earlier pull request, as I used the wrong short name for Norwegian Bokmål (nb), and also added Norwegian Nynorsk (nn). Nb/nn is the correct usage in the config file as well, so you get the day/month translated. 


