### PR TITLE
Added keys to EN and DA translations files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 - Modified translations for Frysk.
+- Modified core English translations.
 - Updated package.json as a result of Snyk security update.
 - Improve object instantiation to prevent reference errors.
 - Improve logger. `Log.log()` now accepts multiple arguments.

--- a/modules/default/alert/translations/da.json
+++ b/modules/default/alert/translations/da.json
@@ -1,0 +1,4 @@
+{
+  "sysTitle": "MagicMirror Notifikation",
+  "welcome": "Velkommen, modulet er succesfuldt startet!"
+}

--- a/translations/da.json
+++ b/translations/da.json
@@ -5,6 +5,7 @@
 	/* CALENDAR */
 	"TODAY": "I dag",
 	"TOMORROW": "I morgen",
+	"DAYAFTERTOMORROW": "I overmorgen",
 	"RUNNING": "Slutter om",
 	"EMPTY": "Ingen kommende begivenheder.",
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -5,6 +5,7 @@
 	/* CALENDAR */
 	"TODAY": "Today",
 	"TOMORROW": "Tomorrow",
+	"DAYAFTERTOMORROW": "The day after tomorrow",
 	"RUNNING": "Ends in",
 	"EMPTY": "No upcoming events.",
 


### PR DESCRIPTION
Added "DAYAFTERTOMORROW" key to the EN and DA translation files. The key appears in other files. People will mainly copy from the EN translation file, therefor it's important that the EN translation is kept up-to-date.