### PR TITLE
Increment timeout e2e test to 20000 ms

### DIFF
--- a/tests/e2e/dev_console.js
+++ b/tests/e2e/dev_console.js
@@ -22,7 +22,7 @@ global.before(function () {
 });
 
 describe("Argument 'dev'", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	before(function() {
 		// Set config sample for use in test

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -22,7 +22,7 @@ global.before(function () {
 });
 
 describe("Electron app environment", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	before(function() {
 		// Set config sample for use in test

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -22,7 +22,7 @@ global.before(function () {
 });
 
 describe("Clock set to spanish language module", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	describe("with default 24hr clock config", function() {
 		before(function() {

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -22,7 +22,7 @@ global.before(function () {
 });
 
 describe("Clock module", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	describe("with default 24hr clock config", function() {
 		before(function() {

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -23,7 +23,7 @@ global.before(function () {
 });
 
 describe("Compliments module", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	describe("parts of days", function() {
 		before(function() {

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -22,7 +22,7 @@ global.before(function () {
 });
 
 describe("Test helloworld module", function () {
-	this.timeout(10000);
+	this.timeout(20000);
 
 	before(function() {
 		// Set config sample for use in test


### PR DESCRIPTION
Increment to 20000ms timeouts of e2e tests.

This recommendation is mentioned by @qistoph
https://forum.magicmirror.builders/post/14358
