### PR TITLE
Added a week section to the clock module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added multiple calendar icon support.
 - Added meta tags to support fullscreen mode on iOS (for server mode)
 - Added `ignoreOldItems` and `ignoreOlderThan` options to the News Feed module
+- Added a configurable Week section to the clock module.
 
 ### Fixed
 - Update .gitignore to not ignore default modules folder.

--- a/modules/default/clock/README.md
+++ b/modules/default/clock/README.md
@@ -30,6 +30,7 @@ The following properties can be configured:
 | `showPeriodUpper` | Show the period (AM/PM) with 12 hour format as uppercase. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `clockBold`       | Remove the colon and bold the minutes to make a more modern look. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showDate`        | Turn off or on the Date section. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showWeek`        | Turn off or on the Week section. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `dateFormat`      | Configure the date format as you like. <br><br> **Possible values:** [Docs](http://momentjs.com/docs/#/displaying/format/) <br> **Default value:** `"dddd, LL"`
 | `displayType`     | Display a digital clock, analog clock, or both together. <br><br> **Possible values:** `digital`, `analog`, or `both` <br> **Default value:** `digital`
 | `analogSize`      | **Specific to the analog clock.** Defines how large the analog display is. <br><br> **Possible values:** A positive number of pixels` <br> **Default value:** `200px`

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -16,6 +16,7 @@ Module.register("clock",{
 		showPeriodUpper: false,
 		clockBold: false,
 		showDate: true,
+		showWeek: false,
 		dateFormat: "dddd, LL",
 
 		/* specific to the analog clock */
@@ -61,10 +62,12 @@ Module.register("clock",{
 		var timeWrapper = document.createElement("div");
 		var secondsWrapper = document.createElement("sup");
 		var periodWrapper = document.createElement("span");
+		var weekWrapper = document.createElement("div")
 		// Style Wrappers
 		dateWrapper.className = "date normal medium";
 		timeWrapper.className = "time bright large light";
 		secondsWrapper.className = "dimmed";
+		weekWrapper.className = "week dimmed medium"
 
 		// Set content of wrappers.
 		// The moment().format("h") method has a bug on the Raspberry Pi.
@@ -89,6 +92,9 @@ Module.register("clock",{
 
 		if(this.config.showDate){
 			dateWrapper.innerHTML = now.format(this.config.dateFormat);
+		}
+		if (this.config.showWeek) {
+			weekWrapper.innerHTML = this.translate("WEEK") + " " + now.week();
 		}
 		timeWrapper.innerHTML = timeString;
 		secondsWrapper.innerHTML = now.format("ss");
@@ -172,16 +178,25 @@ Module.register("clock",{
 			// Display only a digital clock
 			wrapper.appendChild(dateWrapper);
 			wrapper.appendChild(timeWrapper);
+			wrapper.appendChild(weekWrapper);
 		} else if (this.config.displayType === "analog") {
 			// Display only an analog clock
 			dateWrapper.style.textAlign = "center";
-			dateWrapper.style.paddingBottom = "15px";
+
+			if (this.config.showWeek) {
+				weekWrapper.style.paddingBottom = "15px";
+			} else {
+				dateWrapper.style.paddingBottom = "15px";
+			}
+
 			if (this.config.analogShowDate === "top") {
 				wrapper.appendChild(dateWrapper);
+				wrapper.appendChild(weekWrapper);
 				wrapper.appendChild(clockCircle);
 			} else if (this.config.analogShowDate === "bottom") {
 				wrapper.appendChild(clockCircle);
 				wrapper.appendChild(dateWrapper);
+				wrapper.appendChild(weekWrapper);
 			} else {
 				wrapper.appendChild(clockCircle);
 			}
@@ -198,6 +213,7 @@ Module.register("clock",{
 			digitalWrapper.style.cssFloat = "none";
 			digitalWrapper.appendChild(dateWrapper);
 			digitalWrapper.appendChild(timeWrapper);
+			digitalWrapper.appendChild(weekWrapper);
 
 			var appendClocks = function(condition, pos1, pos2) {
 				var padding = [0,0,0,0];

--- a/tests/configs/modules/clock/clock_showWeek.js
+++ b/tests/configs/modules/clock/clock_showWeek.js
@@ -1,0 +1,32 @@
+/* Magic Mirror Test config for default clock module
+ *
+ * By Johan Hammar
+ * MIT Licensed.
+ */
+
+var config = {
+	port: 8080,
+	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
+
+	language: "en",
+	timeFormat: 12,
+	units: "metric",
+	electronOptions: {
+		webPreferences: {
+			nodeIntegration: true,
+		},
+	},
+
+	modules: [
+		{
+			module: "clock",
+			position: "middle_center",
+			config: {
+				showWeek: true
+			}
+		}
+	]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {module.exports = config;}

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -100,4 +100,25 @@ describe("Clock module", function () {
 		});
 	});
 
+	describe("with showWeek config enabled", function() {
+		before(function() {
+			// Set config sample for use in test
+			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_showWeek.js";
+		});
+
+		beforeEach(function (done) {
+			app.start().then(function() { done(); } );
+		});
+
+		afterEach(function (done) {
+			app.stop().then(function() { done(); });
+		});
+
+		it("shows week with correct format", function() {
+			const weekRegex = /^Week [0-9]{1,2}$/;
+			return app.client.waitUntilWindowLoaded()
+				.getText(".clock .week").should.eventually.match(weekRegex);
+		});
+	});
+
 });

--- a/translations/en.json
+++ b/translations/en.json
@@ -7,6 +7,8 @@
 	"RUNNING": "Ends in",
 	"EMPTY": "No upcoming events.",
 
+	"WEEK": "Week",
+
 	"N": "N",
 	"NNE": "NNE",
 	"NE": "NE",

--- a/translations/es.json
+++ b/translations/es.json
@@ -7,6 +7,8 @@
 	"RUNNING": "Termina en",
 	"EMPTY": "No hay eventos programados.",
 
+	"WEEK": "Semana",
+
 	"N": "N",
 	"NNE": "NNE",
 	"NE": "NE",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -7,6 +7,8 @@
 	"RUNNING": "Slutar",
 	"EMPTY": "Inga kommande händelser.",
 
+	"WEEK": "Vecka",
+
 	"N": "N",
 	"NNE": "NNO",
 	"NE": "NO",


### PR DESCRIPTION
This PR adds a configurable week section to the clock module. It is disabled by default.

It basically adds a new section below the date section that displays the week. I.e Week 13

Translations for 'en' and 'sv' are provided and more can be added by translating the WEEK property.

A test have been added as well.

Thanks!

/Johan
