### PR TITLE
Ability ot turn off date view on analog clock & small grammer error f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Prevent `getModules()` selectors from returning duplicate entries.
 - Append endpoints of weather modules with `/` to retreive the correct data. (Issue [#337](https://github.com/MichMich/MagicMirror/issues/337))
+- Corrected grammer in `module.js` from 'suspend' to 'suspended'.
+- Added ability to turn off the date display in `clock.js` when in analog mode.
 
 ## [2.0.3] - 2016-07-12
 ### Added

--- a/js/module.js
+++ b/js/module.js
@@ -114,7 +114,7 @@ var Module = Class.extend({
 	 * This method is called when a module is hidden.
 	 */
 	suspend: function() {
-		Log.log(this.name + " is suspend.");
+		Log.log(this.name + " is suspended.");
 	},
 
 	/* resume()

--- a/modules/default/clock/README.md
+++ b/modules/default/clock/README.md
@@ -101,5 +101,12 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>bottom</code>
 			</td>
 		</tr>
+		<tr>
+			<td><code>analogShowDate</code></td>
+			<td><strong>Specific to the analog clock.</strong> If the clock is used as a separate module and set to analog only, this configures whether a date is also displayed with the clock.<br>
+				<br><b>Possible values:</b> <code>false</code>, <code>top</code>, or <code>bottom</code>
+				<br><b>Default value:</b> <code>top</code>
+			</td>
+		</tr>
 	</tbody>
 </table>

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -19,7 +19,8 @@ Module.register("clock",{
 		/* specific to the analog clock */
 		analogSize: '200px',
 		analogFace: 'simple', // options: 'none', 'simple', 'face-###' (where ### is 001 to 012 inclusive)
-		analogPlacement: 'bottom', // options: top, bottom, left, right
+		analogPlacement: 'bottom', // options: 'top', 'bottom', 'left', 'right'
+		analogShowDate: 'top', // options: false, 'top', or 'bottom'
 		secondsColor: '#888888',
 	},
 	// Define required scripts.
@@ -170,8 +171,15 @@ Module.register("clock",{
 			// Display only an analog clock
 			dateWrapper.style.textAlign = "center";
 			dateWrapper.style.paddingBottom = "15px";
-			wrapper.appendChild(dateWrapper);
-			wrapper.appendChild(clockCircle);
+			if (this.config.analogShowDate === 'top') {
+				wrapper.appendChild(dateWrapper);
+				wrapper.appendChild(clockCircle);
+			} else if (this.config.analogShowDate === 'bottom') {
+				wrapper.appendChild(clockCircle);
+				wrapper.appendChild(dateWrapper);
+			} else {
+				wrapper.appendChild(clockCircle);
+			}
 		} else {
 			// Both clocks have been configured, check position
 			var placement = this.config.analogPlacement;


### PR DESCRIPTION
module.js has a grammer error, 'suspend' should be 'suspended'.
clock.js has a new config option to disable the date display when used in analog mode only.