### PR TITLE
Improve translation flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add test of match current week number on clock module with showWeek configuration.
 - Add test default modules present modules/default/defaultmodules.js.
 - Add unit test calendar_modules function capFirst.
+- Add support for writing translation fucntions to support flexible word order
 
 ### Updated
 - Added missing keys to Polish translation.
 - Added missing key to German translation.
+- Added better translation with flexible word order to Finnish translation
 
 ### Fixed
 - Fix instruction in README for using automatically installer script.

--- a/js/module.js
+++ b/js/module.js
@@ -272,14 +272,18 @@ var Module = Class.extend({
 		}
 	},
 
-	/* translate(key, defaultValue)
-	 * Request the translation for a given key.
+	/* translate(key, defaultValueOrVariables, defaultValue)
+	 * Request the translation for a given key with optional variables and default value.
 	 *
-	 * argument key string - The key of the string to translage
-   * argument defaultValue string - The default value if no translation was found. (Optional)
+	 * argument key string - The key of the string to translate
+   * argument defaultValueOrVariables string/object - The default value or variables for translating. (Optional)
+   * argument defaultValue string - The default value with variables. (Optional)
 	 */
-	translate: function (key, defaultValue) {
-		return Translator.translate(this, key) || defaultValue || "";
+	translate: function (key, defaultValueOrVariables, defaultValue) {
+		if(typeof defaultValueOrVariables === "object") {
+			return Translator.translate(this, key, defaultValueOrVariables) || defaultValue || "";
+		}
+		return Translator.translate(this, key) || defaultValueOrVariables || "";
 	},
 
 	/* updateDom(speed)

--- a/modules/README.md
+++ b/modules/README.md
@@ -429,6 +429,51 @@ this.translate("INFO") //Will return a translated string for the identifier INFO
 
 **Note:** although comments are officially not supported in JSON files, MagicMirror allows it by stripping the comments before parsing the JSON file. Comments in translation files could help other translators.
 
+#####`this.translate(identifier, variables)`
+***identifier* String** - Identifier of the string that should be translated.
+***variables* Object** - Object of variables to be used in translation.
+
+This improved and backwards compatible way to handle translations behaves like the normal translation function and follows the rules described above. It's recommended to use this new format for translating everywhere. It allows translator to change the word order in the sentence to be translated.
+
+
+**Example:**
+````javascript
+var timeUntilEnd = moment(event.endDate, "x").fromNow(true);
+this.translate("RUNNING", { "timeUntilEnd": timeUntilEnd) }); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended.
+````
+
+**Example English .json file:**
+````javascript
+{
+	"RUNNING": "Ends in {timeUntilEnd}",
+}
+````
+
+**Example Finnish .json file:**
+````javascript
+{
+	"RUNNING": "Päättyy {timeUntilEnd} päästä",
+}
+````
+
+**Note:** The *variables* Object has an special case called `fallback`. It's used to support old translations in translation files that do not have the variables in them. If you are upgrading an old module that had translations that did not support the word order, it is recommended to have the fallback layout.
+
+**Example:**
+````javascript
+var timeUntilEnd = moment(event.endDate, "x").fromNow(true);
+this.translate("RUNNING", {
+	"fallback": this.translate("RUNNING") + " {timeUntilEnd}"
+	"timeUntilEnd": timeUntilEnd
+)}); // Will return a translated string for the identifier RUNNING, replacing `{timeUntilEnd}` with the contents of the variable `timeUntilEnd` in the order that translator intended. (has a fallback)
+````
+
+**Example swedish .json file that does not have the variable in it:**
+````javascript
+{
+	"RUNNING": "Slutar",
+}
+
+In this case the `translate`-function will not find any variables in the translation, will look for `fallback` variable and use that if possible to create the translation.
 
 ## The Node Helper: node_helper.js
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -265,7 +265,12 @@ Module.register("calendar", {
 						}
 					}
 				} else {
-					timeWrapper.innerHTML = this.capFirst(this.translate("RUNNING")) + " " + moment(event.endDate, "x").fromNow(true);
+					timeWrapper.innerHTML = this.capFirst(
+						this.translate("RUNNING", {
+							fallback: this.translate("RUNNING") + " {timeUntilEnd}",
+							timeUntilEnd: moment(event.endDate, "x").fromNow(true)
+						})
+					);
 				}
 			}
 			//timeWrapper.innerHTML += ' - '+ moment(event.startDate,'x').format('lll');

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -4,7 +4,7 @@
 	"TODAY": "Tänään",
 	"TOMORROW": "Huomenna",
 	"DAYAFTERTOMORROW": "Ylihuomenna",
-	"RUNNING": "Meneillään",
+	"RUNNING": "Päättyy {timeUntilEnd} päästä",
 	"EMPTY": "Ei tulevia tapahtumia.",
 
 	"N": "P",


### PR DESCRIPTION
As I have described in https://github.com/MichMich/MagicMirror/issues/876 the translation system could be improved with better flexibility in word reordering.

With this code, support for flexible translations can be added with a case by case approach. This change is backwards compatible and should not break existing translations. (As far as I know)

I have provided a sample translation within the default calendar module that solves Finnish language problem with the word order.

If this merge request is accepted, moving from code like this:
```js
this.translate("RUNNING") + " " + moment(event.endDate, "x").fromNow(true)
```
to code like this
```js
this.translate("RUNNING", {
  fallback: this.translate("RUNNING") + " {timeUntilEnd}",
  timeUntilEnd: moment(event.endDate, "x").fromNow(true)
})
```
Would allow translation like this:
```js
"RUNNING": "Päättyy {timeUntilEnd} päästä",
```
to result:
```
Päättyy viiden minuutin päästä
```
while falling back to old behaviour with the `fallback` option given in the variables.

The new translator function checks for the variables object and if it exists, it tries to replace all the variables within the given translation template with ones found in the variables. If the translation template does not contain any variables in curly braces, it checks if there's an fallback option in the variables and uses that to generate the old style translation.

This also fixes the Finnish translation for `RUNNING` events. Instead of saying something like "Ongoing in 5 minutes" like the current translation says, it is fixed to "Ends in 5 minutes" in Finnish.