### PR TITLE
Fix gitignore to not ignore default modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ Temporary Items
 
 # Ignore all modules except the default modules.
 /modules/**
+!/modules/default
 !/modules/default/**
 !/modules/README.md**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add loaded function to modules, providing an async callback.
 
+### Fixed
+- Update .gitignore to not ignore default modules folder
+
 ## [2.1.0] - 2016-12-31
 
 **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`


### PR DESCRIPTION
`/modules/**` makes git ignore all directories and files in `/modules`, so it's not even looking in `/modules/default` for changes. `!/modules/default/**` is therefore never used.

By adding the new line `!/modules/default`, git is told to look in the `/modules/default` folder for changes and will find all sub files/dirs and match these on `!/modules/default/**`.
