### PR TITLE
Uniformly capitalize calendar time phrases / 'getRelative' tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added ability to remove tags from the beginning or end of newsfeed items in 'newsfeed.js'.
 - Added ability to define "the day after tomorrow" for calendar events (Definition for German and Dutch already included).
+- Added ability to change the point of time when calendar events get relative.
+
+### Changed
+- Calendar times are now uniformly capitalized
+
 
 ## [2.0.4] - 2016-08-07
 

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -128,7 +128,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>getRelative</code></td>
-			<td>Determine how much time (in hours) should be left when calendar events start getting relative (If you want this to start half an hour before an event occurs)<br>
+			<td>Determine how much time (in hours) should be left until calendar events start getting relative<br>
 				<br><b>Possible values:</b> <code>0</code> (never) - <code>48</code> (48 hours before the event)
 				<br><b>Default value:</b> <code>6</code>
 			</td>

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -129,7 +129,7 @@ The following properties can be configured:
 		<tr>
 			<td><code>getRelative</code></td>
 			<td>Determine how much time (in hours) should be left until calendar events start getting relative<br>
-				<br><b>Possible values:</b> <code>0</code> (never) - <code>48</code> (48 hours before the event)
+				<br><b>Possible values:</b> <code>0</code> (events stay absolute) - <code>48</code> (48 hours before the event starts)
 				<br><b>Default value:</b> <code>6</code>
 			</td>
 		</tr>

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -129,7 +129,7 @@ The following properties can be configured:
 		<tr>
 			<td><code>getRelative</code></td>
 			<td>Determine how much time (in hours) should be left when calendar events start getting relative (If you want this to start half an hour before an event occurs)<br>
