### PR TITLE
fix module hidden status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix an issue where the analog clock looked scrambled. ([#611](https://github.com/MichMich/MagicMirror/issues/611))
 - If units is set to imperial, the showRainAmount option of weatherforecast will show the correct unit.
 - Module currentWeather: check if temperature received from api is defined.
+- Fix an issue with module hidden status changing to `true` although lock string prevented showing it
 
 ## [2.1.0] - 2016-12-31
 

--- a/js/main.js
+++ b/js/main.js
@@ -232,6 +232,8 @@ var MM = (function() {
 			return;
 		}
 
+		module.hidden = false;
+
 		// If forced show, clean current lockstrings.
 		if (module.lockStrings.length !== 0 && options.force === true) {
 			Log.log("Force show of module: " + module.name);
@@ -504,7 +506,7 @@ var MM = (function() {
 		 * argument options object - Optional settings for the hide method.
 		 */
 		showModule: function(module, speed, callback, options) {
-			module.hidden = false;
+			// do not change module.hidden yet, only if we really show it later
 			showModule(module, speed, callback, options);
 		}
 	};


### PR DESCRIPTION
Did not create an issues for this, since I do not think it is necessary.

Previously the module status was changed before actually showing the module, and if lock strings prevented it from being shown, the `module.hidden` value was incorrectly `false`.