### PR TITLE
Testing

### DIFF
--- a/tests/unit/global_vars/root_path_spec.js
+++ b/tests/unit/global_vars/root_path_spec.js
@@ -2,10 +2,42 @@ var fs = require("fs");
 var path = require("path");
 var chai = require("chai");
 var expect = chai.expect;
+var vm = require("vm");
+
+before(function() {
+	var basedir = path.join(__dirname, "../../..");
+
+	var fileName = "js/app.js";
+	var filePath = path.join(basedir, fileName);
+	var code = fs.readFileSync(filePath);
+
+	this.sandbox = {
+		module: {},
+		__dirname: path.dirname(filePath),
+		global: {},
+		console: {
+			log: function() { /*console.log("console.log(", arguments, ")");*/ }
+		},
+		process: {
+			on: function() { /*console.log("process.on called with: ", arguments);*/ },
+			env: {}
+		}
+	};
+
+	this.sandbox.require = function(filename) {
+		// This modifies the global slightly,
+		// but supplies vm with essential code
+		return require(filename);
+	};
+
+	vm.runInNewContext(code, this.sandbox, fileName);
+});
+
+after(function() {
+	//console.log(global);
+});
 
 describe("'global.root_path' set in js/app.js", function() {
-	var appMM =  require("../../../js/app.js")
-
 	var expectedSubPaths = [
 		"modules",
 		"serveronly",
@@ -18,8 +50,16 @@ describe("'global.root_path' set in js/app.js", function() {
 
 	expectedSubPaths.forEach(subpath => {
 		it(`contains a file/folder "${subpath}"`, function() {
-			expect(fs.existsSync(path.join(global.root_path, subpath))).to.equal(true);
+			expect(fs.existsSync(path.join(this.sandbox.global.root_path, subpath))).to.equal(true);
 		});
+	});
+
+	it("should not modify global.root_path for testing", function() {
+		expect(global.root_path).to.equal(undefined);
+	});
+
+	it("should not modify global.version for testing", function() {
+		expect(global.version).to.equal(undefined);
 	});
 });
 

--- a/tests/unit/translations/same_keys.js
+++ b/tests/unit/translations/same_keys.js
@@ -3,9 +3,6 @@ var path = require("path");
 var chai = require("chai");
 var expect = chai.expect;
 
-// Disabled for now, because of too many errors
-// Remove .skip from it to enable
-
 describe("Translations have the same keys as en.js", function() {
 	var translations = require("../../../translations/translations.js");
 	var base = JSON.parse(stripComments(fs.readFileSync("translations/en.json", "utf8")));
@@ -13,24 +10,33 @@ describe("Translations have the same keys as en.js", function() {
 
 	Object.keys(translations).forEach(function(tr) {
 		var fileName = translations[tr];
-		it(fileName + " should match", function() {
-			var fileContent = stripComments(fs.readFileSync(fileName, "utf8"));
-			var fileTranslations = JSON.parse(fileContent);
-			var fileKeys = Object.keys(fileTranslations).sort();
+		var fileContent = stripComments(fs.readFileSync(fileName, "utf8"));
+		var fileTranslations = JSON.parse(fileContent);
+		var fileKeys = Object.keys(fileTranslations).sort();
 
-			// TODO: when all translations are fixed, use
-			// expect(fileKeys).to.deep.equal(baseKeys);
+		it(fileName + " keys should be in base", function() {
+			fileKeys.forEach(function(key) {
+				expect( baseKeys.indexOf(key) ).to.be.at.least(0);
+			});
+		});
 
-			// Then delete this block:
-			try {
-				expect(fileKeys).to.deep.equal(baseKeys);
-			} catch(e) {
-				if (e instanceof chai.AssertionError) {
-					this.skip();
-				} else {
-					throw e;
+		it(fileName + " should contain all base keys", function() {
+			var test = this;
+			baseKeys.forEach(function(key) {
+				// TODO: when all translations are fixed, use
+				// expect(fileKeys).to.deep.equal(baseKeys);
+				// instead of the try-catch-block
+
+				try {
+					expect(fileKeys).to.deep.equal(baseKeys);
+				} catch(e) {
+					if (e instanceof chai.AssertionError) {
+						test.skip();
+					} else {
+						throw e;
+					}
 				}
-			}
+			});
 		});
 	});
 });

--- a/tests/unit/translations/same_keys.js
+++ b/tests/unit/translations/same_keys.js
@@ -13,11 +13,24 @@ describe("Translations have the same keys as en.js", function() {
 
 	Object.keys(translations).forEach(function(tr) {
 		var fileName = translations[tr];
-		it.skip(fileName + " should match", function() {
+		it(fileName + " should match", function() {
 			var fileContent = stripComments(fs.readFileSync(fileName, "utf8"));
 			var fileTranslations = JSON.parse(fileContent);
 			var fileKeys = Object.keys(fileTranslations).sort();
-			expect(fileKeys).to.deep.equal(baseKeys);
+
+			// TODO: when all translations are fixed, use
+			// expect(fileKeys).to.deep.equal(baseKeys);
+
+			// Then delete this block:
+			try {
+				expect(fileKeys).to.deep.equal(baseKeys);
+			} catch(e) {
+				if (e instanceof chai.AssertionError) {
+					this.skip();
+				} else {
+					throw e;
+				}
+			}
 		});
 	});
 });

--- a/tests/unit/translations/same_keys.js
+++ b/tests/unit/translations/same_keys.js
@@ -1,0 +1,96 @@
+var fs = require("fs");
+var path = require("path");
+var chai = require("chai");
+var expect = chai.expect;
+
+// Disabled for now, because of too many errors
+// Remove .skip from it to enable
+
+describe("Translations have the same keys as en.js", function() {
+	var translations = require("../../../translations/translations.js");
+	var base = JSON.parse(stripComments(fs.readFileSync("translations/en.json", "utf8")));
+	var baseKeys = Object.keys(base).sort();
+
+	Object.keys(translations).forEach(function(tr) {
+		var fileName = translations[tr];
+		it.skip(fileName + " should match", function() {
+			var fileContent = stripComments(fs.readFileSync(fileName, "utf8"));
+			var fileTranslations = JSON.parse(fileContent);
+			var fileKeys = Object.keys(fileTranslations).sort();
+			expect(fileKeys).to.deep.equal(baseKeys);
+		});
+	});
+});
+
+// Copied from js/translator.js
+function stripComments(str, opts) {
+	// strip comments copied from: https://github.com/sindresorhus/strip-json-comments
+
+	var singleComment = 1;
+	var multiComment = 2;
+
+	function stripWithoutWhitespace() {
+		return "";
+	}
+
+	function stripWithWhitespace(str, start, end) {
+		return str.slice(start, end).replace(/\S/g, " ");
+	}
+
+	opts = opts || {};
+
+	var currentChar;
+	var nextChar;
+	var insideString = false;
+	var insideComment = false;
+	var offset = 0;
+	var ret = "";
+	var strip = opts.whitespace === false ? stripWithoutWhitespace : stripWithWhitespace;
+
+	for (var i = 0; i < str.length; i++) {
+		currentChar = str[i];
+		nextChar = str[i + 1];
+
+		if (!insideComment && currentChar === "\"") {
+			var escaped = str[i - 1] === "\\" && str[i - 2] !== "\\";
+			if (!escaped) {
+				insideString = !insideString;
+			}
+		}
+
+		if (insideString) {
+			continue;
+		}
+
+		if (!insideComment && currentChar + nextChar === "//") {
+			ret += str.slice(offset, i);
+			offset = i;
+			insideComment = singleComment;
+			i++;
+		} else if (insideComment === singleComment && currentChar + nextChar === "\r\n") {
+			i++;
+			insideComment = false;
+			ret += strip(str, offset, i);
+			offset = i;
+			continue;
+		} else if (insideComment === singleComment && currentChar === "\n") {
+			insideComment = false;
+			ret += strip(str, offset, i);
+			offset = i;
+		} else if (!insideComment && currentChar + nextChar === "/*") {
+			ret += str.slice(offset, i);
+			offset = i;
+			insideComment = multiComment;
+			i++;
+			continue;
+		} else if (insideComment === multiComment && currentChar + nextChar === "*/") {
+			i++;
+			insideComment = false;
+			ret += strip(str, offset, i + 1);
+			offset = i + 1;
+			continue;
+		}
+	}
+
+	return ret + (insideComment ? strip(str.substr(offset)) : str.substr(offset));
+}

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -31,3 +31,5 @@ var translations = {
 	"hu" : "translations/hu.json", // Hungarian
 	"is" : "translations/is.json", // Icelandic
 };
+
+if (typeof module !== "undefined") {module.exports = translations;}


### PR DESCRIPTION
Improvements for testing.

1. Check keys in the translation files.
2. To prevent loading app.js from corrupting the Mocha test environment, execute the app.js in a virtual environment. This can also serve as an example for future test cases where code needs to be executed in the global namespace. This also allows us to have more control over the environment in which the app.js is run.