### PR TITLE
Remove white flash on boot up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add loaded function to modules, providing an async callback.
 
+### Fixed
+- Remove white flash on boot up
+
 ## [2.1.0] - 2016-12-31
 
 **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`

--- a/js/electron.js
+++ b/js/electron.js
@@ -28,7 +28,8 @@ function createWindow() {
 		webPreferences: {
 			nodeIntegration: false,
 			zoomFactor: config.zoom
-		}
+		},
+		backgroundColor: "#000000"
 	}
 
 	// DEPRECATED: "kioskmode" backwards compatibility, to be removed


### PR DESCRIPTION
When the electron app is started appear a white flash before show the
MagicMirror system.

This patch remove the white flash on boot up.