### PR TITLE
main.js: Fix hidden other modules

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -274,9 +274,7 @@ var MM = (function() {
 
 			var showWrapper = false;
 			Array.prototype.forEach.call(moduleWrappers, function(moduleWrapper) { 
-				if (moduleWrapper.style.position == "static") {
-					showWrapper = true;
-				} 
+				showWrapper = true;
 			});
 
 			wrapper.style.display = showWrapper ? "block" : "none";


### PR DESCRIPTION
In commit e419701 is introduced updateWrapperStates for hide unused
regions.

The problem is, not all the modules loaded have the style.position =
'static', this cause the some modules will be hide.

This is reproduced for the next module config

```
    modules: [
        {
            module: "clock",
            position: "top_left"
        },
        {
            config: {
                feeds: [
                    {
                        title: "New York Times",
                        url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml"
                    }
                ],
                showPublishDate: true,
                showSourceTitle: true
            },
            module: "newsfeed",
            position: "bottom_bar"
        }
    ],

```