### PR TITLE
Mm fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Solve an issue where module margins would appear when the first module of a section was hidden.
-- Solved visual display errors on chrome, if all modules in one of the right sections are hidden
+- Solved visual display errors on chrome, if all modules in one of the right sections are hidden.
+- Module default config values are no longer modified when setting config values.
 
 ## [2.0.5] - 2016-09-20
 

--- a/js/module.js
+++ b/js/module.js
@@ -166,7 +166,7 @@ var Module = Class.extend({
 	 * argument config obejct - Module config.
 	 */
 	setConfig: function (config) {
-		this.config = Object.assign(this.defaults, config);
+		this.config = Object.assign({}, this.defaults, config);
 	},
 
 	/* socket()


### PR DESCRIPTION
"_module.js:setConfig()_" currently overwrites "_this.defaults_" in a module. The first argument from "_Object.assign()_" is the target object too, resulting in "_this.config_" becoming the same object reference as "_this.defaults_" (https://googlechrome.github.io/samples/object-assign-es6/). This results in the modules default config values not necessarily being the true default values at runtime.

Now "_this.config_" gets assigned a new object with the merged values from the default config and the passed config argument instead. That way, "_this.defaults_" still holds the correct default values.
