### PR TITLE
currentweather, weatherforecast: fix locationID empty

### DIFF
--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -259,9 +259,9 @@ Module.register("currentweather",{
 	 */
 	getParams: function() {
 		var params = "?";
-		if(this.config.locationID !== false) {
+		if(this.config.locationID) {
 			params += "id=" + this.config.locationID;
-		} else if(this.config.location !== false) {
+		} else if(this.config.location) {
 			params += "q=" + this.config.location;
 		} else if (this.firstEvent && this.firstEvent.geo) {
 			params += "lat=" + this.firstEvent.geo.lat + "&lon=" + this.firstEvent.geo.lon

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -249,9 +249,9 @@ Module.register("weatherforecast",{
 	 */
 	getParams: function() {
 		var params = "?";
-		if(this.config.locationID !== false) {
+		if(this.config.locationID) {
 			params += "id=" + this.config.locationID;
-		} else if(this.config.location !== false) {
+		} else if(this.config.location) {
 			params += "q=" + this.config.location;
 		} else if (this.firstEvent && this.firstEvent.geo) {
 			params += "lat=" + this.firstEvent.geo.lat + "&lon=" + this.firstEvent.geo.lon


### PR DESCRIPTION
Fix when the option locationID the value = ''

If you have the next config

 config: {
            // See 'Configuration options' for more information.
            location: 'Chillan, Chile',
            locationID: '',
            appid: 'abcde12345abcde12345abcde12345ab'
        }

The modules dont get the data, because the parameters of query is created
in id=''