### PR TITLE
Run npm test on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ node_js:
  - "5.1"
 before_script:
  - npm install grunt-cli -g
-script: grunt
+script:
+- grunt
+- npm test
 cache:
  directories:
   - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Scaled the splash screen down to make it a bit more subtle.
 - Replace HTML tables with markdown tables in README files.
 - Added `DAYAFTERTOMORROW`, `UPDATE_NOTIFICATION` and `UPDATE_NOTIFICATION_MODULE` to Finnish translations.
+- Run `npm test` on Travis automatically
 
 ### Added
 - Add loaded function to modules, providing an async callback.


### PR DESCRIPTION
To improve the automated tests this PR enables `npm test` to run automatically on Travis.