### PR TITLE
Tags at the beginning and/or end of newsfeed items

### DIFF
--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -108,18 +108,35 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>0</code>
 			</td>
 		</tr>
+			removeStartTags: false,
+		removeEndTags: false,
+		startTags: [],
+		endTags: []
+		
+		
 		<tr>
-			<td><code>showMore</code></td>
-			<td>Remove "more..." tags from the end of the item description.<br>
-				<br><b>Possible values:</b><code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
+			<td><code>removeStartTags</code></td>
+			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as "[VIDEO]".
+			This setting allows for the removal of specified tags from the beginning of an item's description and / or title.<br>
+				<br><b>Possible values:</b><code>'none'</code>,<code>description</code>, <code>title</code>, <code>both</code> 
 			</td>
 		</tr>
 		<tr>
-			<td><code>moreTag</code></td>
-			<td>Specify the exact wording of the "more..." tag.<br>
-				<br><b>Possible values:</b> 'YOUR_MORE_TAG_HERE'
-				<br><b>Default value:</b> <code>'more'</code>
+			<td><code>startTags</code></td>
+			<td>List the tags you would like to have removed at the beginning of the feed item<br>
+				<br><b>Possible values:</b> ['TAG'] or ['TAG1','TAG2',...]
+			</td>
+		</tr>
+		<tr>
+			<td><code>removeEndTags</code></td>
+			<td>Remove specified tags from the <B>end</B> of an item's description and / or title.<br>
+				<br><b>Possible values:</b><code>description</code>, <code>title</code>, <code>both</code> 
+			</td>
+		</tr>
+		<tr>
+			<td><code>endTags</code></td>
+			<td>List the tags you would like to have removed at the end of the feed item<br>
+				<br><b>Possible values:</b> ['TAG'] or ['TAG1','TAG2',...]
 			</td>
 		</tr>
 	</tbody>

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -108,7 +108,20 @@ The following properties can be configured:
 				<br><b>Default value:</b> <code>0</code>
 			</td>
 		</tr>
-
+		<tr>
+			<td><code>showMore</code></td>
+			<td>Remove "more..." tags from the end of the item description.<br>
+				<br><b>Possible values:</b><code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
+			<td><code>moreTag</code></td>
+			<td>Specify the exact wording of the "more..." tag.<br>
+				<br><b>Possible values:</b> 'YOUR_MORE_TAG_HERE'
+				<br><b>Default value:</b> <code>''</code>
+			</td>
+		</tr>
 	</tbody>
 </table>
 

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -116,7 +116,7 @@ The following properties can be configured:
 		
 		<tr>
 			<td><code>removeStartTags</code></td>
-			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as <em>VIDEO</em>.
+			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as <em>[VIDEO]</em>.
 			This setting allows for the removal of specified tags from the beginning of an item's description and/or title.<br>
 				<br><b>Possible values:</b><code>'none'</code>,<code>description</code>, <code>title</code>, <code>both</code> 
 			</td>
@@ -124,7 +124,7 @@ The following properties can be configured:
 		<tr>
 			<td><code>startTags</code></td>
 			<td>List the tags you would like to have removed at the beginning of the feed item<br>
-				<br><b>Possible values:</b> ['TAG'] or ['TAG1','TAG2',...]
+				<br><b>Possible values:</b> <code>['TAG']</code> or <code>['TAG1','TAG2',...]</code>
 			</td>
 		</tr>
 		<tr>
@@ -136,7 +136,7 @@ The following properties can be configured:
 		<tr>
 			<td><code>endTags</code></td>
 			<td>List the tags you would like to have removed at the end of the feed item<br>
-				<br><b>Possible values:</b> ['TAG'] or ['TAG1','TAG2',...]
+				<br><b>Possible values:</b> <code>['TAG']</code> or <code>['TAG1','TAG2',...]</code>
 			</td>
 		</tr>
 	</tbody>

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -116,8 +116,8 @@ The following properties can be configured:
 		
 		<tr>
 			<td><code>removeStartTags</code></td>
-			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as "[VIDEO]".
-			This setting allows for the removal of specified tags from the beginning of an item's description and / or title.<br>
+			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as <em>VIDEO</em>.
+			This setting allows for the removal of specified tags from the beginning of an item's description and/or title.<br>
 				<br><b>Possible values:</b><code>'none'</code>,<code>description</code>, <code>title</code>, <code>both</code> 
 			</td>
 		</tr>
@@ -129,7 +129,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>removeEndTags</code></td>
-			<td>Remove specified tags from the <B>end</B> of an item's description and / or title.<br>
+			<td>Remove specified tags from the <B>end</B> of an item's description and/or title.<br>
 				<br><b>Possible values:</b><code>description</code>, <code>title</code>, <code>both</code> 
 			</td>
 		</tr>

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -119,7 +119,7 @@ The following properties can be configured:
 			<td><code>moreTag</code></td>
 			<td>Specify the exact wording of the "more..." tag.<br>
 				<br><b>Possible values:</b> 'YOUR_MORE_TAG_HERE'
