### PR TITLE
currentweather module api url bugfix

### DIFF
--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -164,7 +164,7 @@ Module.register("currentweather",{
 	 * Calls processWeather on succesfull response.
 	 */
 	updateWeather: function() {
-		var url = this.config.apiBase + this.config.apiVersion + "/" + this.config.weatherEndpoint + '/' + this.getParams();
+		var url = this.config.apiBase + this.config.apiVersion + "/" + this.config.weatherEndpoint + this.getParams();
 		var self = this;
 		var retry = true;
 


### PR DESCRIPTION
Running this on Raspberry Pi 2, node version v6.5.0, magicmirror@2.0.0

The current url created has a typo that causes the module to only display default weather units (Kelvin). After checking the website (http://openweathermap.org/current), there is no "/" at this location in the url. Removing it fixes the issue and allows the user to see the specified units in config.js.