### PR TITLE
Added console warning for deprecated config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option `roundTemp` for currentweather and weatherforecast modules to display temperatures rounded to nearest integer.
 - Added abilty set the classes option to compliments module for style and text size of compliments.
 - Added ability to configure electronOptions
+- Added console warning on startup when deprecated config options are used 
 
 ### Updated
 - Modified translations for Frysk.

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,3 @@
 *
 !config.js.sample
+!deprecated.js

--- a/config/deprecated.js
+++ b/config/deprecated.js
@@ -1,0 +1,12 @@
+/* Magic Mirror Deprecated Config Options List
+ *
+ * By Michael Teeuw http://michaelteeuw.nl
+ * MIT Licensed.
+ */
+
+var deprecated = [
+    'kioskmode'
+];
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== 'undefined') {module.exports = deprecated;}

--- a/js/app.js
+++ b/js/app.js
@@ -42,6 +42,7 @@ var App = function() {
 		try {
 			fs.accessSync(configFilename, fs.F_OK);
 			var c = require(configFilename);
+			checkDeprecatedOptions(c);
 			var config = Object.assign(defaults, c);
 			callback(config);
 		} catch (e) {
@@ -57,6 +58,21 @@ var App = function() {
 			}
 		}
 	};
+
+	var checkDeprecatedOptions = function(userConfig) {
+		var deprecatedOptions = require(__dirname + "/../config/deprecated.js");
+		var usedDeprecated = [];
+
+		deprecatedOptions.forEach(function(option) {
+			if (userConfig.hasOwnProperty(option)) {
+				usedDeprecated.push(option);
+			}
+		});
+
+		if (usedDeprecated.length > 0) {
+			console.error("WARNING! Your config is using deprecated options: " + usedDeprecated.join(", ") + ". Check README and CHANGELOG for more up-to-date ways of getting the same functionality.");
+		}
+	}
 
 	/* loadModule(module)
 	 * Loads a specific module.


### PR DESCRIPTION
Inspired by #560. Adds a list of deprecated config options, and shows a console warning on startup when any of them are set in user's `config.js`. List initially only includes `kioskmode`, since it is marked as deprecated in code and `electronOptions` should be used instead.