### PR TITLE
Add error handling to newsfeed

### DIFF
--- a/js/class.js
+++ b/js/class.js
@@ -41,8 +41,8 @@
 
 		return ret;
 	};
-        })(name, prop[name]) :
-        prop[name];
+})(name, prop[name]) :
+prop[name];
 		}
 
 		// The dummy class constructor

--- a/modules/default/newsfeed/fetcher.js
+++ b/modules/default/newsfeed/fetcher.js
@@ -80,7 +80,12 @@ var Fetcher = function(url, reloadInterval, encoding) {
 		});
 
 		var headers = {'User-Agent':'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A'};
-		request({uri: url, encoding: null, headers: headers}).pipe(iconv.decodeStream(encoding)).pipe(parser);
+		request({uri: url, encoding: null, headers: headers})
+			.on('error', function(error) {
+				fetchFailedCallback(self, error);
+				scheduleTimer();
+			})
+			.pipe(iconv.decodeStream(encoding)).pipe(parser);
 
 	};
 


### PR DESCRIPTION
Hi,
I have been having internet issues recently and i noticed that the newsfeed would not update when the internet was restored . 

To reproduce: 
1. Set reload interval to a low value (5seconds)
2. Disconnect internet 
3. Run MagicMirror
4. News feed will be stuck on loading
5. Reconnect internet and newsfeed will appear

Let me know if you want anything changed.
