### PR TITLE
Replace HTML tables with Markdown tables 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Switched out `rrule` package for `rrule-alt` in order to improve calendar issues. (Experimental: [#565](https://github.com/MichMich/MagicMirror/issues/565))
 - Make mouse events pass through the region fullscreen_above to modules below.
 - Scaled the splash screen down to make it a bit more subtle.
+- Replace HTML tables with markdown tables in README files.
 
 ### Added
 - Add loaded function to modules, providing an async callback.

--- a/modules/default/alert/README.md
+++ b/modules/default/alert/README.md
@@ -21,52 +21,13 @@ modules: [
 The following properties can be configured:
 
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>effect</code></td>
-			<td>The animation effect to use for notifications.<br>
-				<br><b>Possible values:</b> <code>scale</code> <code>slide</code> <code>genie</code> <code>jelly</code> <code>flip</code> <code>exploader</code> <code>bouncyflip</code>
-				<br><b>Default value:</b> <code>slide</code>
-			</td>
-		</tr>
-		<td><code>alert_effect</code></td>
-			<td>The animation effect to use for alerts.<br>
-				<br><b>Possible values:</b> <code>scale</code> <code>slide</code> <code>genie</code> <code>jelly</code> <code>flip</code> <code>exploader</code> <code>bouncyflip</code>
-				<br><b>Default value:</b> <code>jelly</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>display_time</code></td>
-			<td>Time a notification is displayed in milliseconds.<br>
-				<br><b>Possible values:</b> <code>int</code>
-				<br><b>Default value:</b> <code>3500</code>
-			</td>
-		</tr>
-		<tr>
-		<tr>
-			<td><code>position</code></td>
-			<td>Position where the notifications should be displayed.<br>
-				<br><b>Possible values:</b> <code>left</code> <code>center</code> <code>right</code>
-				<br><b>Default value:</b> <code>center</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>welcome_message</code></td>
-			<td>Message shown at startup.<br>
-				<br><b>Possible values:</b> <code>string</code> <code>false</code>
-				<br><b>Default value:</b> <code>false</code> (no message at startup)
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option            | Description
+| ----------------- | -----------
+| `effect`          | The animation effect to use for notifications. <br><br> **Possible values:** `scale` `slide` `genie` `jelly` `flip` `exploader` `bouncyflip` <br> **Default value:** `slide`
+| `alert_effect`    | The animation effect to use for alerts. <br><br> **Possible values:** `scale` `slide` `genie` `jelly` `flip` `exploader` `bouncyflip` <br> **Default value:** `jelly`
+| `display_time`    | Time a notification is displayed in milliseconds. <br><br> **Possible values:** `int` <br> **Default value:** `3500`
+| `position`        | Position where the notifications should be displayed. <br><br> **Possible values:** `left` `center` `right` <br> **Default value:** `center`
+| `welcome_message` | Message shown at startup. <br><br> **Possible values:** `string` `false` <br> **Default value:** `false` (no message at startup)
 
 
 ## Developer notes
@@ -82,83 +43,21 @@ self.sendNotification("SHOW_ALERT", {});
 ```
 
 ### Notification params
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>title</code></td>
-			<td>The title of the notification.<br>
-				<br><b>Possible values:</b> <code>text</code> or <code>html</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>message</code></td>
-			<td>The message of the notification.<br>
-				<br><b>Possible values:</b> <code>text</code> or <code>html</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option    | Description
+| --------- | -----------
+| `title`   | The title of the notification. <br><br> **Possible values:** `text` or `html`
+| `message`	| The message of the notification. <br><br> **Possible values:** `text` or `html`
+
 
 ### Alert params
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>title</code></td>
-			<td>The title of the alert.<br>
-				<br><b>Possible values:</b> <code>text</code> or <code>html</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>message</code></td>
-			<td>The message of the alert.<br>
-				<br><b>Possible values:</b> <code>text</code> or <code>html</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>imageUrl</code> (optional)</td>
-			<td>Image to show in the alert<br>
-				<br><b>Possible values:</b> <code>url</code> <code>path</code>
-				<br><b>Default value:</b> <code>none</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>imageFA</code> (optional)</td>
-			<td>Font Awesome icon to show in the alert<br>
-				<br><b>Possible values:</b> See <a href="http://fontawesome.io/icons/" target="_blank">Font Awsome</a> website.
-				<br><b>Default value:</b> <code>none</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>imageHeight</code> (optional even with imageUrl set)</td>
-			<td>Height of the image<br>
-				<br><b>Possible values:</b> <code>intpx</code>
-				<br><b>Default value:</b> <code>80px</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>timer</code> (optional)</td>
-			<td>How long the alert should stay visible in ms.
-			<br><b>Important:</b> If you do not use the <code>timer</code>, it is your duty to hide the alert by using <code>self.sendNotification("HIDE_ALERT");</code>!<br>
-				<br><b>Possible values:</b> <code>int</code> <code>float</code>
-				<br><b>Default value:</b> <code>none</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option                                          | Description
+| ----------------------------------------------- | -----------
+| `title`                                         | The title of the alert. <br><br> **Possible values:** `text` or `html`
+| `message`                                       | The message of the alert. <br><br> **Possible values:** `text` or `html`
+| `imageUrl` (optional)                           | Image to show in the alert <br><br> **Possible values:** `url` `path` <br> **Default value:** `none`
+| `imageFA` (optional)                            | Font Awesome icon to show in the alert <br><br> **Possible values:** See [Font Awsome](http://fontawesome.io/icons/) website. <br> **Default value:** `none`
+| `imageHeight` (optional even with imageUrl set) | Height of the image <br><br> **Possible values:** `intpx` <br> **Default value:** `80px`
+| `timer` (optional)                              | How long the alert should stay visible in ms. <br> **Important:** If you do not use the `timer`, it is your duty to hide the alert by using `self.sendNotification("HIDE_ALERT");`! <br><br>**Possible values:** `int` `float` <br> **Default value:** `none`
 
 ## Open Source Licenses
 ###[NotificationStyles](https://github.com/codrops/NotificationStyles)

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -24,152 +24,26 @@ modules: [
 The following properties can be configured:
 
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>maximumEntries</code></td>
-			<td>The maximum number of events shown.<br>
-				<br><b>Possible values:</b> <code>0</code> - <code>100</code>
-				<br><b>Default value:</b> <code>10</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>maximumNumberOfDays</code></td>
-			<td>The maximum number of days in the future.<br>
-				<br><b>Default value:</b> <code>365</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>displaySymbol</code></td>
-			<td>Display a symbol in front of an entry.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>defaultSymbol</code></td>
-			<td>The default symbol.<br>
-				<br><b>Possible values:</b> See <a href="http://fontawesome.io/icons/" target="_blank">Font Awsome</a> website.
-				<br><b>Default value:</b> <code>calendar</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>maxTitleLength</code></td>
-			<td>The maximum title length.<br>
-				<br><b>Possible values:</b> <code>10</code> - <code>50</code>
-				<br><b>Default value:</b> <code>25</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>fetchInterval</code></td>
-			<td>How often does the content needs to be fetched? (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>
-				<br><b>Default value:</b> <code>300000</code> (5 minutes)
-			</td>
-		</tr>
-		<tr>
-			<td><code>animationSpeed</code></td>
-			<td>Speed of the update animation. (Milliseconds)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>2000</code> (2 seconds)
-			</td>
-		</tr>
-		<tr>
-			<td><code>fade</code></td>
-			<td>Fade the future events to black. (Gradient)<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>fadePoint</code></td>
-			<td>Where to start fade?<br>
-				<br><b>Possible values:</b> <code>0</code> (top of the list) - <code>1</code> (bottom of list)
-				<br><b>Default value:</b> <code>0.25</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>calendars</code></td>
-			<td>The list of calendars.<br>
-				<br><b>Possible values:</b> An array, see <i>calendar configuration</i> below.
-				<br><b>Default value:</b> <i>An example calendar.</i>
-			</td>
-		</tr>
-		<tr>
-			<td><code>titleReplace</code></td>
-			<td>An object of textual replacements applied to the tile of the event. This allow to remove or replace certains words in the title.<br>
-				<br><b>Example:</b> <br>
-				<code>
-					titleReplace: {'Birthday of ' : '', 'foo':'bar'}
-				</code>
-				<br><b>Default value:</b>
-				<code>
-				{
-					"De verjaardag van ": "",
-					"'s birthday": ""
-				}
-				</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>displayRepeatingCountTitle</code></td>
-			<td>Show count title for yearly repeating events (e.g. "X. Birthday", "X. Anniversary")<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>dateFormat</code></td>
-			<td>Format to use for the date of events (when using absolute dates)<br>
-				<br><b>Possible values:</b> See <a href="http://momentjs.com/docs/#/parsing/string-format/">Moment.js formats</a>
-				<br><b>Default value:</b> <code>MMM Do</code> (e.g. Jan 18th)
-			</td>
-		</tr>
-		<tr>
-			<td><code>timeFormat</code></td>
-			<td>Display event times as absolute dates, or relative time<br>
-				<br><b>Possible values:</b> <code>absolute</code> or <code>relative</code>
-				<br><b>Default value:</b> <code>relative</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>getRelative</code></td>
-			<td>How much time (in hours) should be left until calendar events start getting relative?<br>
-				<br><b>Possible values:</b> <code>0</code> (events stay absolute) - <code>48</code> (48 hours before the event starts)
-				<br><b>Default value:</b> <code>6</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>urgency</code></td>
-			<td>When using a timeFormat of <code>absolute</code>, the <code>urgency</code> setting allows you to display events within a specific time frame as <code>relative</code>
-			    This allows events within a certain time frame to be displayed as relative (in xx days) while others are displayed as absolute dates<br>
-				<br><b>Possible values:</b> a positive integer representing the number of days for which you want a relative date, for example <code>7</code> (for 7 days)<br>
-				<br><b>Default value:</b> <code>7</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>broadcastEvents</code></td>
-			<td>If this property is set to true, the calendar will broadcast all the events to all other modules with the notification message: <code>CALENDAR_EVENTS</code>. The event objects are stored in an array and contain the following fields: <code>title</code>, <code>startDate</code>, <code>endDate</code>, <code>fullDayEvent</code>, <code>location</code> and <code>geo</code>.<br>
-				<br><b>Possible values:</b> <code>true</code>, <code>false</code>  <br>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>hidePrivate</code></td>
-			<td>Hides private calendar events.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option                       | Description
+| ---------------------------- | -----------
+| `maximumEntries`             | The maximum number of events shown. / **Possible values:** `0` - `100` <br> **Default value:** `10`
+| `maximumNumberOfDays`        | The maximum number of days in the future. <br><br> **Default value:** `365`
+| `displaySymbol`              | Display a symbol in front of an entry. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `defaultSymbol`              | The default symbol. <br><br> **Possible values:** See [Font Awsome](http://fontawesome.io/icons/) website. <br> **Default value:** `calendar`
+| `maxTitleLength`             | The maximum title length. <br><br> **Possible values:** `10` - `50` <br> **Default value:** `25`
+| `fetchInterval`              | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `300000` (5 minutes)
+| `animationSpeed`             | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `2000` (2 seconds)
+| `fade`                       | Fade the future events to black. (Gradient) <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `fadePoint`                  | Where to start fade? <br><br> **Possible values:** `0` (top of the list) - `1` (bottom of list) <br> **Default value:** `0.25`
+| `calendars`                  | The list of calendars. <br><br> **Possible values:** An array, see _calendar configuration_ below. <br> **Default value:** _An example calendar._
+| `titleReplace`               | An object of textual replacements applied to the tile of the event. This allow to remove or replace certains words in the title. <br><br> **Example:** `{'Birthday of ' : '', 'foo':'bar'}` <br> **Default value:** `{	"De verjaardag van ": "", "'s birthday": ""	}`
+| `displayRepeatingCountTitle` | Show count title for yearly repeating events (e.g. "X. Birthday", "X. Anniversary") <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `dateFormat`                 | Format to use for the date of events (when using absolute dates) <br><br> **Possible values:** See [Moment.js formats](http://momentjs.com/docs/#/parsing/string-format/) <br> **Default value:** `MMM Do` (e.g. Jan 18th)
+| `timeFormat`                 | Display event times as absolute dates, or relative time <br><br> **Possible values:** `absolute` or `relative` <br> **Default value:** `relative`
+| `getRelative`                | How much time (in hours) should be left until calendar events start getting relative? <br><br> **Possible values:** `0` (events stay absolute) - `48` (48 hours before the event starts) <br> **Default value:** `6`
+| `urgency`                    | When using a timeFormat of `absolute`, the `urgency` setting allows you to display events within a specific time frame as `relative`. This allows events within a certain time frame to be displayed as relative (in xx days) while others are displayed as absolute dates <br><br> **Possible values:** a positive integer representing the number of days for which you want a relative date, for example `7` (for 7 days) <br><br> **Default value:** `7`
+| `broadcastEvents`            | If this property is set to true, the calendar will broadcast all the events to all other modules with the notification message: `CALENDAR_EVENTS`. The event objects are stored in an array and contain the following fields: `title`, `startDate`, `endDate`, `fullDayEvent`, `location` and `geo`. <br><br> **Possible values:** `true`, `false` <br><br> **Default value:** `true`
+| `hidePrivate`                | Hides private calendar events. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 
 ### Calendar configuration
 
@@ -189,41 +63,10 @@ config: {
 
 
 #### Calendar configuration options:
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>url</code></td>
-			<td>The url of the calendar .ical. This property is required.<br>
-				<br><b>Possible values:</b> Any public accessble .ical calendar.
-			</td>
-		</tr>
-		<tr>
-			<td><code>symbol</code></td>
-			<td>The symbol to show in front of an event. This property is optional.<br>
-				<br><b>Possible values:</b> See <a href="http://fontawesome.io/icons/" target="_blank">Font Awesome</a> website.
-			</td>
-		</tr>
-		<tr>
-			<td><code>repeatingCountTitle</code></td>
-			<td>The count title for yearly repating events in this calendar. <br>
-				<br><b>Example:</b> <br>
-				<code>'Birthday'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>user</code></td>
-			<td>The username for HTTP Basic authentication.</td>
-		</tr>
-		<tr>
-			<td><code>pass</code></td>
-			<td>The password for HTTP Basic authentication.</td>
-		</tr>
-		</tbody>
-</table>
+| Option                | Description
+| --------------------- | -----------
+| `url`	                | The url of the calendar .ical. This property is required. <br><br> **Possible values:** Any public accessble .ical calendar.
+| `symbol`              | The symbol to show in front of an event. This property is optional. <br><br> **Possible values:** See [Font Awesome](http://fontawesome.io/icons/) website.
+| `repeatingCountTitle`	| The count title for yearly repating events in this calendar.  <br><br> **Example:** `'Birthday'`
+| `user`                | The username for HTTP Basic authentication.
+| `pass`                | The password for HTTP Basic authentication.

--- a/modules/default/clock/README.md
+++ b/modules/default/clock/README.md
@@ -22,106 +22,18 @@ modules: [
 
 The following properties can be configured:
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>timeFormat</code></td>
-			<td>Use 12 or 24 hour format.<br>
-				<br><b>Possible values:</b> <code>12</code> or <code>24</code>
-				<br><b>Default value:</b> uses value of <i>config.timeFormat</i>
-			</td>
-		</tr>
-		<tr>
-			<td><code>displaySeconds</code></td>
-			<td>Display seconds.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showPeriod</code></td>
-			<td>Show the period (am/pm) with 12 hour format.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showPeriodUpper</code></td>
-			<td>Show the period (AM/PM) with 12 hour format as uppercase.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>clockBold</code></td>
-			<td>Remove the colon and bold the minutes to make a more modern look.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showDate</code></td>
-			<td>Turn off or on the Date section.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>displayType</code></td>
-			<td>Display a digital clock, analog clock, or both together.<br>
-				<br><b>Possible values:</b> <code>digital</code>, <code>analog</code>, or <code>both</code>
-				<br><b>Default value:</b> <code>digital</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>analogSize</code></td>
-			<td><strong>Specific to the analog clock.</strong> Defines how large the analog display is.<br>
-				<br><b>Possible values:</b> A positive number of pixels</code>
-				<br><b>Default value:</b> <code>200px</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>analogFace</code></td>
-			<td><strong>Specific to the analog clock.</strong> Specifies which clock face to use.<br>
-				<br><b>Possible values:</b> <code>simple</code> for a simple border, <code>none</code> for no face or border, or <code>face-###</code> (where ### is currently a value between 001 and 012, inclusive)
-				<br><b>Default value:</b> <code>simple</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>secondsColor</code></td>
-			<td><strong>Specific to the analog clock.</strong> Specifies what color to make the 'seconds' hand.<br>
-				<br><b>Possible values:</b> <code>any HTML RGB Color</code>
-				<br><b>Default value:</b> <code>#888888</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>analogPlacement</code></td>
-			<td><strong>Specific to the analog clock. <em>(requires displayType set to <code>'both'</code>)</em></strong> Specifies where the analog clock is in relation to the digital clock<br>
-				<br><b>Possible values:</b> <code>top</code>, <code>right</code>, <code>bottom</code>, or <code>left</code>
-				<br><b>Default value:</b> <code>bottom</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>analogShowDate</code></td>
-			<td><strong>Specific to the analog clock.</strong> If the clock is used as a separate module and set to analog only, this configures whether a date is also displayed with the clock.<br>
-				<br><b>Possible values:</b> <code>false</code>, <code>top</code>, or <code>bottom</code>
-				<br><b>Default value:</b> <code>top</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>timezone</code></td>
-			<td>Specific a timezone to show clock.<br>
-				<br><b>Possible examples values:</b> <code>America/New_York</code>, <code>America/Santiago</code>, <code>Etc/GMT+10</code>
-				<br><b>Default value:</b> <code>none</code>
-			</td>
-		</tr>
-
-	</tbody>
-</table>
+| Option            | Description
+| ----------------- | -----------
+| `timeFormat`      | Use 12 or 24 hour format. <br><br> **Possible values:** `12` or `24` <br> **Default value:** uses value of _config.timeFormat_
+| `displaySeconds`  | Display seconds. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showPeriod`      | Show the period (am/pm) with 12 hour format. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showPeriodUpper` | Show the period (AM/PM) with 12 hour format as uppercase. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `clockBold`       | Remove the colon and bold the minutes to make a more modern look. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `showDate`        | Turn off or on the Date section. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `displayType`     | Display a digital clock, analog clock, or both together. <br><br> **Possible values:** `digital`, `analog`, or `both` <br> **Default value:** `digital`
+| `analogSize`      | **Specific to the analog clock.** Defines how large the analog display is. <br><br> **Possible values:** A positive number of pixels` <br> **Default value:** `200px`
+| `analogFace`      | **Specific to the analog clock.** Specifies which clock face to use. <br><br> **Possible values:** `simple` for a simple border, `none` for no face or border, or `face-###` (where ### is currently a value between 001 and 012, inclusive) <br> **Default value:** `simple`
+| `secondsColor`    | **Specific to the analog clock.** Specifies what color to make the 'seconds' hand. <br><br> **Possible values:** `any HTML RGB Color` <br> **Default value:** `#888888`
+| `analogPlacement` | **Specific to the analog clock. _(requires displayType set to `'both'`)_** Specifies where the analog clock is in relation to the digital clock <br><br> **Possible values:** `top`, `right`, `bottom`, or `left` <br> **Default value:** `bottom`
+| `analogShowDate`  | **Specific to the analog clock.** If the clock is used as a separate module and set to analog only, this configures whether a date is also displayed with the clock. <br><br> **Possible values:** `false`, `top`, or `bottom` <br> **Default value:** `top`
+| `timezone`        | Specific a timezone to show clock. <br><br> **Possible examples values:** `America/New_York`, `America/Santiago`, `Etc/GMT+10` <br> **Default value:** `none`

--- a/modules/default/compliments/README.md
+++ b/modules/default/compliments/README.md
@@ -25,48 +25,12 @@ modules: [
 The following properties can be configured:
 
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-
-		<tr>
-			<td><code>updateInterval</code></td>
-			<td>How often does the compliment have to change? (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>
-				<br><b>Default value:</b> <code>30000</code> (30 seconds)
-			</td>
-		</tr>
-		<tr>
-			<td><code>fadeSpeed</code></td>
-			<td>Speed of the update animation. (Milliseconds)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>4000</code> (4 seconds)
-			</td>
-		</tr>
-		<tr>
-			<td><code>compliments</code></td>
-			<td>The list of compliments.<br>
-				<br><b>Possible values:</b> An object with three arrays: <code>morning</code>, <code>afternoon</code> and<code>evening</code>. See <i>compliment configuration</i> below.
-				<br><b>Default value:</b> See <i>compliment configuration</i> below.
-			</td>
-		</tr>
-		<tr>
-			<td><code>remoteFile</code></td>
-			<td>External file from which to load the compliments<br>
-				<br><b>Possible values:</b>Path to a JSON file containing compliments, configured
-				as per the value of the <i>compliments configuration</i> (see below). An object with three arrays:
-				morning, afternoon and evening. - <code>compliments.json</code>
-				<br><b>Default value:</b> <code>null</code> (Do not load from file)
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option           | Description
+| ---------------- | -----------
+| `updateInterval` | How often does the compliment have to change? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `30000` (30 seconds)
+| `fadeSpeed`      | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `4000` (4 seconds)
+| `compliments`	   | The list of compliments. <br><br> **Possible values:** An object with three arrays: `morning`, `afternoon` and`evening`. See _compliment configuration_ below. <br> **Default value:** See _compliment configuration_ below.
+| `remoteFile`     | External file from which to load the compliments <br><br> **Possible values:** Path to a JSON file containing compliments, configured as per the value of the _compliments configuration_ (see below). An object with three arrays: `morning`, `afternoon` and `evening`. - `compliments.json` <br> **Default value:** `null` (Do not load from file)
 
 ### Compliment configuration
 
@@ -74,22 +38,22 @@ The `compliments` property contains an object with three arrays: <code>morning</
 
 
 If use the currentweather is possible use a actual weather for set compliments. The availables properties are:
-* <code>day_sunny</code>
-* <code>day_cloudy</code>
-* <code>cloudy</code>
-* <code>cloudy_windy</code>
-* <code>showers</code>
-* <code>rain</code>
-* <code>thunderstorm</code>
-* <code>snow</code>
-* <code>fog</code>
-* <code>night_clear</code>
-* <code>night_cloudy</code>
-* <code>night_showers</code>
-* <code>night_rain</code>
-* <code>night_thunderstorm</code>
-* <code>night_snow</code>
-* <code>night_alt_cloudy_windy</code>
+* `day_sunny`
+* `day_cloudy`
+* `cloudy`
+* `cloudy_windy`
+* `showers`
+* `rain`
+* `thunderstorm`
+* `snow`
+* `fog`
+* `night_clear`
+* `night_cloudy`
+* `night_showers`
+* `night_rain`
+* `night_thunderstorm`
+* `night_snow`
+* `night_alt_cloudy_windy`
 
 #### Example use with currentweather module
 ````javascript

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -26,189 +26,52 @@ modules: [
 The following properties can be configured:
 
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>location</code></td>
-			<td>The location used for weather information.<br>
-				<br><b>Example:</b> <code>'Amsterdam,Netherlands'</code>
-				<br><b>Default value:</b> <code>false</code><br><br>
-				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
-			</td>
-		</tr>
-		<tr>
-			<td><code>locationID</code></td>
-			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
-				<br><b>Example:</b> <code>1234567</code>
-				<br><b>Default value:</b> <code>false</code><br><br>
-				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
-			</td>
-		</tr>
-		<tr>
-			<td><code>appid</code></td>
-			<td>The <a href="https://home.openweathermap.org" target="_blank">OpenWeatherMap</a> API key, which can be obtained by creating an OpenWeatherMap account.<br>
-				<br> This value is <b>REQUIRED</b>
-			</td>
-		</tr>
-		<tr>
-			<td><code>units</code></td>
-			<td>What units to use. Specified by config.js<br>
-				<br><b>Possible values:</b> <code>config.units</code> = Specified by config.js, <code>default</code> = Kelvin, <code>metric</code> = Celsius, <code>imperial</code> =Fahrenheit
-				<br><b>Default value:</b> <code>config.units</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>roundTemp</code></td>
-			<td>Round temperature value to nearest integer.<br>
-				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>updateInterval</code></td>
-			<td>How often does the content needs to be fetched? (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>
-				<br><b>Default value:</b> <code>600000</code> (10 minutes)
-			</td>
-		</tr>
-		<tr>
-			<td><code>animationSpeed</code></td>
-			<td>Speed of the update animation. (Milliseconds)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>1000</code> (1 second)
-			</td>
-		</tr>
-		<tr>
-			<td><code>timeFormat</code></td>
-			<td>Use 12 or 24 hour format.<br>
-				<br><b>Possible values:</b> <code>12</code> or <code>24</code>
-				<br><b>Default value:</b> uses value of <i>config.timeFormat</i>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showPeriod</code></td>
-			<td>Show the period (am/pm) with 12 hour format<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showPeriodUpper</code></td>
-			<td>Show the period (AM/PM) with 12 hour format as uppercase<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showWindDirection</code></td>
-			<td>Show the wind direction next to the wind speed.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showHumidity</code></td>
-			<td>Show the current humidity<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>onlyTemp</code></td>
-			<td>Show only current Temperature and weather icon.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>useBeaufort</code></td>
-			<td>Pick between using the Beaufort scale for wind speed or using the default units.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>lang</code></td>
-			<td>The language of the days.<br>
-				<br><b>Possible values:</b> <code>en</code>, <code>nl</code>, <code>ru</code>, etc ...
-				<br><b>Default value:</b> uses value of <i>config.language</i>
-			</td>
-		</tr>
-		<tr>
-			<td><code>initialLoadDelay</code></td>
-			<td>The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>5000</code>
-				<br><b>Default value:</b>  <code>0</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>retryDelay</code></td>
-			<td>The delay before retrying after a request failure. (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>60000</code>
-				<br><b>Default value:</b>  <code>2500</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>apiVersion</code></td>
-			<td>The OpenWeatherMap API version to use.<br>
-				<br><b>Default value:</b>  <code>2.5</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>apiBase</code></td>
-			<td>The OpenWeatherMap base URL.<br>
-				<br><b>Default value:</b>  <code>'http://api.openweathermap.org/data/'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>weatherEndpoint</code></td>
-			<td>The OpenWeatherMap API endPoint.<br>
-				<br><b>Default value:</b>  <code>'weather'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>appendLocationNameToHeader</code></td>
-			<td>If set to <code>true</code>, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly intresting when using calender based weather.<br>
-				<br><b>Default value:</b>  <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>calendarClass</code></td>
-			<td>The class for the calender module to base the event based weather information on.<br>
-				<br><b>Default value:</b>  <code>'calendar'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>iconTable</code></td>
-			<td>The conversion table to convert the weather conditions to weather-icons.<br>
-				<br><b>Default value:</b>  <code>iconTable: {
-			'01d':'wi-day-sunny',
-			'02d':'wi-day-cloudy',
-			'03d':'wi-cloudy',
-			'04d':'wi-cloudy-windy',
-			'09d':'wi-showers',
-			'10d':'wi-rain',
-			'11d':'wi-thunderstorm',
-			'13d':'wi-snow',
-			'50d':'wi-fog',
-			'01n':'wi-night-clear',
-			'02n':'wi-night-cloudy',
-			'03n':'wi-night-cloudy',
-			'04n':'wi-night-cloudy',
-			'09n':'wi-night-showers',
-			'10n':'wi-night-rain',
-			'11n':'wi-night-thunderstorm',
-			'13n':'wi-night-snow',
-			'50n':'wi-night-alt-cloudy-windy'
-		}</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option                       | Description
+| ---------------------------- | -----------
+| `location`                   | The location used for weather information. <br><br> **Example:** `'Amsterdam,Netherlands'` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
+| `locationID`                 | Location ID from [OpenWeatherMap](http://openweathermap.org/help/city_list.txt) **This will override anything you put in location.** <br> Leave blank if you want to use location. <br> **Example:** `1234567` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
+| `appid`                      | The [OpenWeatherMap](https://home.openweathermap.org) API key, which can be obtained by creating an OpenWeatherMap account. <br><br>  This value is **REQUIRED**
+| `units`                      | What units to use. Specified by config.js <br><br> **Possible values:** `config.units` = Specified by config.js, `default` = Kelvin, `metric` = Celsius, `imperial` =Fahrenheit <br> **Default value:** `config.units`
+| `roundTemp`                  | Round temperature value to nearest integer. <br><br> **Possible values:** `true` (round to integer) or `false` (display exact value with decimal point) <br> **Default value:** `false`
+| `updateInterval`             | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `600000` (10 minutes)
+| `animationSpeed`             | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)
+| `timeFormat`                 | Use 12 or 24 hour format. <br><br> **Possible values:** `12` or `24` <br> **Default value:** uses value of _config.timeFormat_
+| `showPeriod`                 | Show the period (am/pm) with 12 hour format <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showPeriodUpper`	           | Show the period (AM/PM) with 12 hour format as uppercase <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `showWindDirection`          | Show the wind direction next to the wind speed. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showHumidity`               | Show the current humidity <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `onlyTemp`                   | Show only current Temperature and weather icon. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `useBeaufort`                | Pick between using the Beaufort scale for wind speed or using the default units. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `lang`                       | The language of the days. <br><br> **Possible values:** `en`, `nl`, `ru`, etc ... <br> **Default value:** uses value of _config.language_
+| `initialLoadDelay`           | The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds) <br><br> **Possible values:** `1000` - `5000` <br> **Default value:**  `0`
+| `retryDelay`                 | The delay before retrying after a request failure. (Milliseconds) <br><br> **Possible values:** `1000` - `60000` <br> **Default value:**  `2500`
+| `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
+| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
+| `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'weather'`
+| `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly intresting when using calender based weather. <br><br> **Default value:**  `true`
+| `calendarClass`              | The class for the calender module to base the event based weather information on. <br><br> **Default value:**  `'calendar'`
+| `iconTable`                  | The conversion table to convert the weather conditions to weather-icons. <br><br> **Default value:**  view tabel below.
+
+#### Default Icon Table
+````javascript
+iconTable: {
+	'01d': 'wi-day-sunny',
+	'02d': 'wi-day-cloudy',
+	'03d': 'wi-cloudy',
+	'04d': 'wi-cloudy-windy',
+	'09d': 'wi-showers',
+	'10d': 'wi-rain',
+	'11d': 'wi-thunderstorm',
+	'13d': 'wi-snow',
+	'50d': 'wi-fog',
+	'01n': 'wi-night-clear',
+	'02n': 'wi-night-cloudy',
+	'03n': 'wi-night-cloudy',
+	'04n': 'wi-night-cloudy',
+	'09n': 'wi-night-showers',
+	'10n': 'wi-night-rain',
+	'11n': 'wi-night-thunderstorm',
+	'13n': 'wi-night-snow',
+	'50n': 'wi-night-alt-cloudy-windy'
+}
+````

--- a/modules/default/helloworld/README.md
+++ b/modules/default/helloworld/README.md
@@ -20,23 +20,6 @@ modules: [
 
 The following properties can be configured:
 
-
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-
-		<tr>
-			<td><code>text</code></td>
-			<td>The text to display.<br>
-				<br><b>Example:</b> <code>'Hello world!'</code>
-				<br><b>Default value:</b> <code>'Hello world!'</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option | Description
+| ------ | -----------
+| `text` | The text to display. <br><br> **Example:** `'Hello world!'` <br> **Default value:** `'Hello world!'`

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -33,37 +33,14 @@ modules: [
 
 ### Notifications
 #### Interacting with the module
-MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/tree/master/modules#thissendnotificationnotification-payload) allows to send notifications to the ````newsfeed```` module. The following notifications are supported:
+MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/tree/master/modules#thissendnotificationnotification-payload) allows to send notifications to the `newsfeed` module. The following notifications are supported:
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Notification Identifier</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>ARTICLE_NEXT</code></td>
-			<td>Shows the next news title (hiding the summary or previously fully displayed article)</td>
-		</tr>
-		<tr>
-			<td><code>ARTICLE_PREVIOUS</code></td>
-			<td>Shows the previous news title (hiding the summary or previously fully displayed article)</td>
-		</tr>
-		<tr>
-			<td><code>ARTICLE_MORE_DETAILS</code></td>
-			<td><p>When received the *first time*, shows the corresponding description of the currently displayed news title.<br />The module expects that the module's configuration option ````showDescription```` is set to ````false```` (default value).</p>
-			When received a *second consecutive time*, shows the full news article in an IFRAME.<br />
-			This requires that the news page can be embedded in an IFRAME, e.g. doesn't have the HTTP response header [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) set to e.g. ````DENY````.</td>
-		</tr>
-		<tr>
-			<td><code>ARTICLE_LESS_DETAILS</code></td>
-			<td>Hides the summary or full news article and only displays the news title of the currently viewed news item.</td>
-		</tr>
-	</tbody>
-</table>
+| Notification Identifier | Description
+| ----------------------- | -----------
+| `ARTICLE_NEXT`          | Shows the next news title (hiding the summary or previously fully displayed article)
+| `ARTICLE_PREVIOUS`      | Shows the previous news title (hiding the summary or previously fully displayed article)
+| `ARTICLE_MORE_DETAILS`  | When received the _first time_, shows the corresponding description of the currently displayed news title. <br> The module expects that the module's configuration option `showDescription` is set to `false` (default value). <br><br> When received a _second consecutive time_, shows the full news article in an IFRAME. <br> This requires that the news page can be embedded in an IFRAME, e.g. doesn't have the HTTP response header [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) set to e.g. `DENY`.
+| `ARTICLE_LESS_DETAILS`  | Hides the summary or full news article and only displays the news title of the currently viewed news item.
 
 Note the payload of the sent notification event is ignored.
 
@@ -73,155 +50,32 @@ The following example shows how the next news article title can be displayed on 
 this.sendNotification('ARTICLE_NEXT');
 ````
 
-#### ````newsfeed```` specific notification emitting modules
+#### `newsfeed` specific notification emitting modules
 The third party [MMM-Gestures](https://github.com/thobach/MMM-Gestures) module supports above notifications when moving your hand up, down, left or right in front of a gesture sensor attached to the MagicMirror. See module's readme for more details.
 
 ## Configuration options
 
 The following properties can be configured:
 
-
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-
-		<tr>
-			<td><code>feeds</code></td>
-			<td>An array of feed urls that will be used as source.<br>
-				More info about this object can be found below.
-				<br><b>Default value:</b> <code>[
-					{
-						title: "New York Times",
-						url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-						encoding: "UTF-8"
-					}
-				]</code>
-			</td>
-		</tr>
-
-		<tr>
-			<td><code>showSourceTitle</code></td>
-			<td>Display the title of the source.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showPublishDate</code></td>
-			<td>Display the publish date of an headline.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>showDescription</code></td>
-			<td>Display the description of an item.<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-
-		<tr>
-			<td><code>reloadInterval</code></td>
-			<td>How often does the content needs to be fetched? (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>
-				<br><b>Default value:</b> <code>300000</code> (5 minutes)
-			</td>
-		</tr>
-		<tr>
-			<td><code>updateInterval</code></td>
-			<td>How often do you want to display a new headline? (Milliseconds)<br>
-				<br><b>Possible values:</b><code>1000</code> - <code>60000</code>
-				<br><b>Default value:</b> <code>10000</code> (10 seconds)
-			</td>
-		</tr>
-		<tr>
-			<td><code>animationSpeed</code></td>
-			<td>Speed of the update animation. (Milliseconds)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>2500</code> (2.5 seconds)
-			</td>
-		</tr>
-		<tr>
-			<td><code>maxNewsItems</code></td>
-			<td>Total amount of news items to cycle through. (0 for unlimited)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>...</code>
-				<br><b>Default value:</b> <code>0</code>
-			</td>
-		</tr>
-			removeStartTags: false,
-		removeEndTags: false,
-		startTags: [],
-		endTags: []
-
-
-		<tr>
-			<td><code>removeStartTags</code></td>
-			<td>Some newsfeeds feature tags at the <B>beginning</B> of their titles or descriptions, such as <em>[VIDEO]</em>.
-			This setting allows for the removal of specified tags from the beginning of an item's description and/or title.<br>
-				<br><b>Possible values:</b><code>'title'</code>, <code>'description'</code>, <code>'both'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>startTags</code></td>
-			<td>List the tags you would like to have removed at the beginning of the feed item<br>
-				<br><b>Possible values:</b> <code>['TAG']</code> or <code>['TAG1','TAG2',...]</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>removeEndTags</code></td>
-			<td>Remove specified tags from the <B>end</B> of an item's description and/or title.<br>
-				<br><b>Possible values:</b><code>'title'</code>, <code>'description'</code>, <code>'both'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>endTags</code></td>
-			<td>List the tags you would like to have removed at the end of the feed item<br>
-				<br><b>Possible values:</b> <code>['TAG']</code> or <code>['TAG1','TAG2',...]</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option            | Description
+| ----------------- | -----------
+| `feeds`           | An array of feed urls that will be used as source. <br> More info about this object can be found below. <br> **Default value:** `[{ title: "New York Times", url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml", encoding: "UTF-8" }]`
+| `showSourceTitle` | Display the title of the source. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showPublishDate` | Display the publish date of an headline. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showDescription` | Display the description of an item. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `reloadInterval`  | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `300000` (5 minutes)
+| `updateInterval`  | How often do you want to display a new headline? (Milliseconds) <br><br> **Possible values:**`1000` - `60000` <br> **Default value:** `10000` (10 seconds)
+| `animationSpeed`  | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `2500` (2.5 seconds)
+| `maxNewsItems`    | Total amount of news items to cycle through. (0 for unlimited) <br><br> **Possible values:**`0` - `...` <br> **Default value:** `0`
+| `removeStartTags` | Some newsfeeds feature tags at the **beginning** of their titles or descriptions, such as _[VIDEO]_. This setting allows for the removal of specified tags from the beginning of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
+| `startTags`       | List the tags you would like to have removed at the beginning of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
+| `removeEndTags`   | Remove specified tags from the **end** of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
+| `endTags`         | List the tags you would like to have removed at the end of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
 
 The `feeds` property contains an array with multiple objects. These objects have the following properties:
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-
-		<tr>
-			<td><code>title</code></td>
-			<td>The name of the feed source to be displayed above the news items.<br>
-				<br>This property is optional.
-			</td>
-		</tr>
-
-		<tr>
-			<td><code>url</code></td>
-			<td>The url of the feed used for the headlines.<br>
-				<br><b>Example:</b> <code>'http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>encoding</code></td>
-			<td>The encoding of the news feed.<br>
-				<br>This property is optional.
-				<br><b>Possible values:</b><code>'UTF-8'</code>, <code>'ISO-8859-1'</code>, etc ...
-				<br><b>Default value:</b> <code>'UTF-8'</code>
-			</td>
-		</tr>
-
-	</tbody>
-</table>
+| Option     | Description
+| ---------- | -----------
+| `title`    | The name of the feed source to be displayed above the news items. <br><br> This property is optional.
+| `url`      | The url of the feed used for the headlines. <br><br> **Example:** `'http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml'`
+| `encoding` | The encoding of the news feed. <br><br> This property is optional. <br> **Possible values:**`'UTF-8'`, `'ISO-8859-1'`, etc ... <br> **Default value:** `'UTF-8'`

--- a/modules/default/updatenotification/README.md
+++ b/modules/default/updatenotification/README.md
@@ -22,21 +22,6 @@ modules: [
 
 The following properties can be configured:
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>updateInterval</code></td>
-			<td>How often do you want to check for a new version? This value represents the interval in milliseconds.<br>
-				<br><b>Possible values:</b> Any value above <code>60000</code> (1 minute);
-				<br><b>Default value:</b> <code>600000</code> (10 minutes);
-			</td>
-		</tr>
-	</tbody>
-</table>
+| Option           | Description
+| ---------------- | -----------
+| `updateInterval` | How often do you want to check for a new version? This value represents the interval in milliseconds. <br><br> **Possible values:** Any value above `60000` (1 minute) <br> **Default value:** `600000` (10 minutes);

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -25,171 +25,49 @@ modules: [
 
 The following properties can be configured:
 
+| Option                       | Description
+| ---------------------------- | -----------
+| `location`                   | The location used for weather information. <br><br> **Example:** `'Amsterdam,Netherlands'` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
+| `locationID`                 | Location ID from [OpenWeatherMap](http://openweathermap.org/help/city_list.txt) **This will override anything you put in location.** <br> Leave blank if you want to use location. <br> **Example:** `1234567` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
+| `appid`                      | The [OpenWeatherMap](https://home.openweathermap.org) API key, which can be obtained by creating an OpenWeatherMap account. <br><br> This value is **REQUIRED**
+| `units`                      | What units to use. Specified by config.js <br><br> **Possible values:** `config.units` = Specified by config.js, `default` = Kelvin, `metric` = Celsius, `imperial` =Fahrenheit <br> **Default value:** `config.units`
+| `roundTemp`                  | Round temperature values to nearest integer. <br><br> **Possible values:** `true` (round to integer) or `false` (display exact value with decimal point) <br> **Default value:** `false`
+| `maxNumberOfDays`            | How many days of forecast to return. Specified by config.js <br><br> **Possible values:** `1` - `16` <br> **Default value:** `7` (7 days) <br> This value is optional. By default the weatherforecast module will return 7 days.
+| `showRainAmount`             | Should the predicted rain amount be displayed? <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false` <br> This value is optional. By default the weatherforecast module will not display the predicted amount of rain.
+| `updateInterval`             | How often does the content needs to be fetched? (Milliseconds) <br><br> **Possible values:** `1000` - `86400000` <br> **Default value:** `600000` (10 minutes)
+| `animationSpeed`             | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `1000` (1 second)
+| `lang`                       | The language of the days. <br><br> **Possible values:** `en`, `nl`, `ru`, etc ... <br> **Default value:** uses value of _config.language_
+| `fade`                       | Fade the future events to black. (Gradient) <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `fadePoint`                  | Where to start fade? <br><br> **Possible values:** `0` (top of the list) - `1` (bottom of list) <br> **Default value:** `0.25`
+| `initialLoadDelay`           | The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds) <br><br> **Possible values:** `1000` - `5000` <br> **Default value:**  `2500` (2.5 seconds delay. This delay is used to keep the OpenWeather API happy.)
+| `retryDelay`                 | The delay before retrying after a request failure. (Milliseconds) <br><br> **Possible values:** `1000` - `60000` <br> **Default value:**  `2500`
+| `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
+| `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
+| `forecastEndpoint`           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'forecast/daily'`
+| `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly intresting when using calender based weather. <br><br> **Default value:**  `true`
+| `calendarClass`              | The class for the calender module to base the event based weather information on. <br><br> **Default value:** `'calendar'`
+| `iconTable`                  | The conversion table to convert the weather conditions to weather-icons. <br><br> **Default value:** view table below
 
-<table width="100%">
-	<!-- why, markdown... -->
-	<thead>
-		<tr>
-			<th>Option</th>
-			<th width="100%">Description</th>
-		</tr>
-	<thead>
-	<tbody>
-		<tr>
-			<td><code>location</code></td>
-			<td>The location used for weather information.<br>
-				<br><b>Example:</b> <code>'Amsterdam,Netherlands'</code>
-				<br><b>Default value:</b> <code>false</code><br><br>
-				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
-			</td>
-		</tr>
-		<tr>
-			<td><code>locationID</code></td>
-			<td>Location ID from <a href="http://openweathermap.org/help/city_list.txt">OpenWeatherMap</a> <b>This will override anything you put in location.</b><br>Leave blank if you want to use location.
-				<br><b>Example:</b> <code>1234567</code>
-				<br><b>Default value:</b> <code>false</code><br><br>
-				<strong>Note:</strong> When the <code>location</code> and <code>locationID</code> are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
-			</td>
-		</tr>
-		<tr>
-			<td><code>appid</code></td>
-			<td>The <a href="https://home.openweathermap.org" target="_blank">OpenWeatherMap</a> API key, which can be obtained by creating an OpenWeatherMap account.<br>
-				<br> This value is <b>REQUIRED</b>
-			</td>
-		</tr>
-		<tr>
-			<td><code>units</code></td>
-			<td>What units to use. Specified by config.js<br>
-				<br><b>Possible values:</b> <code>config.units</code> = Specified by config.js, <code>default</code> = Kelvin, <code>metric</code> = Celsius, <code>imperial</code> =Fahrenheit
-				<br><b>Default value:</b> <code>config.units</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>roundTemp</code></td>
-			<td>Round temperature values to nearest integer.<br>
-				<br><b>Possible values:</b> <code>true</code> (round to integer) or <code>false</code> (display exact value with decimal point)
-				<br><b>Default value:</b> <code>false</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>maxNumberOfDays</code></td>
-			<td>How many days of forecast to return. Specified by config.js<br>
-				<br><b>Possible values:</b> <code>1</code> - <code>16</code>
-				<br><b>Default value:</b> <code>7</code> (7 days)
-				<br>This value is optional. By default the weatherforecast module will return 7 days.
-			</td>
-		</tr>
-		<tr>
-			<td><code>showRainAmount</code></td>
-			<td>Should the predicted rain amount be displayed?<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>false</code>
-				<br>This value is optional. By default the weatherforecast module will not display the predicted amount of rain.
-			</td>
-		</tr>
-		<tr>
-			<td><code>updateInterval</code></td>
-			<td>How often does the content needs to be fetched? (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>86400000</code>
-				<br><b>Default value:</b> <code>600000</code> (10 minutes)
-			</td>
-		</tr>
-		<tr>
-			<td><code>animationSpeed</code></td>
-			<td>Speed of the update animation. (Milliseconds)<br>
-				<br><b>Possible values:</b><code>0</code> - <code>5000</code>
-				<br><b>Default value:</b> <code>1000</code> (1 second)
-			</td>
-		</tr>
-		<tr>
-			<td><code>lang</code></td>
-			<td>The language of the days.<br>
-				<br><b>Possible values:</b> <code>en</code>, <code>nl</code>, <code>ru</code>, etc ...
-				<br><b>Default value:</b> uses value of <i>config.language</i>
-			</td>
-		</tr>
-		<tr>
-			<td><code>fade</code></td>
-			<td>Fade the future events to black. (Gradient)<br>
-				<br><b>Possible values:</b> <code>true</code> or <code>false</code>
-				<br><b>Default value:</b> <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>fadePoint</code></td>
-			<td>Where to start fade?<br>
-				<br><b>Possible values:</b> <code>0</code> (top of the list) - <code>1</code> (bottom of list)
-				<br><b>Default value:</b> <code>0.25</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>initialLoadDelay</code></td>
-			<td>The initial delay before loading. If you have multiple modules that use the same API key, you might want to delay one of the requests. (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>5000</code>
-				<br><b>Default value:</b>  <code>2500</code> (2.5 seconds delay. This delay is used to keep the OpenWeather API happy.)
-			</td>
-		</tr>
-		<tr>
-			<td><code>retryDelay</code></td>
-			<td>The delay before retrying after a request failure. (Milliseconds)<br>
-				<br><b>Possible values:</b> <code>1000</code> - <code>60000</code>
-				<br><b>Default value:</b>  <code>2500</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>apiVersion</code></td>
-			<td>The OpenWeatherMap API version to use.<br>
-				<br><b>Default value:</b>  <code>2.5</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>apiBase</code></td>
-			<td>The OpenWeatherMap base URL.<br>
-				<br><b>Default value:</b>  <code>'http://api.openweathermap.org/data/'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>forecastEndpoint</code></td>
-			<td>The OpenWeatherMap API endPoint.<br>
-				<br><b>Default value:</b>  <code>'forecast/daily'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>appendLocationNameToHeader</code></td>
-			<td>If set to <code>true</code>, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly intresting when using calender based weather.<br>
-				<br><b>Default value:</b>  <code>true</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>calendarClass</code></td>
-			<td>The class for the calender module to base the event based weather information on.<br>
-				<br><b>Default value:</b>  <code>'calendar'</code>
-			</td>
-		</tr>
-		<tr>
-			<td><code>iconTable</code></td>
-			<td>The conversion table to convert the weather conditions to weather-icons.<br>
-				<br><b>Default value:</b>  <code>iconTable: {
-			'01d':'wi-day-sunny',
-			'02d':'wi-day-cloudy',
-			'03d':'wi-cloudy',
-			'04d':'wi-cloudy-windy',
-			'09d':'wi-showers',
-			'10d':'wi-rain',
-			'11d':'wi-thunderstorm',
-			'13d':'wi-snow',
-			'50d':'wi-fog',
-			'01n':'wi-night-clear',
-			'02n':'wi-night-cloudy',
-			'03n':'wi-night-cloudy',
-			'04n':'wi-night-cloudy',
-			'09n':'wi-night-showers',
-			'10n':'wi-night-rain',
-			'11n':'wi-night-thunderstorm',
-			'13n':'wi-night-snow',
-			'50n':'wi-night-alt-cloudy-windy'
-		}</code>
-			</td>
-		</tr>
-	</tbody>
-</table>
+#### Default Icon Table
+````javascript
+iconTable: {
+    '01d': 'wi-day-sunny',
+    '02d': 'wi-day-cloudy',
+    '03d': 'wi-cloudy',
+    '04d': 'wi-cloudy-windy',
+    '09d': 'wi-showers',
+    '10d': 'wi-rain',
+    '11d': 'wi-thunderstorm',
+    '13d': 'wi-snow',
+    '50d': 'wi-fog',
+    '01n': 'wi-night-clear',
+    '02n': 'wi-night-cloudy',
+    '03n': 'wi-night-cloudy',
+    '04n': 'wi-night-cloudy',
+    '09n': 'wi-night-showers',
+    '10n': 'wi-night-rain',
+    '11n': 'wi-night-thunderstorm',
+    '13n': 'wi-night-snow',
+    '50n': 'wi-night-alt-cloudy-windy'
+}
+````


### PR DESCRIPTION
Replace the HTML tables with Markdown tables for all the README.md files in all the default modules
attempt 3 or 4 for me now :I