### PR TITLE
Workaround for missing animation on this.show() when module is alone in region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add  test for compliments module for parts of day
 - Korean Translation.
 - Added console warning on startup when deprecated config options are used
-
+- Added `hiddenWrapperStyle` option for `this.hide()` as an workaround for missing animation on `this.show()` when module is alone in region
 
 ### Fixed
 - Update .gitignore to not ignore default modules folder.

--- a/js/main.js
+++ b/js/main.js
@@ -198,7 +198,12 @@ var MM = (function() {
 				// since it's fade out anyway, we can see it lay above or
 				// below other modules. This works way better than adjusting
 				// the .display property.
-				moduleWrapper.style.position = "fixed";
+
+				if (options.hiddenWrapperStyle === undefined || options.hiddenWrapperStyle != "static" ) {
+					options.hiddenWrapperStyle = "fixed";
+				}
+
+				moduleWrapper.style.position = options.hiddenWrapperStyle;
 
 				updateWrapperStates();
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -321,7 +321,7 @@ To hide a module, you can call the `hide(speed, callback)` method. You can call 
 Possible configurable options:
 
 - `lockString` - String - When setting lock string, the module can not be shown without passing the correct lockstring. This way (multiple) modules can prevent a module from showing. It's considered best practice to use your modules identifier as the locksString: `this.identifier`. See *visibility locking* below.
-
+- `hiddenWrapperStyle` - String - If your module is alone in a region and you want to temporary hide and later show it using animation, you will notice the animation don't work. The module will instead be shown instantly without the animation. To prevent this you have to set `hiddenWrapperStyle` to `static` when calling `this.hide()`. It is recommended that you make this option available for the user of the module. If not set by the user, it should be `fixed` to not break existing functionallity.
 
 **Note 1:** If the hide animation is canceled, for instance because the show method is called before the hide animation was finished, the callback will not be called.<br>
 **Note 2:** If the hide animation is hijacked (an other method calls hide on the same module), the callback will not be called.<br>


### PR DESCRIPTION
When you hide a module using `this.hide()` the function `updateWrapperStates` is called. This function basically checks if **any** module (wrapper) inside each region has it's `style.position` set to `static` (or blank). If no module (wrapper) is found, then the `style.display` is set to `none` and hereby hides the region.

The problem is that this prevents the animation when `this.show()` is later called.

I've added a new parameter to `option` in `this.hide()`: `hiddenWrapperStyle` that has to be set to `static`. 

If you have a module that you later want to animate when showing, you have to explicitly hide the module using this parameter, like this:

```
var options = { hiddenWrapperStyle: 'static' };
this.hide(2000, callback, options);
```