### PR TITLE
Add root_path testing

### DIFF
--- a/tests/global_vars/root_path.js
+++ b/tests/global_vars/root_path.js
@@ -1,0 +1,24 @@
+var fs = require("fs");
+var path = require("path");
+var chai = require("chai");
+var expect = chai.expect;
+var appMM =  require("../../js/app.js")
+
+describe("Test global.root_path, set in js/app.js", function() {
+	var expectedSubPaths = [
+		'modules',
+		'serveronly',
+		'js',
+		'js/app.js',
+		'js/main.js',
+		'js/electron.js',
+		'config'
+	];
+
+	expectedSubPaths.forEach(subpath => {
+		it(`should contain a file/folder "${subpath}"`, function() {
+			expect(fs.existsSync(path.join(global.root_path, subpath))).to.equal(true);
+		});
+	});
+});
+


### PR DESCRIPTION
This PR adds test cases to confirm the global.root_path is set correctly, by checking some files and folders that are expected in there.