### PR TITLE
Test "dev" argument

### DIFF
--- a/tests/e2e/dev_console.js
+++ b/tests/e2e/dev_console.js
@@ -1,0 +1,52 @@
+const Application = require("spectron").Application;
+const path = require("path");
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+
+var electronPath = path.join(__dirname, "../../", "node_modules", ".bin", "electron");
+
+if (process.platform === "win32") {
+	electronPath += ".cmd";
+}
+
+var appPath = path.join(__dirname, "../../js/electron.js");
+
+var app = new Application({
+	path: electronPath
+});
+
+global.before(function () {
+	chai.should();
+	chai.use(chaiAsPromised);
+});
+
+describe("Argument 'dev'", function () {
+	this.timeout(10000);
+
+	before(function() {
+		// Set config sample for use in test
+		process.env.MM_CONFIG_FILE = "tests/configs/env.js";
+	});
+
+	afterEach(function (done) {
+		app.stop().then(function() { done(); });
+	});
+
+	it("should not open dev console when absent", function () {
+		app.args = [appPath];
+
+		return app.start().then(function() {
+			return app.client.waitUntilWindowLoaded()
+				.getWindowCount().should.eventually.equal(1);
+		});
+	});
+
+	it("should open dev console when provided", function () {
+		app.args = [appPath, 'dev'];
+
+		return app.start().then(function() {
+			return app.client.waitUntilWindowLoaded()
+				.getWindowCount().should.eventually.equal(2);
+		});
+	});
+});

--- a/tests/e2e/dev_console.js
+++ b/tests/e2e/dev_console.js
@@ -42,7 +42,7 @@ describe("Argument 'dev'", function () {
 	});
 
 	it("should open dev console when provided", function () {
-		app.args = [appPath, 'dev'];
+		app.args = [appPath, "dev"];
 
 		return app.start().then(function() {
 			return app.client.waitUntilWindowLoaded()


### PR DESCRIPTION
This PR adds a test for the development console in the electron environment.

Testing the "dev" argument for the start script still needs to be done. This is on the Trello board for the test suite.