### PR TITLE
Task/improve dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.1.2] - Unreleased
 
 ### Changed
+- Fix the dockerfile to have it running from the first time.
 
 ### Added
 - Add in option to wrap long calendar events to multiple lines using `wrapEvents` configuration option.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,22 @@
 FROM node:latest
 
-RUN apt-get update && apt-get -y install dos2unix
-
+ENV NODE_ENV production
+ENV MM_PORT 8080
 WORKDIR /opt/magic_mirror
+
 COPY . .
 COPY /modules unmount_modules
 COPY /config unmount_config
 
-ENV NODE_ENV production
-ENV MM_PORT 8080
-
-RUN npm install
-
-RUN ["dos2unix", "docker-entrypoint.sh"]
-RUN ["chmod", "+x", "docker-entrypoint.sh"]
+RUN apt-get update \
+  && apt-get -qy install tofrodos dos2unix \
+  && chmod -R 777 vendor \
+  && npm install \
+  && cd vendor \ 
+  && npm install \ 
+  && cd .. \ 
+  && dos2unix docker-entrypoint.sh \
+  && chmod +x docker-entrypoint.sh
 
 EXPOSE $MM_PORT
 ENTRYPOINT ["/opt/magic_mirror/docker-entrypoint.sh"]


### PR DESCRIPTION
There is a problem in the installation with the statement "cd vendor && npm install" generating the exception:
"npm WARN lifecycle magicmirror@2.1.1~install: cannot run in wd %s %s (wd=%s) magicmirror@2.1.1 cd vendor && npm install --unsafe-perm /opt/magic_mirror"

This PR tries to solve this issue.


