### PR TITLE
add support for http basic auth for calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Added
+- Calendar module now supports http basic auth for calendars
+
 ## [2.0.4] - 2016-08-07
 
 ### Added

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -183,5 +183,13 @@ config: {
 				<code>'Birthday'</code>
 			</td>
 		</tr>
+		<tr>
+			<td><code> user </code></td>
+			<td>The username for HTTP Basic authentication.</td>
+		</tr>
+		<tr>
+			<td><code> pass </code></td>
+			<td>The password for HTTP Basic authentication.</td>
+		</tr>
 		</tbody>
 </table>

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -64,7 +64,7 @@ Module.register("calendar",{
 		for (var c in this.config.calendars) {
 			var calendar = this.config.calendars[c];
 			calendar.url = calendar.url.replace("webcal://", "http://");
-			this.addCalendar(calendar.url);
+			this.addCalendar(calendar.url, calendar.user, calendar.pass);
 		}
 
 		this.calendarData = {};
@@ -275,12 +275,14 @@ Module.register("calendar",{
 	 *
 	 * argument url sting - Url to add.
 	 */
-	addCalendar: function(url) {
+	addCalendar: function(url, user, pass) {
 		this.sendSocketNotification("ADD_CALENDAR", {
 			url: url,
 			maximumEntries: this.config.maximumEntries,
 			maximumNumberOfDays: this.config.maximumNumberOfDays,
-			fetchInterval: this.config.fetchInterval
+			fetchInterval: this.config.fetchInterval,
+			user: user,
+			pass: pass
 		});
 	},
 

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -8,7 +8,7 @@
 var ical = require("./vendor/ical.js");
 var moment = require("moment");
 
-var CalendarFetcher = function(url, reloadInterval, maximumEntries, maximumNumberOfDays) {
+var CalendarFetcher = function(url, reloadInterval, maximumEntries, maximumNumberOfDays, user, pass) {
 	var self = this;
 
 	var reloadTimer = null;
@@ -29,7 +29,16 @@ var CalendarFetcher = function(url, reloadInterval, maximumEntries, maximumNumbe
 			headers: {
 				'User-Agent': 'Mozilla/5.0 (Node.js 6.0.0) MagicMirror/v2 (https://github.com/MichMich/MagicMirror/)'
 			}
+		};
+
+		if (user && pass) {
+			opts.auth = {
+				user: user,
+				pass: pass,
+				sendImmediately: true
+			}
 		}
+
 		ical.fromURL(url, opts, function(err, data) {
 			if (err) {
 				fetchFailedCallback(self, err);

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -25,7 +25,7 @@ module.exports = NodeHelper.create({
 	socketNotificationReceived: function(notification, payload) {
 		if (notification === "ADD_CALENDAR") {
 			//console.log('ADD_CALENDAR: ');
-			this.createFetcher(payload.url, payload.fetchInterval, payload.maximumEntries, payload.maximumNumberOfDays);
+			this.createFetcher(payload.url, payload.fetchInterval, payload.maximumEntries, payload.maximumNumberOfDays, payload.user, payload.pass);
 		}
 	},
 
@@ -37,7 +37,7 @@ module.exports = NodeHelper.create({
 	 * attribute reloadInterval number - Reload interval in milliseconds.
 	 */
 
-	createFetcher: function(url, fetchInterval, maximumEntries, maximumNumberOfDays) {
+	createFetcher: function(url, fetchInterval, maximumEntries, maximumNumberOfDays, user, pass) {
 		var self = this;
 
 		if (!validUrl.isUri(url)) {
@@ -48,7 +48,7 @@ module.exports = NodeHelper.create({
 		var fetcher;
 		if (typeof self.fetchers[url] === "undefined") {
 			console.log("Create new calendar fetcher for url: " + url + " - Interval: " + fetchInterval);
-			fetcher = new CalendarFetcher(url, fetchInterval, maximumEntries, maximumNumberOfDays);
+			fetcher = new CalendarFetcher(url, fetchInterval, maximumEntries, maximumNumberOfDays, user, pass);
 
 			fetcher.onReceive(function(fetcher) {
 				//console.log('Broadcast events.');


### PR DESCRIPTION
Allows accessing password protected calendars by sending http basic auth headers

Example config:

```js
{
    symbol: 'calendar-check-o ',
    url: 'https://example/nextcloud/remote.php/dav/calendars/icewind/default?export&accept=ical',
    user: 'icewind',
    pass: 'xxxxxx'
}
```