### PR TITLE
currentweather, weatherforecast: sample URL for LocationID:

### DIFF
--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -14,7 +14,7 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
-			locationID: '', //Location ID from http://bulk.openweather.org/sample/ 
+			locationID: '', //Location ID from http://openweathermap.org/help/city_list.txt
 			appid: 'abcde12345abcde12345abcde12345ab' //openweathermap.org API key.
 		}
 	}
@@ -45,7 +45,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>locationID</code></td>
-			<td>Location ID from <a href="http://bulk.openweather.org/sample/">OpenWeather</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
+			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
 				<br><b>Example:</b> <code>1234567</code>
 				<br><b>Default value:</b> <code></code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -14,7 +14,7 @@ modules: [
 		config: {
 			// See 'Configuration options' for more information.
 			location: 'Amsterdam,Netherlands',
-			locationID: '', //Location ID from http://bulk.openweather.org/sample/ 
+			locationID: '', //Location ID from http://openweathermap.org/help/city_list.txt
 			appid: 'abcde12345abcde12345abcde12345ab' //openweathermap.org API key.
 		}
 	}
@@ -45,7 +45,7 @@ The following properties can be configured:
 		</tr>
 		<tr>
 			<td><code>locationID</code></td>
-			<td>Location ID from <a href="http://bulk.openweather.org/sample/">OpenWeather</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
+			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
 				<br><b>Example:</b> <code>1234567</code>
 				<br><b>Default value:</b> <code></code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.


### PR DESCRIPTION
Changed from README the sample URLs for get the LocationID.
The http://bulk.openweather.org/sample/ doesn't work
