### PR TITLE
Issue with date alignment in clock.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix double message about port when server is starting
 - Corrected Swedish translations for TODAY/TOMORROW/DAYAFTERTOMORROW.
 - Removed unused import from js/electron.js
+- Fixed alignment of analog clock when a large calendar is displayed in the same side bar
 
 ## [2.1.1] - 2017-04-01
 

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -180,7 +180,6 @@ Module.register("clock",{
 			wrapper.appendChild(weekWrapper);
 		} else if (this.config.displayType === "analog") {
 			// Display only an analog clock
-			dateWrapper.style.textAlign = "center";
 
 			if (this.config.showWeek) {
 				weekWrapper.style.paddingBottom = "15px";

--- a/modules/default/clock/clock_styles.css
+++ b/modules/default/clock/clock_styles.css
@@ -1,5 +1,5 @@
 .clockCircle {
-  margin: 0 auto;
+  margin: 0;
   position: relative;
   border-radius: 50%;
   background-size: 100%;


### PR DESCRIPTION
In reference to issue #927. Made changes to clock.js and clock_styles.css to prevent alignment problem when displaying analog clock and large calendar entries