-				<br><b>Default value:</b> <code>''</code>
+				<br><b>Default value:</b> <code>'more'</code>
 			</td>
 		</tr>
 	</tbody>

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -25,8 +25,11 @@ Module.register("newsfeed",{
 		updateInterval: 10 * 1000,
 		animationSpeed: 2.5 * 1000,
 		maxNewsItems: 0, // 0 for unlimited
-		more: false,
-		moreTag: 'more'
+		removeStartTags: false,
+		removeEndTags: false,
+		startTags: [],
+		endTags: []
+		
 	},
 
 	// Define required scripts.
@@ -98,20 +101,50 @@ Module.register("newsfeed",{
 				wrapper.appendChild(sourceAndTimestamp);
 			}
 
+			//Remove selected tags from the beginning of rss feed items (title or description)
+
+			if (this.config.removeStartTags) {
+				
+				for (f=0; f<this.config.startTags.length;f++) {
+					if (this.newsItems[this.activeItem].title.slice(0,this.config.startTags[f].length) == this.config.startTags[f]) {
+						this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].title.slice(this.config.startTags[f].length,this.newsItems[this.activeItem].title.length);
+						}
+				}
+				
+				if (this.config.showDescription) {
+					for (f=0; f<this.config.startTags.length;f++) {
+						if (this.newsItems[this.activeItem].description.slice(0,this.config.startTags[f].length) == this.config.startTags[f]) {
+							this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].description.slice(this.config.startTags[f].length,this.newsItems[this.activeItem].description.length);
+							}
+					}
+				}
+			
+			}
+			
+			//Remove selected tags from the end of rss feed items (title or description)
+
+			if (this.config.removeEndTags) {
+				for (f=0; f<this.config.endTags.length;f++) {
+					if (this.newsItems[this.activeItem].title.slice(-this.config.endTags[f].length)==this.config.endTags[f]) {
+						this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].title.slice(0,-this.config.endTags[f].length);
+						}
+				}
+				
+				if (this.config.showDescription) {
+					for (f=0; f<this.config.endTags.length;f++) {
+						if (this.newsItems[this.activeItem].description.slice(-this.config.endTags[f].length)==this.config.endTags[f]) {
+							this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0,-this.config.endTags[f].length);
+								}
+					}
+				}
+			
+			}
+			
 			var title = document.createElement("div");
 			title.className = "bright medium light";
 			title.innerHTML = this.newsItems[this.activeItem].title;
 			wrapper.appendChild(title);
-			
-			//Remove "more" tag from description of rss feeds
-			
-			if (this.config.showMore) {
-					if (this.newsItems[this.activeItem].description.slice(-this.config.moreTag.length)==this.config.moreTag) {
-					this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0,-this.config.moreTag.length);
-				}
-			}
-			
-			
+				
 			if (this.config.showDescription) {
 				var description = document.createElement("div");
 				description.className = "small light";
@@ -226,5 +259,7 @@ Module.register("newsfeed",{
 	 */
 	capitalizeFirstLetter: function(string) {
 		return string.charAt(0).toUpperCase() + string.slice(1);
-	}
+	},
+
+
 });

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -24,7 +24,9 @@ Module.register("newsfeed",{
 		reloadInterval:  5 * 60 * 1000, // every 5 minutes
 		updateInterval: 10 * 1000,
 		animationSpeed: 2.5 * 1000,
-		maxNewsItems: 0 // 0 for unlimited
+		maxNewsItems: 0, // 0 for unlimited
+		more: false,
+		moreTag: 'more'
 	},
 
 	// Define required scripts.
@@ -100,7 +102,16 @@ Module.register("newsfeed",{
 			title.className = "bright medium light";
 			title.innerHTML = this.newsItems[this.activeItem].title;
 			wrapper.appendChild(title);
-
+			
+			//Remove "more" tag from description of rss feeds
+			
+			if (this.config.showMore) {
+					if (this.newsItems[this.activeItem].description.slice(-this.config.moreTag.length)==this.config.moreTag) {
+					this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0,-this.config.moreTag.length);
+				}
+			}
+			
+			
 			if (this.config.showDescription) {
 				var description = document.createElement("div");
 				description.className = "small light";

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -25,8 +25,8 @@ Module.register("newsfeed",{
 		updateInterval: 10 * 1000,
 		animationSpeed: 2.5 * 1000,
 		maxNewsItems: 0, // 0 for unlimited
-		removeStartTags: false,
-		removeEndTags: false,
+		removeStartTags: '',
+		removeEndTags: '',
 		startTags: [],
 		endTags: []
 		
@@ -103,13 +103,17 @@ Module.register("newsfeed",{
 
 			//Remove selected tags from the beginning of rss feed items (title or description)
 
-			if (this.config.removeStartTags) {
+			if (this.config.removeStartTags == 'title' || 'both') {
 				
 				for (f=0; f<this.config.startTags.length;f++) {
 					if (this.newsItems[this.activeItem].title.slice(0,this.config.startTags[f].length) == this.config.startTags[f]) {
 						this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].title.slice(this.config.startTags[f].length,this.newsItems[this.activeItem].title.length);
 						}
 				}
+				
+			}
+				
+			if (this.config.removeStartTags == 'description' || 'both') {
 				
 				if (this.config.showDescription) {
 					for (f=0; f<this.config.startTags.length;f++) {


### PR DESCRIPTION
Many feed descriptions end with with a link tag to the actual article online (see http://www.deutschlandfunk.de/die-nachrichten.353.de.rss, for example - tag: " mehr."). The mirror news description looks strange with this tag in the end.

Other newsfeeds feature tags at the beginning of an item (see http://www.francetvinfo.fr/titres.rss - tags like "VIDEO" or "CARTE" are placed at the beginning of some titles), which also make very little sense within the setup of this project.

I have added an option to remove the tags from the beginning or end of an item's description and/or title and updated the readme.md accordingly.



