### PR TITLE
Mm fixes

### DIFF
--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -144,7 +144,7 @@ The following properties can be configured:
 			<td>When using a timeFormat of <code>absolute</code>, the <code>urgency</code> setting allows you to display events within a specific time frame as <code>relative</code>
 			    This allows events within a certain time frame to be displayed as relative (in xx days) while others are displayed as absolute dates<br>
 				<br><b>Possible values:</b> a positive integer representing the number of days for which you want a relative date, for example <code>7</code> (for 7 days)<br>
-				<br><b>Default value:</b> <code>0</code> (disabled)
+				<br><b>Default value:</b> <code>7</code>
 			</td>
 		</tr>
 		<tr>

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -109,6 +109,13 @@ The following properties can be configured:
 				<code>
 					titleReplace: {'Birthday of ' : '', 'foo':'bar'}
 				</code>
+				<br><b>Default value:</b> 
+				<code>
+				{
+					"De verjaardag van ": "",
+					"'s birthday": ""
+				}
+				</code>
 			</td>
 		</tr>
 		<tr>

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -32,10 +32,7 @@ Module.register("calendar", {
 				url: "http://www.calendarlabs.com/templates/ical/US-Holidays.ics",
 			},
 		],
-		titleReplace: {
-			"De verjaardag van ": "",
-			"'s birthday": ""
-		},
+		titleReplace: {},
 		broadcastEvents: true
 	},
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -32,7 +32,10 @@ Module.register("calendar", {
 				url: "http://www.calendarlabs.com/templates/ical/US-Holidays.ics",
 			},
 		],
-		titleReplace: {},
+		titleReplace: {
+			"De verjaardag van ": "",
+			"'s birthday": ""
+		},
 		broadcastEvents: true
 	},
 

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -39,7 +39,7 @@ The following properties can be configured:
 			<td><code>location</code></td>
 			<td>The location used for weather information.<br>
 				<br><b>Example:</b> <code>'Amsterdam,Netherlands'</code>
-				<br><b>Default value:</b> <code>New York</code><br><br>
+				<br><b>Default value:</b> <code>false</code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 			</td>
 		</tr>
@@ -47,7 +47,7 @@ The following properties can be configured:
 			<td><code>locationID</code></td>
 			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
 				<br><b>Example:</b> <code>1234567</code>
-				<br><b>Default value:</b> <code></code><br><br>
+				<br><b>Default value:</b> <code>false</code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 			</td>
 		</tr>
@@ -82,7 +82,7 @@ The following properties can be configured:
 			<td><code>animationSpeed</code></td>
 			<td>Speed of the update animation. (Milliseconds)<br>
 				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>2000</code> (2 seconds)
+				<br><b>Default value:</b> <code>1000</code> (1 second)
 			</td>
 		</tr>
 		<tr>

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -53,6 +53,7 @@ The following properties can be configured:
 					{
 						title: "New York Times",
 						url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+						encoding: "UTF-8" //ISO-8859-1
 					}
 				]</code>
 			</td>

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -53,7 +53,7 @@ The following properties can be configured:
 					{
 						title: "New York Times",
 						url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-						encoding: "UTF-8" //ISO-8859-1
+						encoding: "UTF-8"
 					}
 				]</code>
 			</td>

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -39,7 +39,7 @@ The following properties can be configured:
 			<td><code>location</code></td>
 			<td>The location used for weather information.<br>
 				<br><b>Example:</b> <code>'Amsterdam,Netherlands'</code>
-				<br><b>Default value:</b> <code>New York</code><br><br>
+				<br><b>Default value:</b> <code>false</code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 			</td>
 		</tr>
@@ -47,7 +47,7 @@ The following properties can be configured:
 			<td><code>locationID</code></td>
 			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
 				<br><b>Example:</b> <code>1234567</code>
-				<br><b>Default value:</b> <code></code><br><br>
+				<br><b>Default value:</b> <code>false</code><br><br>
 				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 			</td>
 		</tr>
@@ -98,7 +98,7 @@ The following properties can be configured:
 			<td><code>animationSpeed</code></td>
 			<td>Speed of the update animation. (Milliseconds)<br>
 				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>2000</code> (2 seconds)
+				<br><b>Default value:</b> <code>1000</code> (1 second)
 			</td>
 		</tr>
 		<tr>
@@ -126,7 +126,7 @@ The following properties can be configured:
 			<td><code>initialLoadDelay</code></td>
 			<td>The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds)<br>
 				<br><b>Possible values:</b> <code>1000</code> - <code>5000</code>
-				<br><b>Default value:</b>  <code>0</code>
+				<br><b>Default value:</b>  <code>2500</code> (2.5 seconds delay. This delay is used to keep the OpenWeather API happy.)
 			</td>
 		</tr>
 		<tr>
@@ -149,7 +149,7 @@ The following properties can be configured:
 			</td>
 		</tr>
 		<tr>
-			<td><code>weatherEndpoint</code></td>
+			<td><code>forecastEndpoint</code></td>
 			<td>The OpenWeatherMap API endPoint.<br>
 				<br><b>Default value:</b>  <code>'forecast/daily'</code>
 			</td>


### PR DESCRIPTION
Fixes #562 

I have updated the READMEs with the values defined in the script-files, EXCEPT for the calendar module, where `titleReplace` was defined as this:

```
titleReplace: {
    "De verjaardag van ": "",
    "'s birthday": ""
}
```

I don't think that makes sense, that this is the default value for it (in respect to the default defined calendar) and changed it to an empty object (`{}`) instead.