### PR TITLE
Check for dev console instead of counting windows

### DIFF
--- a/tests/e2e/dev_console.js
+++ b/tests/e2e/dev_console.js
@@ -1,6 +1,7 @@
 const Application = require("spectron").Application;
 const path = require("path");
 const chai = require("chai");
+const expect = chai.expect;
 const chaiAsPromised = require("chai-as-promised");
 
 var electronPath = path.join(__dirname, "../../", "node_modules", ".bin", "electron");
@@ -36,8 +37,7 @@ describe("Argument 'dev'", function () {
 		app.args = [appPath];
 
 		return app.start().then(function() {
-			return app.client.waitUntilWindowLoaded()
-				.getWindowCount().should.eventually.equal(1);
+			return expect(app.browserWindow.isDevToolsOpened()).to.eventually.equal(false);
 		});
 	});
 
@@ -45,8 +45,7 @@ describe("Argument 'dev'", function () {
 		app.args = [appPath, "dev"];
 
 		return app.start().then(function() {
-			return app.client.waitUntilWindowLoaded()
-				.getWindowCount().should.eventually.equal(2);
+			return expect(app.browserWindow.isDevToolsOpened()).to.eventually.equal(true);
 		});
 	});
 });

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -39,7 +39,7 @@ describe("Clock set to spanish language module", function () {
 		});
 
 		it("shows date with correct format", function () {
-			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sabado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
+			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
 			return app.client.waitUntilWindowLoaded()
 				.getText(".clock .date").should.eventually.match(dateRegex);
 		});
@@ -66,7 +66,7 @@ describe("Clock set to spanish language module", function () {
 		});
 
 		it("shows date with correct format", function () {
-			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sabado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
+			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
 			return app.client.waitUntilWindowLoaded()
 				.getText(".clock .date").should.eventually.match(dateRegex);
 		});


### PR DESCRIPTION
Update the e2e test for the "dev" argument to open the development console.

Found a way to check if the dev console is actually open, instead of just counting the number of windows.