### PR TITLE
Patch limited access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Method to overwrite the module's header. [See documentation.](https://github.com/MichMich/MagicMirror/tree/develop/modules#getheader)
+- Option to limit access to certain IP addresses based on the value of `ipWhitelist` in the `config.js`, default is access from localhost only (Issue [#456](https://github.com/MichMich/MagicMirror/issues/456))
 
 ### Updated
 - Modified translations for Frysk.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The following properties can be configured:
 | **Option** | **Description** |
 | --- | --- |
 | `port` | The port on which the MagicMirror² server will run on. The default value is `8080`. |
+| `ipWhitelist` | The list of IPs from which you are allowed to access the MagicMirror². The default value is `["127.0.0.1", "::ffff:127.0.0.1"]`.It is possible to specify IPs with subnet masks (`["127.0.0.1", "127.0.0.1/24"]`) or define ip ranges (`["127.0.0.1", ["192.168.0.1", "192.168.0.100"]]`).
+ |
 | `kioskmode` | This allows MagicMirror² to run in Kiosk Mode. It protects from other programs popping on top of your screen. The default value is `false`|
 | `language` | The language of the interface. (Note: Not all elements will be localized.) Possible values are `en`, `nl`, `ru`, `fr`, etc., but the default value is `en`. |
 | `timeFormat` | The form of time notation that will be used. Possible values are `12` or `24`. The default is `24`. |

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -6,6 +6,9 @@
 
 var config = {
 	port: 8080,
+	ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
+	// you use ips with subnet mask: ['127.0.0.1', '127.0.0.1/24']
+	// you use also use ip ranges: ['127.0.0.1', ['192.168.0.1', '192.168.0.100']]
 
 	language: 'en',
 	timeFormat: 24,

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -7,8 +7,8 @@
 var config = {
 	port: 8080,
 	ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
-	// you use ips with subnet mask: ['127.0.0.1', '127.0.0.1/24']
-	// you use also use ip ranges: ['127.0.0.1', ['192.168.0.1', '192.168.0.100']]
+	// you can use ips with subnet mask: ['127.0.0.1', '127.0.0.1/24']
+	// you can also use ip ranges: ['127.0.0.1', ['192.168.0.1', '192.168.0.100']]
 
 	language: 'en',
 	timeFormat: 24,

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -6,9 +6,7 @@
 
 var config = {
 	port: 8080,
-	ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
-	// you can use ips with subnet mask: ['127.0.0.1', '127.0.0.1/24']
-	// you can also use ip ranges: ['127.0.0.1', ['192.168.0.1', '192.168.0.100']]
+	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1"],
 
 	language: 'en',
 	timeFormat: 24,

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -10,7 +10,7 @@
 var defaults = {
 	port: 8080,
 	kioskmode: false,
-	ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
+	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1"],
 
 	language: "en",
 	timeFormat: 24,

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -10,6 +10,7 @@
 var defaults = {
 	port: 8080,
 	kioskmode: false,
+	ipWhitelist: ['127.0.0.1', '::ffff:127.0.0.1'],
 
 	language: "en",
 	timeFormat: 24,

--- a/js/server.js
+++ b/js/server.js
@@ -16,10 +16,6 @@ var Server = function(config, callback) {
 	console.log("Starting server op port " + config.port + " ... ");
 
 	server.listen(config.port);
-	if (config.ipWhitelist === undefined) {
-		config.ipWhitelist = ["127.0.0.1", "::ffff:127.0.0.1"];
-		console.log("Warning: Missing value (ipWhitelist) from config.js, assuming default (localhost access only): " + config.ipWhitelist);
-	}
 
 	app.use(function(req, res, next) {
 		var result = ipfilter(config.ipWhitelist, {mode: "allow", log: false})(req, res, function(err) {

--- a/js/server.js
+++ b/js/server.js
@@ -20,7 +20,16 @@ var Server = function(config, callback) {
 		config.ipWhitelist = ['127.0.0.1', '::ffff:127.0.0.1'];
 		console.log("Warning: Missing value (ipWhitelist) from config.js, assuming default (localhost access only): " + config.ipWhitelist);
 	}
-	app.use(ipfilter(config.ipWhitelist, {mode: 'allow', log: false}));
+
+	app.use(function(req, res, next) {
+		var result = ipfilter(config.ipWhitelist, {mode: 'allow', log: false})(req, res, function(err) {
+			if (err === undefined) {
+				return next();
+			}
+			res.status(403).send("This device is not allowed to access your mirror. <br> Please check your config.js or config.js.sample to change this.");
+		});
+	});
+
 	app.use("/js", express.static(__dirname));
 	app.use("/config", express.static(path.resolve(__dirname + "/../config")));
 	app.use("/css", express.static(path.resolve(__dirname + "/../css")));

--- a/js/server.js
+++ b/js/server.js
@@ -10,11 +10,17 @@ var app = require("express")();
 var server = require("http").Server(app);
 var io = require("socket.io")(server);
 var path = require("path");
+var ipfilter = require('express-ipfilter').IpFilter;
 
 var Server = function(config, callback) {
 	console.log("Starting server op port " + config.port + " ... ");
 
 	server.listen(config.port);
+	if (config.ipWhitelist === undefined) {
+		config.ipWhitelist = ['127.0.0.1', '::ffff:127.0.0.1'];
+		console.log("Warning: Missing value (ipWhitelist) from config.js, assuming default (localhost access only): " + config.ipWhitelist);
+	}
+	app.use(ipfilter(config.ipWhitelist, {mode: 'allow', log: false}));
 	app.use("/js", express.static(__dirname));
 	app.use("/config", express.static(path.resolve(__dirname + "/../config")));
 	app.use("/css", express.static(path.resolve(__dirname + "/../css")));

--- a/js/server.js
+++ b/js/server.js
@@ -10,19 +10,19 @@ var app = require("express")();
 var server = require("http").Server(app);
 var io = require("socket.io")(server);
 var path = require("path");
-var ipfilter = require('express-ipfilter').IpFilter;
+var ipfilter = require("express-ipfilter").IpFilter;
 
 var Server = function(config, callback) {
 	console.log("Starting server op port " + config.port + " ... ");
 
 	server.listen(config.port);
 	if (config.ipWhitelist === undefined) {
-		config.ipWhitelist = ['127.0.0.1', '::ffff:127.0.0.1'];
+		config.ipWhitelist = ["127.0.0.1", "::ffff:127.0.0.1"];
 		console.log("Warning: Missing value (ipWhitelist) from config.js, assuming default (localhost access only): " + config.ipWhitelist);
 	}
 
 	app.use(function(req, res, next) {
-		var result = ipfilter(config.ipWhitelist, {mode: 'allow', log: false})(req, res, function(err) {
+		var result = ipfilter(config.ipWhitelist, {mode: "allow", log: false})(req, res, function(err) {
 			if (err === undefined) {
 				return next();
 			}

--- a/js/server.js
+++ b/js/server.js
@@ -22,6 +22,7 @@ var Server = function(config, callback) {
 			if (err === undefined) {
 				return next();
 			}
+			console.log(err.message);
 			res.status(403).send("This device is not allowed to access your mirror. <br> Please check your config.js or config.js.sample to change this.");
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "electron-prebuilt": "^0.37.2",
     "express": "^4.14.0",
+    "express-ipfilter": "latest",
     "feedme": "latest",
     "iconv-lite": "latest",
     "moment": "latest",


### PR DESCRIPTION
Solves #456 as discussed there. 

Features:
- Warning message of default behaviour is logged, if `ipWhitelist` value is not specified in the `config`
- If you try access from a blacklisted IP you will see how to change it
- It logs if anyone tries to access your mirror, who is not allowed

From my PC:
![screenshot from 2016-09-29 17 10 32](https://cloud.githubusercontent.com/assets/564777/18959895/00b49034-8668-11e6-8dad-0a077b08edf1.png)

From my phone:
![screenshot_2016-09-29-17-10-56](https://cloud.githubusercontent.com/assets/564777/18959897/029c8532-8668-11e6-81c6-0ba677f0a5af.png)
