### PR TITLE
Option to scale the whole display using Electron's zoom factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option `address` to set bind address.
 - Added option `onlyTemp` for currentweather module to show show only current temperature and weather icon.
 - Added option `remoteFile` to compliments module to load compliment array from filesystem.
+- Added option `zoom` to scale the whole mirror display with a given factor.
 
 ### Updated
 - Modified translations for Frysk.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following properties can be configured:
 | `address` | The ip address the accept connections. The  default open bind `::` is IPv6 is available or `0.0.0.0` IPv4 run on.  Example config: `192.168.10.100`. |
 | `ipWhitelist` | The list of IPs from which you are allowed to access the MagicMirror². The default value is `["127.0.0.1", "::ffff:127.0.0.1", "::1"]`. It is possible to specify IPs with subnet masks (`["127.0.0.1", "127.0.0.1/24"]`) or define ip ranges (`["127.0.0.1", ["192.168.0.1", "192.168.0.100"]]`).|
 | `kioskmode` | This allows MagicMirror² to run in Kiosk Mode. It protects from other programs popping on top of your screen. The default value is `false`|
+| `zoom` | This allows to scale the mirror contents with a given zoom factor. The default value is `1.0`|
 | `language` | The language of the interface. (Note: Not all elements will be localized.) Possible values are `en`, `nl`, `ru`, `fr`, etc., but the default value is `en`. |
 | `timeFormat` | The form of time notation that will be used. Possible values are `12` or `24`. The default is `24`. |
 | `units` | The units that will be used in the default weather modules. Possible values are `metric` or `imperial`. The default is `metric`. |

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -11,10 +11,11 @@ var defaults = {
 	port: 8080,
 	kioskmode: false,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
-
+	
 	language: "en",
 	timeFormat: 24,
 	units: "metric",
+	zoom: 1,
 
 	modules: [
 		{

--- a/js/electron.js
+++ b/js/electron.js
@@ -20,9 +20,9 @@ let mainWindow;
 function createWindow() {
 	// Create the browser window.
 	if (config.kioskmode) {
-		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, kiosk:true, darkTheme: true, webPreferences: {nodeIntegration: false}});
+		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, kiosk:true, darkTheme: true, webPreferences: {nodeIntegration: false, zoomFactor: config.zoom}});
 	} else {
-		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, fullscreen: true, autoHideMenuBar: true, darkTheme: true, webPreferences: {nodeIntegration: false}});
+		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, fullscreen: true, autoHideMenuBar: true, darkTheme: true, webPreferences: {nodeIntegration: false, zoomFactor: config.zoom}});
 	}
 
 	// and load the index.html of the app.

--- a/js/electron.js
+++ b/js/electron.js
@@ -18,12 +18,28 @@ const BrowserWindow = electron.BrowserWindow;
 let mainWindow;
 
 function createWindow() {
-	// Create the browser window.
-	if (config.kioskmode) {
-		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, kiosk:true, darkTheme: true, webPreferences: {nodeIntegration: false, zoomFactor: config.zoom}});
-	} else {
-		mainWindow = new BrowserWindow({width: 800, height: 600, x: 0, y: 0, fullscreen: true, autoHideMenuBar: true, darkTheme: true, webPreferences: {nodeIntegration: false, zoomFactor: config.zoom}});
+	
+	var electronOptions = {
+		width: 800, 
+		height: 600, 
+		x: 0, 
+		y: 0,
+		darkTheme: true, 
+		webPreferences: {
+			nodeIntegration: false, 
+			zoomFactor: config.zoom
+		}
 	}
+
+	if (config.kioskmode) {
+		electronOptions.kiosk = true;	
+	} else {
+		electronOptions.fullscreen = true;
+		electronOptions.autoHideMenuBar = true;
+	}
+
+	// Create the browser window.
+	mainWindow = new BrowserWindow(electronOptions);
 
 	// and load the index.html of the app.
 	//mainWindow.loadURL('file://' + __dirname + '../../index.html');


### PR DESCRIPTION
Added an option to scale the whole mirror display, using Electron's `zoomFactor`. Default value is `1.0`, so default behaviour is unchanged. Allows to make everything larger (and thus more readable) on high-resolution mirror displays.