### PR TITLE
Add the ability to use the docker image with a raspberry pi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.1.2] - Unreleased
 
 ### Changed
+- Change Docker base image (Debian + Node) to an arm based distro (AlpineARM + Node) ([#846](https://github.com/MichMich/MagicMirror/pull/846))
 - Fix the dockerfile to have it running from the first time.
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,27 @@
-FROM node:latest
+FROM izone/arm:node
 
+# Set env variables
 ENV NODE_ENV production
 ENV MM_PORT 8080
+
 WORKDIR /opt/magic_mirror
 
-COPY . .
-COPY /modules unmount_modules
-COPY /config unmount_config
+# Cache node_modules
+COPY package.json /opt/magic_mirror
+RUN npm install
 
-RUN apt-get update \
-  && apt-get -qy install tofrodos dos2unix \
-  && chmod -R 777 vendor \
-  && npm install \
-  && cd vendor \ 
-  && npm install \ 
-  && cd .. \ 
-  && dos2unix docker-entrypoint.sh \
-  && chmod +x docker-entrypoint.sh
+# Copy all needed files
+COPY . /opt/magic_mirror
+
+# Save/Cache config and modules folder for docker-entrypoint
+COPY /modules /opt/magic_mirror/unmount_modules
+COPY /config /opt/magic_mirror/unmount_config
+
+# Convert docker-entrypoint.sh to unix format and grant execution privileges
+RUN apk update \
+    && apk add dos2unix --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
+    && dos2unix docker-entrypoint.sh \
+    && chmod +x docker-entrypoint.sh
 
 EXPOSE $MM_PORT
 ENTRYPOINT ["/opt/magic_mirror/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run  -d \
 			--volume ~/magic_mirror/config:/opt/magic_mirror/config \
 			--volume ~/magic_mirror/modules:/opt/magic_mirror/modules \
 			--name magic_mirror \
-			MichMich/MagicMirror
+			michmich/magicmirror
 ```
 
 | **Volumes** | **Description** |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ ! -f /opt/magic_mirror/modules ]; then
-    cp -R /opt/magic_mirror/unmount_modules/. /opt/magic_mirror/modules
+    cp -Rn /opt/magic_mirror/unmount_modules/. /opt/magic_mirror/modules
 fi
 
 if [ ! -f /opt/magic_mirror/config ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! -f /opt/magic_mirror/modules ]; then
     cp -R /opt/magic_mirror/unmount_modules/. /opt/magic_mirror/modules


### PR DESCRIPTION
## What does this PR do?
This PR replaces the base image from the Dockerfile and fixes some little thinks (see related issues).
Due to the raspberry pi architecture, the current Docker image doesn't work with any Raspberry PI, because it uses Debian with an x86 architecture. I replaced Debian with an ARM compatible Linux distro, so the image also works on a Raspberry PI.
## Related issues
#835 #833 
## Important
@MichMich You need to connect this repo to your Docker Hub/Store account, so we can actually use [this command](https://github.com/MichMich/MagicMirror/blame/master/README.md#L56). This will also fix #835.
