### PR TITLE
Check updates (in updatenotification) only for repos with remote

### DIFF
--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -29,7 +29,18 @@ module.exports = NodeHelper.create({
 					continue;
 				}
 
-				simpleGits.push({"module": moduleName, "git": SimpleGit(moduleFolder)});
+				var res = function(mn, mf) {
+					var git = SimpleGit(mf);
+					git.getRemotes(true, function(err, remotes) {
+						if (remotes.length < 1 || remotes[0].name.length < 1) {
+							// No valid remote for folder, skip
+							return;
+						}
+
+						// Folder has .git and has at least one git remote, watch this folder
+						simpleGits.push({"module": mn, "git": git});
+					});
+				}(moduleName, moduleFolder);
 			}
 		}
 


### PR DESCRIPTION
A remote repository is not always available for git repos. Developping new modules locally and storing changes in git for example. This PR fixes the updatenotifcation module to only check for updates if the git repo actually has a remote to fetch from.