### PR TITLE
Minor clean up for test suite

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,8 +7,8 @@ module.exports = function(grunt) {
 				configFile: ".eslintrc.json"
 			},
 			target: ["js/*.js", "modules/default/*.js", "modules/default/*/*.js",
-				"serveronly/*.js", "*.js", "!modules/default/alert/notificationFx.js",
-				"!modules/default/alert/modernizr.custom.js", "!modules/default/alert/classie.js"
+				"serveronly/*.js", "*.js", "tests/*/*.js", "!modules/default/alert/notificationFx.js",
+				"!modules/default/alert/modernizr.custom.js", "!modules/default/alert/classie.js",
 			]
 		},
 		stylelint: {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "electron js/electron.js",
     "postinstall": "sh installers/postinstall/postinstall.sh",
-	"test": "./node_modules/mocha/bin/mocha tests --recursive"
+    "test": "./node_modules/mocha/bin/mocha tests --recursive"
   },
   "repository": {
     "type": "git",

--- a/tests/functions/compare-version.js
+++ b/tests/functions/compare-version.js
@@ -1,21 +1,20 @@
-var chai = require('chai');
+var chai = require("chai");
 var expect = chai.expect;
-var classMM = require('../../js/class.js'); // require for load module.js
-var moduleMM =  require('../../js/module.js')
+var classMM = require("../../js/class.js"); // require for load module.js
+var moduleMM =  require("../../js/module.js")
 
-describe('Test function cmpVersions in js/module.js', function() {
+describe("Test function cmpVersions in js/module.js", function() {
 
-	it('Should be return -1 ', function() {
-		expect(moduleMM._test.cmpVersions('2.1', '2.2')).to.equal(-1);
+	it("should return -1 when comparing 2.1 to 2.2", function() {
+		expect(moduleMM._test.cmpVersions("2.1", "2.2")).to.equal(-1);
 	});
 
-	it('Should be return 0 ', function() {
-		expect(moduleMM._test.cmpVersions('2.2', '2.2')).to.equal(0);
+	it("should be return 0 when comparing 2.2 to 2.2", function() {
+		expect(moduleMM._test.cmpVersions("2.2", "2.2")).to.equal(0);
 	});
 
-	it('Should be return 1', function() {
-		expect(moduleMM._test.cmpVersions('1.1', '1.0')).to.equal(1);
+	it("should be return 1 when comparing 1.1 to 1.0", function() {
+		expect(moduleMM._test.cmpVersions("1.1", "1.0")).to.equal(1);
 	});
-
 });
 


### PR DESCRIPTION
@roramirez thanks for starting adding tests. I figured that we might as well grunt them and follow same rules for linting as we do for rest of JS code in the repo.

I've made following minor modifications:
- added tests to the grunt target
- fixed indentation in package.json
- made tests a bit more descriptive
- fixed eslint errors surfaced by grunt
