### PR TITLE
Fixed missing animations on this.show() when module is alone in a region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Module currentWeather: check if temperature received from api is defined.
 - Fix an issue with module hidden status changing to `true` although lock string prevented showing it
 - Fix newsfeed module bug (removeStartTags)
+- Fixed missing animation on `this.show(speed)` when module is alone in a region.
 
 ## [2.1.0] - 2016-12-31
 

--- a/js/main.js
+++ b/js/main.js
@@ -249,14 +249,14 @@ var MM = (function() {
 			updateWrapperStates();
 
 			// Waiting for DOM-changes done in updateWrapperStates before we can start the animation.
-			setTimeout(function(){
-				moduleWrapper.style.opacity = 1;
+			var dummy = moduleWrapper.parentElement.parentElement.offsetHeight; 
+			
+			moduleWrapper.style.opacity = 1;
 
-				clearTimeout(module.showHideTimer);
-				module.showHideTimer = setTimeout(function() {
-					if (typeof callback === "function") { callback(); }
-				}, speed);
-			}, 0);
+			clearTimeout(module.showHideTimer);
+			module.showHideTimer = setTimeout(function() {
+				if (typeof callback === "function") { callback(); }
+			}, speed);
 		}
 	};
 

--- a/js/main.js
+++ b/js/main.js
@@ -245,14 +245,12 @@ var MM = (function() {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			// Restore the postition. See hideModule() for more info.
 			moduleWrapper.style.position = "static";
-			
+
 			updateWrapperStates();
 
 			// Waiting for DOM-changes done in updateWrapperStates before we can start the animation.
 			setTimeout(function(){
 				moduleWrapper.style.opacity = 1;
-
-
 
 				clearTimeout(module.showHideTimer);
 				module.showHideTimer = setTimeout(function() {

--- a/js/main.js
+++ b/js/main.js
@@ -249,8 +249,8 @@ var MM = (function() {
 			updateWrapperStates();
 
 			// Waiting for DOM-changes done in updateWrapperStates before we can start the animation.
-			var dummy = moduleWrapper.parentElement.parentElement.offsetHeight; 
-			
+			var dummy = moduleWrapper.parentElement.parentElement.offsetHeight;
+
 			moduleWrapper.style.opacity = 1;
 
 			clearTimeout(module.showHideTimer);

--- a/js/main.js
+++ b/js/main.js
@@ -245,15 +245,20 @@ var MM = (function() {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			// Restore the postition. See hideModule() for more info.
 			moduleWrapper.style.position = "static";
-			moduleWrapper.style.opacity = 1;
-
+			
 			updateWrapperStates();
 
-			clearTimeout(module.showHideTimer);
-			module.showHideTimer = setTimeout(function() {
-				if (typeof callback === "function") { callback(); }
-			}, speed);
+			// Waiting for DOM-changes done in updateWrapperStates before we can start the animation.
+			setTimeout(function(){
+				moduleWrapper.style.opacity = 1;
 
+
+
+				clearTimeout(module.showHideTimer);
+				module.showHideTimer = setTimeout(function() {
+					if (typeof callback === "function") { callback(); }
+				}, speed);
+			}, 0);
 		}
 	};
 


### PR DESCRIPTION
Fix for missing animation when using `this.show()` when module is alone in region.

Replaces previously PR https://github.com/MichMich/MagicMirror/pull/744