### PR TITLE
Corrected Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix instruction in README for using automatically installer script.
 - Bug of duplicated compliments as described in [here](https://forum.magicmirror.builders/topic/2381/compliments-module-stops-cycling-compliments).
 - Fix double message about port when server is starting
+- Corrected Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW.
 
 ## [2.1.1] - 2017-04-01
 

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1,9 +1,9 @@
 {
 	"LOADING": "Laddar &hellip;",
 
-	"TODAY": "Idag",
-	"TOMORROW": "Imorgon",
-	"DAYAFTERTOMORROW": "Iövermorgon",
+	"TODAY": "I dag",
+	"TOMORROW": "I morgon",
+	"DAYAFTERTOMORROW": "I övermorgon",
 	"RUNNING": "Slutar",
 	"EMPTY": "Inga kommande händelser.",
 


### PR DESCRIPTION
Changed Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW:

DAYAFTERTOMORROW was wrong and has been corrected.

TODAY and TOMORROW was ok before but have been changed to the recommended spelling according to: https://sv.wiktionary.org/wiki/i_dag
