### PR TITLE
Dateformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option to show rain amount in the weatherforecast default module
 - Add module `updatenotification` to get an update whenever a new version is availabe. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/updatenotification) for more information.
 - Add the abilty to set timezone on the date display in the Clock Module
+- Ability to set date format in calendar module
 
 ### Updated
 - Modified translations for Frysk.

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -119,6 +119,13 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>dateFormat</code></td>
+			<td>Format to use for the date of events (when using absolute dates)<br>
+				<br><b>Possible values:</b> See <a href="http://momentjs.com/docs/#/parsing/string-format/">Moment.js formats</a>
+				<br><b>Default value:</b> <code>MMM Do</code> (e.g. Jan 18th)
+			</td>
+		</tr>
+		<tr>
 			<td><code>timeFormat</code></td>
 			<td>Display event times as absolute dates, or relative time<br>
 				<br><b>Possible values:</b> <code>absolute</code> or <code>relative</code>

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -23,6 +23,7 @@ Module.register("calendar", {
 		fade: true,
 		urgency: 7,
 		timeFormat: "relative",
+		dateFormat: "MMM Do",
 		getRelative: 6,
 		fadePoint: 0.25, // Start on 1/4th of the list.
 		calendars: [
@@ -175,7 +176,7 @@ Module.register("calendar", {
 							// This event falls within the config.urgency period that the user has set
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						} else {
-							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format("MMM Do"));
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
 						}
 					} else {
 						timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
@@ -205,7 +206,7 @@ Module.register("calendar", {
 								// This event falls within the config.urgency period that the user has set
 								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 							} else {
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format("MMM Do"));
+								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
 							}
 						} else {
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());


### PR DESCRIPTION
Added ability to set date format in calendar module. E.g. "ddd D MMM" will show "Thu 10 Oct".

```javascript
{
	module: 'calendar',
	header: 'Agenda',
	position: 'top_left',
	config: {
		timeFormat: 'absolute',
		dateFormat: 'ddd D MMM',
		urgency: 0,
		calendars: [
			{
				symbol: 'calendar-check-o ',
				url: 'webcal://www.calendarlabs.com/templates/ical/US-Holidays.ics'
			}
		]
	}
}
```

![image](https://cloud.githubusercontent.com/assets/678500/20185319/e3a025ec-a76b-11e6-8ee7-618615b1289b.png)

