### PR TITLE
Add option to show rain amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Module API: Option to define the minimumn MagicMirror version to run a module. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules#requiresversion) for more information.
 - Calendar module now broadcasts the event list to all other modules using the notification system. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/calendar) for more information.
 - Possibility to use the the calendar feed as the source for the weather (currentweather & weatherforecast) location data. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/weatherforecast) for more information.
+- Added option to show rain amount in the weatherforecast default module
 
 ### Updated
 - Modified translations for Frysk.

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -73,6 +73,14 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>showRainAmount</code></td>
+			<td>Should the predicted rain amount be displayed?<br>
+				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
+				<br><b>Default value:</b> <code>false</code>
+				<br>This value is optional. By default the weatherforecast module will not display the predicted amount of rain.
+			</td>
+		</tr>
+		<tr>
 			<td><code>updateInterval</code></td>
 			<td>How often does the content needs to be fetched? (Milliseconds)<br>
 				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>

--- a/modules/default/weatherforecast/weatherforecast.css
+++ b/modules/default/weatherforecast/weatherforecast.css
@@ -12,3 +12,8 @@
   padding-left: 20px;
   padding-right: 0;
 }
+
+.weatherforecast .rain {
+  padding-left: 20px;
+  padding-right: 0;
+}

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -16,6 +16,7 @@ Module.register("weatherforecast",{
 		appid: "",
 		units: config.units,
 		maxNumberOfDays: 7,
+		showRainAmount: false,
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		animationSpeed: 1000,
 		timeFormat: config.timeFormat,
@@ -141,6 +142,17 @@ Module.register("weatherforecast",{
 			minTempCell.innerHTML = forecast.minTemp;
 			minTempCell.className = "align-right min-temp";
 			row.appendChild(minTempCell);
+
+			if (this.config.showRainAmount) {
+				var rainCell = document.createElement("td");
+				if (isNaN(forecast.rain)) {
+					rainCell.innerHTML = "";
+				} else {
+					rainCell.innerHTML = forecast.rain + " mm";
+				}
+				rainCell.className = "align-right bright rain";
+				row.appendChild(rainCell);
+			}
 
 			if (this.config.fade && this.config.fadePoint < 1) {
 				if (this.config.fadePoint < 0) {
@@ -280,7 +292,8 @@ Module.register("weatherforecast",{
 				day: moment(forecast.dt, "X").format("ddd"),
 				icon: this.config.iconTable[forecast.weather[0].icon],
 				maxTemp: this.roundValue(forecast.temp.max),
-				minTemp: this.roundValue(forecast.temp.min)
+				minTemp: this.roundValue(forecast.temp.min),
+				rain: this.roundValue(forecast.rain)
 
 			});
 		}


### PR DESCRIPTION
This adds a boolean configuration option to show the estimated amount of rain in millimetres. This has been running on my mirror for a long time now. It is not a perfect prediction, but gives a rough idea, if there is going to be a **lot** of rain or if it is just a few drops.

Maybe someone else, also wants to see this information?

With the options set to `false` (same as before) and `true`:
![screenshot from 2016-10-14 23 08 54](https://cloud.githubusercontent.com/assets/564777/19402925/4b3cfc88-9264-11e6-9e70-40dd69bb119b.png)


