### PR TITLE
Compliments module can use remoteFile without default daytime arrays defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `chai-as-promised` npm module to devDependencies
 - Basic set of tests for clock module
 - Run e2e test in Travis
+- Estonian Translation.
+
 
 ### Fixed
 - Update .gitignore to not ignore default modules folder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Add `anytime` group for Compliments module.
+- Compliments module can use remoteFile without default daytime arrays defined
 - Installer: Use init config.js from config.js.sample.
 - Switched out `rrule` package for `rrule-alt` and fixes in `ical.js` in order to fix calendar issues. ([#565](https://github.com/MichMich/MagicMirror/issues/565))
 - Make mouse events pass through the region fullscreen_above to modules below.

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -107,6 +107,8 @@ Module.register("compliments",{
 			compliments = this.config.compliments.evening;
 		}
 
+		if (typeof compliments === 'undefined' ) compliments = new Array();
+
 		if ( this.currentWeatherType in this.config.compliments) {
 			compliments.push.apply(compliments, this.config.compliments[this.currentWeatherType]);
 		}

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -6,8 +6,7 @@
  * By Michael Teeuw http://michaelteeuw.nl
  * MIT Licensed.
  */
-
-Module.register("compliments",{
+Module.register("compliments", {
 
 	// Module config defaults.
 	defaults: {
@@ -97,7 +96,7 @@ Module.register("compliments",{
 	 */
 	complimentArray: function() {
 		var hour = moment().hour();
-		var compliments  = null;
+		var compliments = null;
 
 		if (hour >= 3 && hour < 12) {
 			compliments = this.config.compliments.morning;
@@ -107,9 +106,11 @@ Module.register("compliments",{
 			compliments = this.config.compliments.evening;
 		}
 
-		if (typeof compliments === 'undefined' ) compliments = new Array();
+		if (typeof compliments === "undefined") {
+			compliments = new Array();
+		}
 
-		if ( this.currentWeatherType in this.config.compliments) {
+		if (this.currentWeatherType in this.config.compliments) {
 			compliments.push.apply(compliments, this.config.compliments[this.currentWeatherType]);
 		}
 
@@ -126,7 +127,7 @@ Module.register("compliments",{
 		var xobj = new XMLHttpRequest();
 		xobj.overrideMimeType("application/json");
 		xobj.open("GET", this.file(this.config.remoteFile), true);
-		xobj.onreadystatechange = function () {
+		xobj.onreadystatechange = function() {
 			if (xobj.readyState == 4 && xobj.status == "200") {
 				callback(xobj.responseText);
 			}

--- a/translations/et.json
+++ b/translations/et.json
@@ -8,7 +8,7 @@
 	"EMPTY": "Pole tulevasi sündmuseid.",
 
 	"N": "Põhi",
-	"NNE": "PõhiKirre",
+	"NNE": "Põhikirre",
 	"NE": "Kirre",
 	"ENE": "Idakirre",
 	"E": "Ida",


### PR DESCRIPTION
Compliments module can use remoteFile without default daytime arrays defined.
et.js case correction.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.
