### PR TITLE
 Added option to remove "more" tags in newsfeed description

### DIFF
--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -108,7 +108,20 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>0</code>
 			</td>
 		</tr>
-
+		<tr>
+			<td><code>showMore</code></td>
+			<td>Remove "more..." tags from the end of the item description.<br>
+				<br><b>Possible values:</b><code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>moreTag</code></td>
+			<td>Specify the exact wording of the "more..." tag.<br>
+				<br><b>Possible values:</b> 'YOUR_MORE_TAG_HERE'
+				<br><b>Default value:</b> <code>''</code>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -119,7 +119,7 @@ The following properties can be configured:
 			<td><code>moreTag</code></td>
 			<td>Specify the exact wording of the "more..." tag.<br>
 				<br><b>Possible values:</b> 'YOUR_MORE_TAG_HERE'
-				<br><b>Default value:</b> <code>''</code>
+				<br><b>Default value:</b> <code>'more'</code>
 			</td>
 		</tr>
 	</tbody>

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -24,7 +24,9 @@ Module.register("newsfeed",{
 		reloadInterval:  5 * 60 * 1000, // every 5 minutes
 		updateInterval: 10 * 1000,
 		animationSpeed: 2.5 * 1000,
-		maxNewsItems: 0 // 0 for unlimited
+		maxNewsItems: 0, // 0 for unlimited
+		more: false,
+		moreTag: 'more'
 	},
 
 	// Define required scripts.
@@ -100,7 +102,16 @@ Module.register("newsfeed",{
 			title.className = "bright medium light";
 			title.innerHTML = this.newsItems[this.activeItem].title;
 			wrapper.appendChild(title);
-
+			
+			//Remove "more" tag from description of rss feeds
+			
+			if (this.config.showMore) {
+					if (this.newsItems[this.activeItem].description.slice(-this.config.moreTag.length)==this.config.moreTag) {
+					this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0,-this.config.moreTag.length);
+				}
+			}
+			
+			
 			if (this.config.showDescription) {
 				var description = document.createElement("div");
 				description.className = "small light";


### PR DESCRIPTION
Many feed descriptions end with with a link tag to the actual article
online (see http://www.deutschlandfunk.de/die-nachrichten.353.de.rss,
for example). The mirror news description looks strange with this tag in
the end.

I have added an option to remove the tag from the description and
updated the readme.md accordingly.


