### PR TITLE
Add async callback to module when loaded

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -96,6 +96,21 @@ requiresVersion: "2.1.0",
 ####`init()`
 This method is called when a module gets instantiated. In most cases you do not need to subclass this method.
 
+####`loaded(callback)`
+
+*Introduced in version: 2.1.1.*
+
+This method is called when a module is loaded. Subsequent modules in the config are not yet loaded. The `callback` function MUST be called when the module is done loading. In most cases you do not need to subclass this method.
+
+**Example:**
+````javascript
+loaded: function(callback) {
+	this.finishLoading();
+	Log.log(this.name + ' is loaded!');
+	callback();
+}
+````
+
 ####`start()`
 This method is called when all modules are loaded an the system is ready to boot up. Keep in mind that the dom object for the module is not yet created. The start method is a perfect place to define any additional module properties:
 

--- a/modules/node_modules/node_helper/index.js
+++ b/modules/node_modules/node_helper/index.js
@@ -14,6 +14,11 @@ NodeHelper = Class.extend({
 		console.log("Initializing new module helper ...");
 	},
 
+	loaded: function(callback) {
+		console.log("Module helper loaded: " + this.name);
+		callback();
+	},
+
 	start: function() {
 		console.log("Staring module helper: " + this.name);
 	},


### PR DESCRIPTION
To enable the [autoinstall-module](https://github.com/qistoph/MMM-autoinstall) to install modules before they are loaded it was necessary to modify MagicMirror. This change provides an async function (loaded) with callback-function to modules. It is called when the module is loaded, before any other modules are loaded. The next module is loaded only after the callback function is called. This enables modules to do async operations (i.e. git-fetch and npm install) and then continue the loading of other modules afterwards.

If you see a better solution to delay loading modules, I'd be happy to adapt the autoinstall-module to that.