### PR TITLE
Enabled newsfeed default module for gesture events from https://github.com/thobach/MMM-Gestures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [develop] - release date to be defined
-- Made default newsfeed module aware of gesture events from https://github.com/thobach/MMM-Gestures
+- Made default newsfeed module aware of gesture events from [MMM-Gestures](https://github.com/thobach/MMM-Gestures)
 
 ## [2.1.0] - 2016-12-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [develop] - release date to be defined
+- Made default newsfeed module aware of gesture events from https://github.com/thobach/MMM-Gestures
+
 ## [2.1.0] - 2016-12-31
 
 **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -152,21 +152,21 @@ Module.register("newsfeed",{
 				}
 
 			}
-			
+
 			if(!this.config.showFullArticle){
 				var title = document.createElement("div");
 				title.className = "bright medium light";
 				title.innerHTML = this.newsItems[this.activeItem].title;
 				wrapper.appendChild(title);
 			}
-				
+
 			if (this.config.showDescription) {
 				var description = document.createElement("div");
 				description.className = "small light";
 				description.innerHTML = this.newsItems[this.activeItem].description;
 				wrapper.appendChild(description);
 			}
-			
+
 			if (this.config.showFullArticle) {
 				var fullArticle = document.createElement("iframe");
 				fullArticle.className = "";
@@ -176,8 +176,8 @@ Module.register("newsfeed",{
 				fullArticle.src = this.newsItems[this.activeItem].url;
 				wrapper.appendChild(fullArticle);
 			}
-			
-			
+
+
 
 		} else {
 			wrapper.innerHTML = this.translate("LOADING");
@@ -287,14 +287,14 @@ Module.register("newsfeed",{
 	capitalizeFirstLetter: function(string) {
 		return string.charAt(0).toUpperCase() + string.slice(1);
 	},
-	
+
 	notificationReceived: function(notification, payload, sender) {
 		Log.info(this.name + " - received event");
-		if(notification == 'GESTURE'){
+		if(notification == "GESTURE"){
 			Log.info(this.name + " - received gesture");
 			var gesture = payload.gesture;
 			// actually RIGHT, because gesture sensor is built in upside down
-			if(gesture == 'LEFT'){
+			if(gesture == "LEFT"){
 				Log.info(this.name + " - received right");
 				var before = this.activeItem;
 				this.activeItem++;
@@ -310,7 +310,7 @@ Module.register("newsfeed",{
 				this.updateDom(100);
 			}
 			// actually LEFT, because gesture sensor is built in upside down
-			else if(gesture == 'RIGHT'){
+			else if(gesture == "RIGHT"){
 				Log.info(this.name + " - received left");
 				var before = this.activeItem;
 				this.activeItem--;
@@ -326,7 +326,7 @@ Module.register("newsfeed",{
 				this.updateDom(100);
 			}
 			// actually UP, because gesture sensor is built in upside down
-			else if(gesture == 'DOWN' && !this.config.showDescription){
+			else if(gesture == "DOWN" && !this.config.showDescription){
 				Log.info(this.name + " - received up");
 				this.config.showDescription = true;
 				this.config.showFullArticle = false;
@@ -335,7 +335,7 @@ Module.register("newsfeed",{
 				this.updateDom(100);
 			}
 			// actually DOWN, because gesture sensor is built in upside down
-			else if(gesture == 'UP'){
+			else if(gesture == "UP"){
 				Log.info(this.name + " - received down");
 				this.config.showDescription = false;
 				this.config.showFullArticle = false;
@@ -345,7 +345,7 @@ Module.register("newsfeed",{
 				this.updateDom(100);
 			}
 			// actually UP, because gesture sensor is built in upside down
-			else if(gesture == 'DOWN' && this.config.showDescription){
+			else if(gesture == "DOWN" && this.config.showDescription){
 				Log.info(this.name + " - received up again");
 				this.config.showFullArticle = true;
 				this.config.showDescription = false;

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -171,7 +171,10 @@ Module.register("newsfeed",{
 				var fullArticle = document.createElement("iframe");
 				fullArticle.className = "";
 				fullArticle.style.width = "100%";
-				fullArticle.style.height = "1735px";
+				fullArticle.style.top = "0";
+				fullArticle.style.left = "0";
+				fullArticle.style.position = "fixed";
+				fullArticle.height = window.innerHeight;
 				fullArticle.style.border = "none";
 				fullArticle.src = this.newsItems[this.activeItem].url;
 				wrapper.appendChild(fullArticle);

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -89,7 +89,7 @@ Module.register("newsfeed",{
 
 		if (this.newsItems.length > 0) {
 
-			// this.config.showFullArticle is a run-time configuration, triggered by optional gestures
+			// this.config.showFullArticle is a run-time configuration, triggered by optional notifications
 			if (!this.config.showFullArticle && (this.config.showSourceTitle || this.config.showPublishDate)) {
 				var sourceAndTimestamp = document.createElement("div");
 				sourceAndTimestamp.className = "light small dimmed";
@@ -289,74 +289,62 @@ Module.register("newsfeed",{
 	},
 
 	notificationReceived: function(notification, payload, sender) {
-		Log.info(this.name + " - received event");
-		if(notification == "GESTURE"){
-			Log.info(this.name + " - received gesture");
-			var gesture = payload.gesture;
-			// actually RIGHT, because gesture sensor is built in upside down
-			if(gesture == "LEFT"){
-				Log.info(this.name + " - received right");
-				var before = this.activeItem;
-				this.activeItem++;
-				if (this.activeItem >= this.newsItems.length) {
-					this.activeItem = 0;
-				}
-				this.config.showDescription = false;
-				this.config.showFullArticle = false;
-				if(!timer){
-					this.scheduleUpdateInterval();
-				}
-				Log.info(this.name + " - going from " + before + " to " + this.activeItem + " (of " + this.newsItems.length + ")");
-				this.updateDom(100);
+		Log.info(this.name + " - received notification: " + notification);
+		if(notification == "ARTICLE_NEXT"){
+			var before = this.activeItem;
+			this.activeItem++;
+			if (this.activeItem >= this.newsItems.length) {
+				this.activeItem = 0;
 			}
-			// actually LEFT, because gesture sensor is built in upside down
-			else if(gesture == "RIGHT"){
-				Log.info(this.name + " - received left");
-				var before = this.activeItem;
-				this.activeItem--;
-				if (this.activeItem < 0) {
-					this.activeItem = this.newsItems.length - 1;
-				}
-				this.config.showDescription = false;
-				this.config.showFullArticle = false;
-				if(!timer){
-					this.scheduleUpdateInterval();
-				}
-				Log.info(this.name + " - going from " + before + " to " + this.activeItem + " (of " + this.newsItems.length + ")");
-				this.updateDom(100);
+			this.config.showDescription = false;
+			this.config.showFullArticle = false;
+			if(!timer){
+				this.scheduleUpdateInterval();
 			}
-			// actually UP, because gesture sensor is built in upside down
-			else if(gesture == "DOWN" && !this.config.showDescription){
-				Log.info(this.name + " - received up");
-				this.config.showDescription = true;
-				this.config.showFullArticle = false;
-				clearInterval(timer);
-				timer = null;
-				this.updateDom(100);
+			Log.info(this.name + " - going from article #" + before + " to #" + this.activeItem + " (of " + this.newsItems.length + ")");
+			this.updateDom(100);
+		} else if(notification == "ARTICLE_PREVIOUS"){
+			var before = this.activeItem;
+			this.activeItem--;
+			if (this.activeItem < 0) {
+				this.activeItem = this.newsItems.length - 1;
 			}
-			// actually DOWN, because gesture sensor is built in upside down
-			else if(gesture == "UP"){
-				Log.info(this.name + " - received down");
-				this.config.showDescription = false;
-				this.config.showFullArticle = false;
-				if(!timer){
-					this.scheduleUpdateInterval();
-				}
-				this.updateDom(100);
+			this.config.showDescription = false;
+			this.config.showFullArticle = false;
+			if(!timer){
+				this.scheduleUpdateInterval();
 			}
-			// actually UP, because gesture sensor is built in upside down
-			else if(gesture == "DOWN" && this.config.showDescription){
-				Log.info(this.name + " - received up again");
-				this.config.showFullArticle = true;
-				this.config.showDescription = false;
-				clearInterval(timer);
-				timer = null;
-				this.updateDom(100);
-			} else {
-				Log.info(this.name + " - received other: " + gesture);
+			Log.info(this.name + " - going from article #" + before + " to #" + this.activeItem + " (of " + this.newsItems.length + ")");
+			this.updateDom(100);
+		}
+		// received "more details" the first time, so showing article summary
+		else if(notification == "ARTICLE_MORE_DETAILS" && !this.config.showDescription){
+			this.config.showDescription = true;
+			this.config.showFullArticle = false;
+			clearInterval(timer);
+			timer = null;
+			Log.info(this.name + " - showing article description");
+			this.updateDom(100);
+		} else if(notification == "ARTICLE_LESS_DETAILS"){
+			this.config.showDescription = false;
+			this.config.showFullArticle = false;
+			if(!timer){
+				this.scheduleUpdateInterval();
 			}
+			Log.info(this.name + " - showing only article titles again");
+			this.updateDom(100);
+		}
+		// received "more details" a second time, so showing full article
+		else if(notification == "ARTICLE_MORE_DETAILS" && this.config.showDescription){
+			this.config.showFullArticle = true;
+			this.config.showDescription = false;
+			clearInterval(timer);
+			timer = null;
+			Log.info(this.name + " - showing full article");
+			this.updateDom(100);
+		} else {
+			Log.info(this.name + " - unknown notification, ignoring: " + notification);
 		}
 	},
-
 
 });

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -291,6 +291,14 @@ Module.register("newsfeed",{
 		return string.charAt(0).toUpperCase() + string.slice(1);
 	},
 
+	resetDescrOrFullArticleAndTimer: function() {
+		this.config.showDescription = false;
+		this.config.showFullArticle = false;
+		if(!timer){
+			this.scheduleUpdateInterval();
+		}
+	},
+
 	notificationReceived: function(notification, payload, sender) {
 		Log.info(this.name + " - received notification: " + notification);
 		if(notification == "ARTICLE_NEXT"){
@@ -299,11 +307,7 @@ Module.register("newsfeed",{
 			if (this.activeItem >= this.newsItems.length) {
 				this.activeItem = 0;
 			}
-			this.config.showDescription = false;
-			this.config.showFullArticle = false;
-			if(!timer){
-				this.scheduleUpdateInterval();
-			}
+			this.resetDescrOrFullArticleAndTimer();
 			Log.info(this.name + " - going from article #" + before + " to #" + this.activeItem + " (of " + this.newsItems.length + ")");
 			this.updateDom(100);
 		} else if(notification == "ARTICLE_PREVIOUS"){
@@ -312,38 +316,21 @@ Module.register("newsfeed",{
 			if (this.activeItem < 0) {
 				this.activeItem = this.newsItems.length - 1;
 			}
-			this.config.showDescription = false;
-			this.config.showFullArticle = false;
-			if(!timer){
-				this.scheduleUpdateInterval();
-			}
+			this.resetDescrOrFullArticleAndTimer();
 			Log.info(this.name + " - going from article #" + before + " to #" + this.activeItem + " (of " + this.newsItems.length + ")");
 			this.updateDom(100);
 		}
-		// received "more details" the first time, so showing article summary
-		else if(notification == "ARTICLE_MORE_DETAILS" && !this.config.showDescription){
-			this.config.showDescription = true;
-			this.config.showFullArticle = false;
+		// if "more details" is received the first time: show article summary, on second time show full article
+		else if(notification == "ARTICLE_MORE_DETAILS"){
+			this.config.showDescription = !this.config.showDescription;
+			this.config.showFullArticle = !this.config.showDescription;
 			clearInterval(timer);
 			timer = null;
-			Log.info(this.name + " - showing article description");
+			Log.info(this.name + " - showing " + this.config.showDescription ? "article description" : "full article");
 			this.updateDom(100);
 		} else if(notification == "ARTICLE_LESS_DETAILS"){
-			this.config.showDescription = false;
-			this.config.showFullArticle = false;
-			if(!timer){
-				this.scheduleUpdateInterval();
-			}
+			this.resetDescrOrFullArticleAndTimer();
 			Log.info(this.name + " - showing only article titles again");
-			this.updateDom(100);
-		}
-		// received "more details" a second time, so showing full article
-		else if(notification == "ARTICLE_MORE_DETAILS" && this.config.showDescription){
-			this.config.showFullArticle = true;
-			this.config.showDescription = false;
-			clearInterval(timer);
-			timer = null;
-			Log.info(this.name + " - showing full article");
 			this.updateDom(100);
 		} else {
 			Log.info(this.name + " - unknown notification, ignoring: " + notification);


### PR DESCRIPTION
Enabled newsfeed default module for gesture events from https://github.com/thobach/MMM-Gestures

The newsfeed can be controlled by gestures now from a gesture sensor (see https://github.com/thobach/MMM-Gestures). This allows to show a news description upon an UP gesture and display the full news article upon another UP gesture. With a DOWN gesture the normal news ticker appears and scrolls through the titles. With a LEFT or RIGHT gesture you can manually scroll through the news titles.

Demo on: http://blog.thomas-bachmann.com/2016/02/magic-mirror-2-0-mit-gestensteuerung.html (German) / https://www.youtube.com/watch?v=V8a6UgeoYOU