### PR TITLE
Change position from absolute to fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Solve an issue where module margins would appear when the first module of a section was hidden.
-- Solve visual display errors on chrome, if all modules in one of the right sections are hidden
+- Solved visual display errors on chrome, if all modules in one of the right sections are hidden
 
 ## [2.0.5] - 2016-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Solve an issue where module margins would appear when the first module of a section was hidden.
+- Solve visual display errors on chrome, if all modules in one of the right sections are hidden
 
 ## [2.0.5] - 2016-09-20
 

--- a/js/main.js
+++ b/js/main.js
@@ -196,7 +196,7 @@ var MM = (function() {
 				// since it's fade out anyway, we can see it lay above or
 				// below other modules. This works way better than adjusting
 				// the .display property.
-				moduleWrapper.style.position = "absolute";
+				moduleWrapper.style.position = "fixed";
 
 				if (typeof callback === "function") { callback(); }
 			}, speed);


### PR DESCRIPTION
* Does the pull request solve a **related** issue?

No.

* What does the pull request accomplish?

Fixes visual display on chrome. Does not change anything when displaying with electron. Hopefully also does not change anything on other browsers.

* If it includes major visual changes please add screenshots.

With the `absolute` position of a hidden module (opacity is manually changed to 1)
other modules move into weird position because of the extra margin:
![absolute](https://cloud.githubusercontent.com/assets/564777/19418550/89bee198-93c6-11e6-9b84-8a13be96e553.png)
With the `fixed` position (opacity is manually changed to 1), the module itself moves out of the window:
![fixed](https://cloud.githubusercontent.com/assets/564777/19418552/8b3e5922-93c6-11e6-9c01-c5eaa43ae7c6.png)

Chrome is on newest Ubuntu version: Version 54.0.2840.59 (64-bit).