### PR TITLE
Xuanyou patch compliments documentation

### DIFF
--- a/modules/default/compliments/README.md
+++ b/modules/default/compliments/README.md
@@ -13,7 +13,7 @@ modules: [
 									// Best results in one of the middle regions like: lower_third
 		config: {
 			// The config property is optional.
-			// If no config is set, an example calendar is shown.
+			// If no config is set, the default compliments are shown.
 			// See 'Configuration options' for more information.
 		}
 	}
@@ -31,6 +31,7 @@ The following properties can be configured:
 | `fadeSpeed`      | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `4000` (4 seconds)
 | `compliments`	   | The list of compliments. <br><br> **Possible values:** An object with four arrays: `morning`, `afternoon`, `evening` and `anytime`. See _compliment configuration_ below. <br> **Default value:** See _compliment configuration_ below.
 | `remoteFile`     | External file from which to load the compliments <br><br> **Possible values:** Path to a JSON file containing compliments, configured as per the value of the _compliments configuration_ (see below). An object with four arrays: `morning`, `afternoon`, `evening` and `anytime`. - `compliments.json` <br> **Default value:** `null` (Do not load from file)
+| `classes`        | Override the CSS classes of the div showing the compliments
 
 ### Compliment configuration
 

--- a/modules/default/compliments/README.md
+++ b/modules/default/compliments/README.md
@@ -31,7 +31,7 @@ The following properties can be configured:
 | `fadeSpeed`      | Speed of the update animation. (Milliseconds) <br><br> **Possible values:**`0` - `5000` <br> **Default value:** `4000` (4 seconds)
 | `compliments`	   | The list of compliments. <br><br> **Possible values:** An object with four arrays: `morning`, `afternoon`, `evening` and `anytime`. See _compliment configuration_ below. <br> **Default value:** See _compliment configuration_ below.
 | `remoteFile`     | External file from which to load the compliments <br><br> **Possible values:** Path to a JSON file containing compliments, configured as per the value of the _compliments configuration_ (see below). An object with four arrays: `morning`, `afternoon`, `evening` and `anytime`. - `compliments.json` <br> **Default value:** `null` (Do not load from file)
-| `classes`        | Override the CSS classes of the div showing the compliments
+| `classes`        | Override the CSS classes of the div showing the compliments <br><br> **Default value:** `thin xlarge bright`
 
 ### Compliment configuration
 


### PR DESCRIPTION
# Description

There is a "hidden" configuration in the compliments module, named "classes", that allows the user to override the classes of the displayed div in the compliments module.

This is not described in the documentation of the compliments module.

Also, there is a logical error where the documentation of the compliments module states "an example calendar is shown".

# Proposed fix

Add documentation for the config variable "classes" that allows the user to override the css classes of the compliments module display.

Fix the erroneous "an example calendar is shown" to "default compliments are shown".
