### PR TITLE
Add missing 'chai-as-promised' dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Option for colored min-temp and max-temp
 - Add test e2e helloworld
 - Add test e2e enviroment
+- Add `chai-as-promised` npm module to devDependencies
 
 ### Fixed
 - Update .gitignore to not ignore default modules folder.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/MichMich/MagicMirror#readme",
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^6.0.0",
     "grunt": "latest",
     "grunt-eslint": "latest",
     "grunt-jsonlint": "latest",


### PR DESCRIPTION
When I attempted to run e2e tests I got following error:

```
$npm run test:e2e

> magicmirror@2.1.1 test:e2e /Users/sergeym/localDev/MagicMirror
> ./node_modules/mocha/bin/mocha tests/e2e --recursive

module.js:471
    throw err;
    ^

Error: Cannot find module 'chai-as-promised'
...
```

Adding `chai-as-promised` to `package.json` and running `npm install` fixes it.