-				<br><b>Possible values:</b> <code>0 (never)</code> - <code>48 (48 hours before the event)</code>
+				<br><b>Possible values:</b> <code>0</code> (never) - <code>48</code> (48 hours before the event)
 				<br><b>Default value:</b> <code>6</code>
 			</td>
 		</tr>

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -128,7 +128,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>getRelative</code></td>
-			<td>Determine how much time (in hours) should be left until calendar events start getting relative<br>
+			<td>How much time (in hours) should be left until calendar events start getting relative?<br>
 				<br><b>Possible values:</b> <code>0</code> (events stay absolute) - <code>48</code> (48 hours before the event starts)
 				<br><b>Default value:</b> <code>6</code>
 			</td>

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -127,6 +127,13 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>getRelative</code></td>
+			<td>Determine how much time (in hours) should be left when calendar events start getting relative (If you want this to start half an hour before an event occurs)<br>
+				<br><b>Possible values:</b> <code>0 (never)</code> - <code>48 (48 hours before the event)</code>
+				<br><b>Default value:</b> <code>6</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>urgency</code></td>
 			<td>When using a timeFormat of <code>absolute</code>, the <code>urgency</code> setting allows you to display events within a specific time frame as <code>relative</code>
 			    This allows events within a certain time frame to be displayed as relative (in xx days) while others are displayed as absolute dates<br>

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -147,18 +147,14 @@ Module.register("calendar",{
 			var one_day = one_hour * 24;
 			if (event.fullDayEvent) {
 				if (event.today) {
-					timeWrapper.innerHTML = this.translate("TODAY");
+					timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
 				} else if (event.startDate - now < one_day && event.startDate - now > 0) {
-					timeWrapper.innerHTML = this.translate("TOMORROW");
+					timeWrapper.innerHTML = this.capFirst(this.translate("TOMORROW"));
 				} else if (event.startDate - now < 2*one_day && event.startDate - now > 0) {
-				/*Provide ability to show "the day after tomorrow" instead of "in a day" 
-				 *if "DAYAFTERTOMORROW" is configured in a language's translation .json file, 
-				 *,which can be found in MagicMirror/translations/
-				 */
 					if (this.translate('DAYAFTERTOMORROW') !== 'DAYAFTERTOMORROW') {
-    						timeWrapper.innerHTML = this.translate("DAYAFTERTOMORROW");
+					timeWrapper.innerHTML = this.capFirst(this.translate("DAYAFTERTOMORROW"));
 					} else {
-    						timeWrapper.innerHTML = moment(event.startDate, "x").fromNow();
+					timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 					}
 				} else {
 					/* Check to see if the user displays absolute or relative dates with their events
@@ -171,12 +167,12 @@ Module.register("calendar",{
 					if (this.config.timeFormat === "absolute") {
 						if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * one_day))) {
 							// This event falls within the config.urgency period that the user has set
-							timeWrapper.innerHTML = moment(event.startDate, "x").fromNow();
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						} else {
-							timeWrapper.innerHTML = moment(event.startDate, "x").format("MMM Do");
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format("MMM Do"));
 						}
 					} else {
-						timeWrapper.innerHTML =  moment(event.startDate, "x").fromNow();
+						timeWrapper.innerHTML =  this.capFirst(moment(event.startDate, "x").fromNow());
 					}
 				}
 			} else {
@@ -185,10 +181,10 @@ Module.register("calendar",{
 						// This event is within the next 48 hours (2 days)
 						if (event.startDate - now < 6 * one_hour) {
 							// If event is within 6 hour, display 'in xxx' time format or moment.fromNow()
-							timeWrapper.innerHTML = moment(event.startDate, "x").fromNow();
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						} else {
 							// Otherwise just say 'Today/Tomorrow at such-n-such time'
-							timeWrapper.innerHTML = moment(event.startDate, "x").calendar();
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar());
 						}
 					} else {
 						/* Check to see if the user displays absolute or relative dates with their events
@@ -201,16 +197,16 @@ Module.register("calendar",{
 						if (this.config.timeFormat === "absolute") {
 							if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * one_day))) {
 								// This event falls within the config.urgency period that the user has set
-								timeWrapper.innerHTML = moment(event.startDate, "x").fromNow();
+								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 							} else {
-								timeWrapper.innerHTML = moment(event.startDate, "x").format("MMM Do");
+								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format("MMM Do"));
 							}
 						} else {
-							timeWrapper.innerHTML = moment(event.startDate, "x").fromNow();
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						}
 					}
 				} else {
-					timeWrapper.innerHTML =  this.translate("RUNNING") + ' ' + moment(event.endDate,"x").fromNow(true);
+					timeWrapper.innerHTML =  this.capFirst(this.translate("RUNNING")) + ' ' + this.capFirst(moment(event.endDate,"x").fromNow(true));
 				}
 			}
 			//timeWrapper.innerHTML += ' - '+ moment(event.startDate,'x').format('lll');
@@ -344,6 +340,15 @@ Module.register("calendar",{
 		}
 
 		return string;
+	},
+
+	/* capFirst(string)
+	 * Capitalize the first letter of a string
+	 * Eeturn capitalized string
+	 */
+	
+	capFirst: function(string) {
+		return string.charAt(0).toUpperCase() + string.slice(1);
 	},
 
 	/* titleTransform(title)

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -21,7 +21,7 @@ Module.register("calendar",{
 		fetchInterval: 5 * 60 * 1000, // Update every 5 minutes.
 		animationSpeed: 2000,
 		fade: true,
-		urgency: 7,
+		urgency: 7, 
 		timeFormat: "relative",
 		getRelative: '6',
 		fadePoint: 0.25, // Start on 1/4th of the list.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -23,7 +23,7 @@ Module.register("calendar",{
 		fade: true,
 		urgency: 7,
 		timeFormat: "relative",
-		getRelative: '6',
+		getRelative: 6,
 		fadePoint: 0.25, // Start on 1/4th of the list.
 		calendars: [
 			{

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -207,7 +207,7 @@ Module.register("calendar",{
 						}
 					}
 				} else {
-					timeWrapper.innerHTML =  this.capFirst(this.translate("RUNNING")) + ' ' + this.capFirst(moment(event.endDate,"x").fromNow(true));
+					timeWrapper.innerHTML =  this.capFirst(this.translate("RUNNING")) + ' ' + moment(event.endDate,"x").fromNow(true);
 				}
 			}
 			//timeWrapper.innerHTML += ' - '+ moment(event.startDate,'x').format('lll');

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -23,6 +23,7 @@ Module.register("calendar",{
 		fade: true,
 		urgency: 7,
 		timeFormat: "relative",
+		getRelative: '6',
 		fadePoint: 0.25, // Start on 1/4th of the list.
 		calendars: [
 			{
@@ -179,7 +180,7 @@ Module.register("calendar",{
 				if (event.startDate >= new Date()) {
 					if (event.startDate - now < 2 * one_day) {
 						// This event is within the next 48 hours (2 days)
-						if (event.startDate - now < 6 * one_hour) {
+						if (event.startDate - now < this.config.getRelative * one_hour) {
 							// If event is within 6 hour, display 'in xxx' time format or moment.fromNow()
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						} else {

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -21,7 +21,7 @@ Module.register("calendar",{
 		fetchInterval: 5 * 60 * 1000, // Update every 5 minutes.
 		animationSpeed: 2000,
 		fade: true,
-		urgency: 7, 
+		urgency: 7,
 		timeFormat: "relative",
 		getRelative: '6',
 		fadePoint: 0.25, // Start on 1/4th of the list.


### PR DESCRIPTION
This is an attempt at standardizing the calendar layout. Currently the calendar times are only partly capitalized, some time phrases start with lower-case letters, some don't (The ones pulled from the TRANSLATIONS folder start with upper-case letters, the others don't). Behavior has been changed to create a more standardized layout.

See examples here: https://forum.magicmirror.builders/topic/580/calendar-time-capitalize-first-letters