### PR TITLE
Added option to ignore old items in the news feed module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added hideLoading option for News Feed module
 - Added configurable dateFormat to clock module.
 - Added multiple calendar icon support.
+- Added `ignoreOldItems` and `ignoreOlderThan` options to the News Feed module
 
 ### Fixed
 - Update .gitignore to not ignore default modules folder.

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -70,6 +70,8 @@ The following properties can be configured:
 | `updateInterval`  | How often do you want to display a new headline? (Milliseconds) <br><br> **Possible values:**`1000` - `60000` <br> **Default value:** `10000` (10 seconds)
 | `animationSpeed`  | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `2500` (2.5 seconds)
 | `maxNewsItems`    | Total amount of news items to cycle through. (0 for unlimited) <br><br> **Possible values:**`0` - `...` <br> **Default value:** `0`
+| `ignoreOldItems`  | Ignore news items that are outdated. <br><br> **Possible values:**`true` or `false <br> **Default value:** `false`
+| `ignoreOlderThan` | How old should news items be before they are considered outdated? (Milliseconds) <br><br> **Possible values:**`1` - `...` <br> **Default value:** `86400000` (1 day)
 | `removeStartTags` | Some newsfeeds feature tags at the **beginning** of their titles or descriptions, such as _[VIDEO]_. This setting allows for the removal of specified tags from the beginning of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
 | `startTags`       | List the tags you would like to have removed at the beginning of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
 | `removeEndTags`   | Remove specified tags from the **end** of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -28,6 +28,8 @@ Module.register("newsfeed",{
 		updateInterval: 10 * 1000,
 		animationSpeed: 2.5 * 1000,
 		maxNewsItems: 0, // 0 for unlimited
+		ignoreOldItems: false,
+		ignoreOlderThan: 24 * 60 * 60 * 1000, // 1 day
 		removeStartTags: "",
 		removeEndTags: "",
 		startTags: [],
@@ -226,7 +228,9 @@ Module.register("newsfeed",{
 				for (var i in feedItems) {
 					var item = feedItems[i];
 					item.sourceTitle = this.titleForFeed(feed);
-					newsItems.push(item);
+					if (!(this.config.ignoreOldItems && ((Date.now() - new Date(item.pubdate)) > this.config.ignoreOlderThan))) {
+						newsItems.push(item);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Some RSS feeds from major news sites contain headlines that are rather old.
To prevent the news feed module from displaying outdated items over and over again, this pull request adds an `ignoreOldItems`option to the module. If this option is set to `true`, the module will only display headlines that have been published within the last 24 hours. The precise time interval can be adjusted via the `ignoreOlderThan` option.

_This PR does not solve any related issues._