### PR TITLE
Add `apt-get update` in raspberry.sh script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Update .gitignore to not ignore default modules folder.
 - Remove white flash on boot up.
+- Added `update` in Raspberry Pi installation script.
 
 
 ## [2.1.0] - 2016-12-31

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -38,7 +38,7 @@ function command_exists () { type "$1" &> /dev/null ;}
 
 # Update before first apt-get
 echo -e "\e[96mUpdating packages ...\e[90m"
-sudo apt-get update || exit
+sudo apt-get update || echo -e "\e[91mUpdate failed, carrying on installation ...\e[90m"
 
 # Installing helper tools
 echo -e "\e[96mInstalling helper tools ...\e[90m"

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -36,6 +36,10 @@ fi
 function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
 function command_exists () { type "$1" &> /dev/null ;}
 
+# Update before first apt-get
+echo -e "\e[96mUpdating packages ...\e[90m"
+sudo apt-get update || exit
+
 # Installing helper tools
 echo -e "\e[96mInstalling helper tools ...\e[90m"
 sudo apt-get install curl wget git build-essential unzip || exit


### PR DESCRIPTION
This PR is related to the (closed) #616, but there were some mishandled, my bad. EDIT: Ok, I am useless and a new pull request was indeed not needed. Sorry.

It includes the comments addressed by @roramirez. It basically performs an `apt-get update`prior to any and all `apt-get` operation (to avoid a failure under non up-to-date installations, which can be common).

Disclaimer: the execution of the installer scripts triggers extra `update`s, I don't know if they should be addressed as a whole, or left alone given the modularity of the installation. I was planning to drop the PR, but @roramirez comments made me reconsider it.