### PR TITLE
Option to display temperatures rounded to nearest integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option `address` to set bind address.
 - Added option `onlyTemp` for currentweather module to show show only current temperature and weather icon.
 - Added option `remoteFile` to compliments module to load compliment array from filesystem.
+- Added option `roundTemp` for currentweather and weatherforecast modules to display temperatures rounded to nearest integer.
 
 ### Updated
 - Modified translations for Frysk.

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -65,6 +65,13 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>roundTemperature</code></td>
+			<td>Round temperature value to nearest integer.<br>
+				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>updateInterval</code></td>
 			<td>How often does the content needs to be fetched? (Milliseconds)<br>
 				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -65,7 +65,7 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
-			<td><code>roundTemperature</code></td>
+			<td><code>roundTemp</code></td>
 			<td>Round temperature value to nearest integer.<br>
 				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
 				<br><b>Default value:</b> <code>false</code>

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -15,6 +15,7 @@ Module.register("currentweather",{
 		locationID: false,
 		appid: "",
 		units: config.units,
+		roundTemperature: false,
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		animationSpeed: 1000,
 		timeFormat: config.timeFormat,
@@ -181,9 +182,13 @@ Module.register("currentweather",{
 		weatherIcon.className = "wi weathericon " + this.weatherType;
 		large.appendChild(weatherIcon);
 
+		var temp = this.temperature;
+		if (this.config.roundTemperature) {
+			temp = Math.round(temp);
+		}
 		var temperature = document.createElement("span");
 		temperature.className = "bright";
-		temperature.innerHTML = " " + this.temperature + "&deg;";
+		temperature.innerHTML = " " + temp + "&deg;";
 		large.appendChild(temperature);
 
 		wrapper.appendChild(large);

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -15,7 +15,6 @@ Module.register("currentweather",{
 		locationID: false,
 		appid: "",
 		units: config.units,
-		roundTemperature: false,
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		animationSpeed: 1000,
 		timeFormat: config.timeFormat,
@@ -37,7 +36,8 @@ Module.register("currentweather",{
 		calendarClass: "calendar",
 
 		onlyTemp: false,
-
+		roundTemp: false,
+		
 		iconTable: {
 			"01d": "wi-day-sunny",
 			"02d": "wi-day-cloudy",
@@ -183,7 +183,7 @@ Module.register("currentweather",{
 		large.appendChild(weatherIcon);
 
 		var temp = this.temperature;
-		if (this.config.roundTemperature) {
+		if (this.config.roundTemp) {
 			temp = Math.round(temp);
 		}
 		var temperature = document.createElement("span");

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -386,14 +386,6 @@ Module.register("currentweather",{
 		return 12;
 	},
 
-	/* function(temperature)
-	 * Rounds a temperature to 1 decimal.
-	 *
-	 * argument temperature number - Temperature.
-	 *
-	 * return number - Rounded Temperature.
-	 */
-
 	deg2Cardinal: function(deg) {
                 if (deg>11.25 && deg<=33.75){
                         return "NNE";
@@ -430,7 +422,13 @@ Module.register("currentweather",{
                 }
 	},
 
-
+	/* function(temperature)
+	 * Rounds a temperature to 1 decimal.
+	 *
+	 * argument temperature number - Temperature.
+	 *
+	 * return number - Rounded Temperature.
+	 */
 	roundValue: function(temperature) {
 		var decimals = this.config.roundTemp ? 0 : 1;
 		return parseFloat(temperature).toFixed(decimals);

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -423,7 +423,7 @@ Module.register("currentweather",{
 	},
 
 	/* function(temperature)
-	 * Rounds a temperature to 1 decimal.
+	 * Rounds a temperature to 1 decimal or integer (depending on config.roundTemp).
 	 *
 	 * argument temperature number - Temperature.
 	 *

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -182,13 +182,9 @@ Module.register("currentweather",{
 		weatherIcon.className = "wi weathericon " + this.weatherType;
 		large.appendChild(weatherIcon);
 
-		var temp = this.temperature;
-		if (this.config.roundTemp) {
-			temp = Math.round(temp);
-		}
 		var temperature = document.createElement("span");
 		temperature.className = "bright";
-		temperature.innerHTML = " " + temp + "&deg;";
+		temperature.innerHTML = " " + this.temperature + "&deg;";
 		large.appendChild(temperature);
 
 		wrapper.appendChild(large);
@@ -436,6 +432,7 @@ Module.register("currentweather",{
 
 
 	roundValue: function(temperature) {
-		return parseFloat(temperature).toFixed(1);
+		var decimals = this.config.roundTemp ? 0 : 1;
+		return parseFloat(temperature).toFixed(decimals);
 	}
 });

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -65,7 +65,7 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
-			<td><code>roundTemperature</code></td>
+			<td><code>roundTemp</code></td>
 			<td>Round temperature values to nearest integer.<br>
 				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
 				<br><b>Default value:</b> <code>false</code>

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -65,6 +65,13 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
+			<td><code>roundTemperature</code></td>
+			<td>Round temperature values to nearest integer.<br>
+				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
+				<br><b>Default value:</b> <code>false</code>
+			</td>
+		</tr>
+		<tr>
 			<td><code>maxNumberOfDays</code></td>
 			<td>How many days of forecast to return. Specified by config.js<br>
 				<br><b>Possible values:</b> <code>1</code> - <code>16</code>

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -135,20 +135,13 @@ Module.register("weatherforecast",{
 			icon.className = "wi weathericon " + forecast.icon;
 			iconCell.appendChild(icon);
 
-			var maxTemp = forecast.maxTemp;
-			var minTemp = forecast.minTemp;
-			if (this.config.roundTemp) {
-				maxTemp = Math.round(maxTemp);
-				minTemp = Math.round(minTemp);
-			}
-			
 			var maxTempCell = document.createElement("td");
-			maxTempCell.innerHTML = maxTemp;
+			maxTempCell.innerHTML = forecast.maxTemp;
 			maxTempCell.className = "align-right bright max-temp";
 			row.appendChild(maxTempCell);
 
 			var minTempCell = document.createElement("td");
-			minTempCell.innerHTML = minTemp;
+			minTempCell.innerHTML = forecast.minTemp;
 			minTempCell.className = "align-right min-temp";
 			row.appendChild(minTempCell);
 
@@ -351,14 +344,15 @@ Module.register("weatherforecast",{
 	},
 
 	/* function(temperature)
-	 * Rounds a temperature to 1 decimal.
+	 * Rounds a temperature to 1 decimal or integer (depending on config.roundTemp).
 	 *
 	 * argument temperature number - Temperature.
 	 *
 	 * return number - Rounded Temperature.
 	 */
 	roundValue: function(temperature) {
-		return parseFloat(temperature).toFixed(1);
+		var decimals = this.config.roundTemp ? 0 : 1;
+		return parseFloat(temperature).toFixed(decimals);
 	}
 });
 

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -15,7 +15,6 @@ Module.register("weatherforecast",{
 		locationID: false,
 		appid: "",
 		units: config.units,
-		roundTemperature: false,
 		maxNumberOfDays: 7,
 		showRainAmount: false,
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
@@ -35,6 +34,8 @@ Module.register("weatherforecast",{
 		appendLocationNameToHeader: true,
 		calendarClass: "calendar",
 
+		roundTemp: false,
+		
 		iconTable: {
 			"01d": "wi-day-sunny",
 			"02d": "wi-day-cloudy",
@@ -136,7 +137,7 @@ Module.register("weatherforecast",{
 
 			var maxTemp = forecast.maxTemp;
 			var minTemp = forecast.minTemp;
-			if (this.config.roundTemperature) {
+			if (this.config.roundTemp) {
 				maxTemp = Math.round(maxTemp);
 				minTemp = Math.round(minTemp);
 			}

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -15,6 +15,7 @@ Module.register("weatherforecast",{
 		locationID: false,
 		appid: "",
 		units: config.units,
+		roundTemperature: false,
 		maxNumberOfDays: 7,
 		showRainAmount: false,
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
@@ -133,13 +134,20 @@ Module.register("weatherforecast",{
 			icon.className = "wi weathericon " + forecast.icon;
 			iconCell.appendChild(icon);
 
+			var maxTemp = forecast.maxTemp;
+			var minTemp = forecast.minTemp;
+			if (this.config.roundTemperature) {
+				maxTemp = Math.round(maxTemp);
+				minTemp = Math.round(minTemp);
+			}
+			
 			var maxTempCell = document.createElement("td");
-			maxTempCell.innerHTML = forecast.maxTemp;
+			maxTempCell.innerHTML = maxTemp;
 			maxTempCell.className = "align-right bright max-temp";
 			row.appendChild(maxTempCell);
 
 			var minTempCell = document.createElement("td");
-			minTempCell.innerHTML = forecast.minTemp;
+			minTempCell.innerHTML = minTemp;
 			minTempCell.className = "align-right min-temp";
 			row.appendChild(minTempCell);
 
@@ -352,3 +360,4 @@ Module.register("weatherforecast",{
 		return parseFloat(temperature).toFixed(1);
 	}
 });
+


### PR DESCRIPTION
Added a config option `roundTemp` for both _currentweather_ and _weatherforecast_ modules that rounds the temperature values to the nearest integer before display. Default behaviour is unchanged (option set to <code>false</code> in defaults).

Reasoning: no-one really needs to know the temperature exact to a decimal point. The display looks much cleaner with rounded numbers, too.