### PR TITLE
Calender respects timeformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix double message about port when server is starting
 - Corrected Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW.
 - Removed unused import from js/electron.js
+- Made calendar.js respect config.timeFormat irrespecive of locale setting
 
 ## [2.1.1] - 2017-04-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -69,6 +69,29 @@ Module.register("calendar", {
 		// Set locale.
 		moment.locale(config.language);
 
+		switch (config.timeFormat) {
+		case 12: {
+			moment.updateLocale(config.language, {
+				longDateFormat: {
+					LT: "h:mm A"
+				}
+			});
+			break;
+		}
+		case 24: {
+			moment.updateLocale(config.language, {
+				longDateFormat: {
+					LT: "hh:mm"
+				}
+			});
+			break;
+		}
+		// If config.timeFormat was not given (or has invalid format) default to locale default
+		default: {
+			break;
+		}
+		}
+
 		for (var c in this.config.calendars) {
 			var calendar = this.config.calendars[c];
 			calendar.url = calendar.url.replace("webcal://", "http://");


### PR DESCRIPTION
In reference to issue #776, made changes to calendar.js to respect timeformat config option if it is used