### PR TITLE
Mm fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Solve an issue where module margins would appear when the first module of a section was hidden.
-- Solved visual display errors on chrome, if all modules in one of the right sections are hidden
+- Solved visual display errors on chrome, if all modules in one of the right sections are hidden.
+- Module default config values are no longer modified when setting config values.
 
 ## [2.0.5] - 2016-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Solved visual display errors on chrome, if all modules in one of the right sections are hidden.
 - Module default config values are no longer modified when setting config values.
 - Hide a region if all modules in a region are hidden. Prevention unwanted margins. 
+- Default config definition conforms now with the JSON specification.
 
 ## [2.0.5] - 2016-09-20
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -5,75 +5,75 @@
  */
 
 var config = {
-	port: 8080,
-	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
+	"port": 8080,
+	"ipWhitelist": ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 
-	language: 'en',
-	timeFormat: 24,
-	units: 'metric',
+	"language": "en",
+	"timeFormat": 24,
+	"units": "metric",
 
-	modules: [
+	"modules": [
 		{
-			module: 'alert',
-		},
+			"module": "alert"
+		}, 
 		{
-			module: "updatenotification",
-			position: "top_bar"
-		},
+			"module": "updatenotification",
+			"position": "top_bar"
+		}, 
 		{
-			module: 'clock',
-			position: 'top_left'
-		},
+			"module": "clock",
+			"position": "top_left"
+		}, 
 		{
-			module: 'calendar',
-			header: 'US Holidays',
-			position: 'top_left',
-			config: {
-				calendars: [
+			"module": "calendar",
+			"header": "US Holidays",
+			"position": "top_left",
+			"config": {
+				"calendars": [
 					{
-						symbol: 'calendar-check-o ',
-						url: 'webcal://www.calendarlabs.com/templates/ical/US-Holidays.ics'
+						"symbol": "calendar-check-o ",
+						"url": "webcal://www.calendarlabs.com/templates/ical/US-Holidays.ics"
 					}
 				]
 			}
-		},
+		}, 
 		{
-			module: 'compliments',
-			position: 'lower_third'
-		},
+			"module": "compliments",
+			"position": "lower_third"
+		}, 
 		{
-			module: 'currentweather',
-			position: 'top_right',
-			config: {
-				location: 'New York',
-				locationID: '',  //ID from http://www.openweathermap.org
-				appid: 'YOUR_OPENWEATHER_API_KEY'
+			"module": "currentweather",
+			"position": "top_right",
+			"config": {
+				"location": "New York",
+				"locationID": "", //ID from http://www.openweathermap.org
+				"appid": "YOUR_OPENWEATHER_API_KEY"
 			}
-		},
+		}, 
 		{
-			module: 'weatherforecast',
-			position: 'top_right',
-			header: 'Weather Forecast',
-			config: {
-	            location: 'New York',
-				locationID: '5128581',  //ID from http://www.openweathermap.org
-	            appid: 'YOUR_OPENWEATHER_API_KEY'
+			"module": "weatherforecast",
+			"position": "top_right",
+			"header": "Weather Forecast",
+			"config": {
+				"location": "New York",
+				"locationID": "5128581", //ID from http://www.openweathermap.org
+				"appid": "YOUR_OPENWEATHER_API_KEY"
 			}
-		},
+		}, 
 		{
-			module: 'newsfeed',
-			position: 'bottom_bar',
-			config: {
-				feeds: [
+			"module": "newsfeed",
+			"position": "bottom_bar",
+			"config": {
+				"feeds": [
 					{
-						title: "New York Times",
-						url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml"
+						"title": "New York Times",
+						"url": "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml"
 					}
 				],
-				showSourceTitle: true,
-				showPublishDate: true
+				"showSourceTitle": true,
+				"showPublishDate": true
 			}
-		},
+		}
 	]
 
 };


### PR DESCRIPTION
The default config definition doesn't conform with the JSON specification (http://www.json.org/ , http://jsonlint.com/). 

The issues were:

- value names must be strings
- strings are enclosed in double quotes
- no trailing commas

I am currently developing a module, where i modify the config file and i need to be able to parse the config JSON-Object with JSON.parse(...). But that fails, because its not valid JSON (when config.js is based on the default config). I will probably add a workaround for this into my module, but it would be good, if the default config file uses the standard.