### PR TITLE
Removed unused import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bug of duplicated compliments as described in [here](https://forum.magicmirror.builders/topic/2381/compliments-module-stops-cycling-compliments).
 - Fix double message about port when server is starting
 - Corrected Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW.
+- Removed unused import from js/electron.js
 
 ## [2.1.1] - 2017-04-01
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -2,7 +2,6 @@
 
 "use strict";
 
-const Server = require(__dirname + "/server.js");
 const electron = require("electron");
 const core = require(__dirname + "/app.js");
 


### PR DESCRIPTION
Noticed that `const Server = require(__dirname + "/server.js");` is not used anywhere in the electron.js script.

Removed unused import from js/electron.js