### PR TITLE
Pass pointer-events on fullscreen overlay to underlaying modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.1.1] - Unreleased
+- Make mouse events pass through the region fullscreen_above to modules below.
 
 ## [2.1.0] - 2016-12-31
 

--- a/css/main.css
+++ b/css/main.css
@@ -135,6 +135,11 @@ sup {
   left: -60px;
   right: -60px;
   bottom: -60px;
+  pointer-events: none;
+}
+
+.region.fullscreen * {
+  pointer-events: auto;
 }
 
 .region.right {


### PR DESCRIPTION
The fullscreen_above overlay prevents mouse actions like _hover_ to be passes to modules.

1. Make fullscreen regions (based on CSS class) not handle mouse events.
2. Make all children in fullscreen regions handle mouse events, to negate any possible side-effects of 1.

Just 1. would fix the issue I was having where my module did not receive _hover_ events. Adding 2. makes sure that modules placed in a fullscreen region still **do** receive their mouse events.