### PR TITLE
Auto install non-default modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option `address` to set bind address.
 - Added option `onlyTemp` for currentweather module to show show only current temperature and weather icon.
 - Added option `remoteFile` to compliments module to load compliment array from filesystem.
+- Added option `repository` to modules to allow auto installation.
 
 ### Updated
 - Modified translations for Frysk.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Module configuration:
 | **Option** | **Description** |
 | --- | --- |
 | `module` | The name of the module. This can also contain the subfolder. Valid examples include `clock`, `default/calendar` and `custommodules/mymodule`. |
+| `repository` | The URL of the git repository. This is used to automatically install the non-default module. This field is optional. |
 | `position` | The location of the module in which the module will be loaded. Possible values are `top_ bar`, `top_left`, `top_center`, `top_right`, `upper_third`, `middle_center`, `lower_third`, `bottom_left`, `bottom_center`, `bottom_right`, `bottom_bar`, `fullscreen_above`, and `fullscreen_below`. This field is optional but most modules require this field to set. Check the documentation of the module for more information. Multiple modules with the same position will be ordered based on the order in the configuration file. |
 | `classes` | Additional classes which are passed to the module. The field is optional. |
 | `header` | To display a header text above the module, add the header property. This field is optional. |


### PR DESCRIPTION
Another idea I've had, if you're interested.

This change allows non-default modules to be automatically installed if the git-URL is provided in the module's optional argument 'repository'.

When configuring MagicMirror on RPi, instead of my dev-machine, I would like to just copy the config.js and not have to think of installing some modules manually. See here, a solution to that.

Future improvement might be to automatically update modules, maybe depending on a setting in the configuration.