### PR TITLE
Remove stripComments for translation files

### DIFF
--- a/js/translator.js
+++ b/js/translator.js
@@ -19,90 +19,10 @@ var Translator = (function() {
 		xhr.open("GET", file, true);
 		xhr.onreadystatechange = function () {
 			if (xhr.readyState == 4 && xhr.status == "200") {
-				callback(JSON.parse(stripComments(xhr.responseText)));
+				callback(JSON.parse(xhr.responseText));
 			}
 		};
 		xhr.send(null);
-	}
-
-	/* loadJSON(str, options)
-	 * Remove any commenting from a json file so it can be parsed.
-	 *
-	 * argument str string - The string that contains json with comments.
-	 * argument opts function - Strip options.
-	 *
-	 * return the stripped string.
-	 */
-	function stripComments(str, opts) {
-		// strip comments copied from: https://github.com/sindresorhus/strip-json-comments
-
-		var singleComment = 1;
-		var multiComment = 2;
-
-		function stripWithoutWhitespace() {
-			return "";
-		}
-
-		function stripWithWhitespace(str, start, end) {
-			return str.slice(start, end).replace(/\S/g, " ");
-		}
-
-		opts = opts || {};
-
-		var currentChar;
-		var nextChar;
-		var insideString = false;
-		var insideComment = false;
-		var offset = 0;
-		var ret = "";
-		var strip = opts.whitespace === false ? stripWithoutWhitespace : stripWithWhitespace;
-
-		for (var i = 0; i < str.length; i++) {
-			currentChar = str[i];
-			nextChar = str[i + 1];
-
-			if (!insideComment && currentChar === "\"") {
-				var escaped = str[i - 1] === "\\" && str[i - 2] !== "\\";
-				if (!escaped) {
-					insideString = !insideString;
-				}
-			}
-
-			if (insideString) {
-				continue;
-			}
-
-			if (!insideComment && currentChar + nextChar === "//") {
-				ret += str.slice(offset, i);
-				offset = i;
-				insideComment = singleComment;
-				i++;
-			} else if (insideComment === singleComment && currentChar + nextChar === "\r\n") {
-				i++;
-				insideComment = false;
-				ret += strip(str, offset, i);
-				offset = i;
-				continue;
-			} else if (insideComment === singleComment && currentChar === "\n") {
-				insideComment = false;
-				ret += strip(str, offset, i);
-				offset = i;
-			} else if (!insideComment && currentChar + nextChar === "/*") {
-				ret += str.slice(offset, i);
-				offset = i;
-				insideComment = multiComment;
-				i++;
-				continue;
-			} else if (insideComment === multiComment && currentChar + nextChar === "*/") {
-				i++;
-				insideComment = false;
-				ret += strip(str, offset, i + 1);
-				offset = i + 1;
-				continue;
-			}
-		}
-
-		return ret + (insideComment ? strip(str.substr(offset)) : str.substr(offset));
 	}
 
 	return {

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -39,7 +39,7 @@ describe("Clock set to spanish language module", function () {
 		});
 
 		it("shows date with correct format", function () {
-			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sabado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
+			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
 			return app.client.waitUntilWindowLoaded()
 				.getText(".clock .date").should.eventually.match(dateRegex);
 		});
@@ -66,7 +66,7 @@ describe("Clock set to spanish language module", function () {
 		});
 
 		it("shows date with correct format", function () {
-			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sabado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
+			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
 			return app.client.waitUntilWindowLoaded()
 				.getText(".clock .date").should.eventually.match(dateRegex);
 		});

--- a/tests/unit/translations/same_keys.js
+++ b/tests/unit/translations/same_keys.js
@@ -5,12 +5,12 @@ var expect = chai.expect;
 
 describe("Translations have the same keys as en.js", function() {
 	var translations = require("../../../translations/translations.js");
-	var base = JSON.parse(stripComments(fs.readFileSync("translations/en.json", "utf8")));
+	var base = JSON.parse(fs.readFileSync("translations/en.json", "utf8"));
 	var baseKeys = Object.keys(base).sort();
 
 	Object.keys(translations).forEach(function(tr) {
 		var fileName = translations[tr];
-		var fileContent = stripComments(fs.readFileSync(fileName, "utf8"));
+		var fileContent = fs.readFileSync(fileName, "utf8");
 		var fileTranslations = JSON.parse(fileContent);
 		var fileKeys = Object.keys(fileTranslations).sort();
 
@@ -40,76 +40,3 @@ describe("Translations have the same keys as en.js", function() {
 		});
 	});
 });
-
-// Copied from js/translator.js
-function stripComments(str, opts) {
-	// strip comments copied from: https://github.com/sindresorhus/strip-json-comments
-
-	var singleComment = 1;
-	var multiComment = 2;
-
-	function stripWithoutWhitespace() {
-		return "";
-	}
-
-	function stripWithWhitespace(str, start, end) {
-		return str.slice(start, end).replace(/\S/g, " ");
-	}
-
-	opts = opts || {};
-
-	var currentChar;
-	var nextChar;
-	var insideString = false;
-	var insideComment = false;
-	var offset = 0;
-	var ret = "";
-	var strip = opts.whitespace === false ? stripWithoutWhitespace : stripWithWhitespace;
-
-	for (var i = 0; i < str.length; i++) {
-		currentChar = str[i];
-		nextChar = str[i + 1];
-
-		if (!insideComment && currentChar === "\"") {
-			var escaped = str[i - 1] === "\\" && str[i - 2] !== "\\";
-			if (!escaped) {
-				insideString = !insideString;
-			}
-		}
-
-		if (insideString) {
-			continue;
-		}
-
-		if (!insideComment && currentChar + nextChar === "//") {
-			ret += str.slice(offset, i);
-			offset = i;
-			insideComment = singleComment;
-			i++;
-		} else if (insideComment === singleComment && currentChar + nextChar === "\r\n") {
-			i++;
-			insideComment = false;
-			ret += strip(str, offset, i);
-			offset = i;
-			continue;
-		} else if (insideComment === singleComment && currentChar === "\n") {
-			insideComment = false;
-			ret += strip(str, offset, i);
-			offset = i;
-		} else if (!insideComment && currentChar + nextChar === "/*") {
-			ret += str.slice(offset, i);
-			offset = i;
-			insideComment = multiComment;
-			i++;
-			continue;
-		} else if (insideComment === multiComment && currentChar + nextChar === "*/") {
-			i++;
-			insideComment = false;
-			ret += strip(str, offset, i + 1);
-			offset = i + 1;
-			continue;
-		}
-	}
-
-	return ret + (insideComment ? strip(str.substr(offset)) : str.substr(offset));
-}


### PR DESCRIPTION
As the translation files are now proper JSON (without comments), the stripComments functions are no longer needed in the loader and in tester.