### PR TITLE
Fix error when building and running docker on windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:latest
 
+RUN apt-get update && apt-get -y install dos2unix
+
 WORKDIR /opt/magic_mirror
 COPY . .
 COPY /modules unmount_modules
@@ -9,6 +11,8 @@ ENV NODE_ENV production
 ENV MM_PORT 8080
 
 RUN npm install
+
+RUN ["dos2unix", "docker-entrypoint.sh"]
 RUN ["chmod", "+x", "docker-entrypoint.sh"]
 
 EXPOSE $MM_PORT


### PR DESCRIPTION
I got an error when building and running the docker image on my windows machine:
> standard_init_linux.go:178: exec user process caused "no such file or directory"

With the dos2unix command its working.

Please confirm that it's working also on Linux/Unix
