### PR TITLE
Fix grunt errors in root_path.js and syntax in da.json

### DIFF
--- a/tests/global_vars/root_path.js
+++ b/tests/global_vars/root_path.js
@@ -2,17 +2,18 @@ var fs = require("fs");
 var path = require("path");
 var chai = require("chai");
 var expect = chai.expect;
-var appMM =  require("../../js/app.js")
 
 describe("Test global.root_path, set in js/app.js", function() {
+	var appMM =  require("../../js/app.js")
+
 	var expectedSubPaths = [
-		'modules',
-		'serveronly',
-		'js',
-		'js/app.js',
-		'js/main.js',
-		'js/electron.js',
-		'config'
+		"modules",
+		"serveronly",
+		"js",
+		"js/app.js",
+		"js/main.js",
+		"js/electron.js",
+		"config"
 	];
 
 	expectedSubPaths.forEach(subpath => {

--- a/translations/da.json
+++ b/translations/da.json
@@ -25,7 +25,7 @@
 	"W": "V",
 	"WNW": "VNV",
 	"NW": "NV",
-	"NNW": "NNV"
+	"NNW": "NNV",
 
 
 	/* UPDATE INFO */


### PR DESCRIPTION
root_path.js failed grunt testing, but passed Travis-CI somehow... (https://travis-ci.org/qistoph/MagicMirror/jobs/194886345)

translations/da.json missed a comma