### PR TITLE
Update currentweather to support indoor temperature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add test default modules present modules/default/defaultmodules.js.
 - Add unit test calendar_modules function capFirst.
 - Add test for check if exits the directories present in defaults modules.
+- Add ability for `currentweather` module to display indoor temperature via INDOOR_TEMPERATURE notification
 
 ### Updated
 - Added missing keys to Polish translation.

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -41,6 +41,7 @@ The following properties can be configured:
 | `showPeriodUpper`	           | Show the period (AM/PM) with 12 hour format as uppercase <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showWindDirection`          | Show the wind direction next to the wind speed. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showHumidity`               | Show the current humidity <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
+| `showIndoorTemperature`      | If you have another module that emits the INDOOR_TEMPERATURE notification, the indoor temperature will be displayed <br> **Default value:** `false`
 | `onlyTemp`                   | Show only current Temperature and weather icon. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `useBeaufort`                | Pick between using the Beaufort scale for wind speed or using the default units. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `lang`                       | The language of the days. <br><br> **Possible values:** `en`, `nl`, `ru`, etc ... <br> **Default value:** uses value of _config.language_

--- a/modules/default/currentweather/currentweather.css
+++ b/modules/default/currentweather/currentweather.css
@@ -1,4 +1,5 @@
-.currentweather .weathericon {
+.currentweather .weathericon,
+.currentweather .fa-home {
   font-size: 75%;
   line-height: 65px;
   display: inline-block;

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -25,6 +25,7 @@ Module.register("currentweather",{
 		lang: config.language,
 		showHumidity: false,
 		degreeLabel: false,
+		showIndoorTemperature: false,
 
 		initialLoadDelay: 0, // 0 seconds delay
 		retryDelay: 2500,
@@ -97,6 +98,7 @@ Module.register("currentweather",{
 		this.sunriseSunsetTime = null;
 		this.sunriseSunsetIcon = null;
 		this.temperature = null;
+		this.indoorTemperature = null;
 		this.weatherType = null;
 
 		this.loaded = false;
@@ -203,6 +205,17 @@ Module.register("currentweather",{
 		temperature.innerHTML = " " + this.temperature + "&deg;" + degreeLabel;
 		large.appendChild(temperature);
 
+		if (this.config.showIndoorTemperature && this.indoorTemperature) {
+			var indoorIcon = document.createElement("span");
+			indoorIcon.className = "fa fa-home";
+			large.appendChild(indoorIcon);
+
+			var indoorTemperatureElem = document.createElement("span");
+			indoorTemperatureElem.className = "bright";
+			indoorTemperatureElem.innerHTML = " " + this.indoorTemperature + "&deg;" + degreeLabel;
+			large.appendChild(indoorTemperatureElem);
+		}
+
 		wrapper.appendChild(large);
 		return wrapper;
 	},
@@ -238,6 +251,10 @@ Module.register("currentweather",{
 					}
 				}
 			}
+		}
+		if (notification === "INDOOR_TEMPERATURE") {
+			this.indoorTemperature = this.roundValue(payload);
+			this.updateDom(self.config.animationSpeed);
 		}
 	},
 


### PR DESCRIPTION
This is an enhancement to allow the `currentweather` module to show indoor and outdoor temperature side-by-side if you have another module that can supply the indoor temperature value.

I'm currently working on a new module to interface with the Vera MiOS home automation system (https://github.com/jasonyork/MMM-mios) with the idea that it could emit the indoor temperature from the thermostat (or other temperature sensing device)

Below is a screenshot from my working implementation.

![image](https://cloud.githubusercontent.com/assets/1487146/25569088/9ba2c966-2dd5-11e7-8ad1-9ddd48164e5e.png)

Looking forward to your feedback and ideas.  Thanks.
