### PR TITLE
Fix default weather forecast module api URL

### DIFF
--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -102,7 +102,7 @@ Module.register("weatherforecast",{
 		}
 
 		if (!this.loaded) {
-			wrapper.innerHTML = this.translate('LOADING');
+			wrapper.innerHTML = this.translate("LOADING");
 			wrapper.className = "dimmed light small";
 			return wrapper;
 		}
@@ -161,7 +161,7 @@ Module.register("weatherforecast",{
 	 * Calls processWeather on succesfull response.
 	 */
 	updateWeather: function() {
-		var url = this.config.apiBase + this.config.apiVersion + "/" + this.config.forecastEndpoint + '/' + this.getParams();
+		var url = this.config.apiBase + this.config.apiVersion + "/" + this.config.forecastEndpoint + this.getParams();
 		var self = this;
 		var retry = true;
 


### PR DESCRIPTION
* Does the pull request solve a **related** issue? [yes | no]  
yes
* If so, can you reference the issue?  
same issue as #427 but for weather forecast instead of current weather module
* What does the pull request accomplish? (please list)  
The current url created has a typo that causes the module to only display incorrect data. After checking the website (http://openweathermap.org/current), there is no "/" at this location in the url. Removing it fixes the issue and allows the user to see the specified units in config.js.




