### PR TITLE
Removed 'null' setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Edit Alert Module to display title & message if they are provided in the notification (Issue #300)
-- Removed 'null' reference from updateModuleContent(). This fixes recent Edge and Internet Explorer browser displays
+- Removed 'null' reference from updateModuleContent(). This fixes recent Edge and Internet Explorer browser displays (Issue #319)
 
 ### Changed
 - Added default string to calendar titleReplace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Edit Alert Module to display title & message if they are provided in the notification (Issue #300)
+- Removed 'null' reference from updateModuleContent(). This fixes recent Edge and Internet Explorer browser displays
 
 ### Changed
 - Added default string to calendar titleReplace.

--- a/js/main.js
+++ b/js/main.js
@@ -144,7 +144,7 @@ var MM = (function() {
 		var moduleWrapper = document.getElementById(module.identifier);
 		var contentWrapper = moduleWrapper.getElementsByClassName("module-content")[0];
 
-		contentWrapper.innerHTML = null;
+		contentWrapper.innerHTML = "";
 		contentWrapper.appendChild(content);
 	};
 


### PR DESCRIPTION
Removing this fixes the 'null' display on both latest versions of Edge and Internet Explorer browsers.