### PR TITLE
Fix repeating count of yearly calendar events

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -134,7 +134,7 @@ Module.register("calendar", {
 				repeatingCountTitle = this.countTitleForUrl(event.url);
 
 				if (repeatingCountTitle !== "") {
-					var thisYear = new Date().getFullYear(),
+					var thisYear = new Date(parseInt(event.startDate)).getFullYear(),
 						yearDiff = thisYear - event.firstYear;
 
 					repeatingCountTitle = ", " + yearDiff + ". " + repeatingCountTitle;


### PR DESCRIPTION
#568  
The occurrence counter for a yearly repeating event e was calculated by "current year" - "e.firstYear", instead of "e.year" - "e.firstYear". That leads to a repeating event counter - 1 at the end of the year. E.g.
event e: first Date: 2015-01-02, yearly repetition
repeating count evaluated on 2015-12-31: 2015-2015 = 0 => incorrect
repeating count evaluated on 2016-01-01: 2016-2015 = 1 => correct
Fix: repeating count has to be calculated from event date instead of current date.