### PR TITLE
Support showing wind direction with an arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add test of match current week number on clock module with showWeek configuration.
 - Add test default modules present modules/default/defaultmodules.js.
 - Add unit test calendar_modules function capFirst.
+- Add support for showing wind direction as an arrow instead of abbreviation in currentWeather module.
 
 ### Updated
 - Added missing keys to Polish translation.

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -40,6 +40,7 @@ The following properties can be configured:
 | `showPeriod`                 | Show the period (am/pm) with 12 hour format <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showPeriodUpper`	           | Show the period (AM/PM) with 12 hour format as uppercase <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showWindDirection`          | Show the wind direction next to the wind speed. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showWindDirectionAsArrow`   | Show the wind direction as an arrow instead of abbreviation <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showHumidity`               | Show the current humidity <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `onlyTemp`                   | Show only current Temperature and weather icon. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `useBeaufort`                | Pick between using the Beaufort scale for wind speed or using the default units. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -21,6 +21,7 @@ Module.register("currentweather",{
 		showPeriod: true,
 		showPeriodUpper: false,
 		showWindDirection: true,
+		showWindDirectionAsArrow: false,
 		useBeaufort: true,
 		lang: config.language,
 		showHumidity: false,

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -94,6 +94,7 @@ Module.register("currentweather",{
 
 		this.windSpeed = null;
 		this.windDirection = null;
+		this.windDeg = null;
 		this.sunriseSunsetTime = null;
 		this.sunriseSunsetIcon = null;
 		this.temperature = null;
@@ -122,7 +123,13 @@ Module.register("currentweather",{
 
 		if (this.config.showWindDirection) {
 			var windDirection = document.createElement("sup");
-			windDirection.innerHTML = " " + this.translate(this.windDirection);
+			if (this.config.showWindDirectionAsArrow) {
+				if(this.windDeg !== null) {
+					windDirection.innerHTML = " &nbsp;<i class=\"fa fa-long-arrow-down\" style=\"transform:rotate("+this.windDeg+"deg);\"></i>&nbsp;";
+				}
+			} else {
+				windDirection.innerHTML = " " + this.translate(this.windDirection);
+			}
 			small.appendChild(windDirection);
 		}
 		var spacer = document.createElement("span");
@@ -329,6 +336,7 @@ Module.register("currentweather",{
 
 
 		this.windDirection = this.deg2Cardinal(data.wind.deg);
+		this.windDeg = data.wind.deg;
 		this.weatherType = this.config.iconTable[data.weather[0].icon];
 
 		var now = new Date();


### PR DESCRIPTION
As described in https://github.com/MichMich/MagicMirror/issues/871 this feature lets user use arrow instead of an abbreviation for wind directions. This can be especially helpful on languages like Finnish that do not have all the compass directions English has.

If the user toggles config for current weather like this: `showWindDirectionAsArrow: true` they'll see the arrow like this:

![image](https://cloud.githubusercontent.com/assets/1191667/25357795/db90aada-2947-11e7-9111-d69fd71a01d4.png)