### PR TITLE
add symbol and color on broadcasted events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 ### Added
+- Add symbol and color properties of event when `CALENDAR_EVENTS` notification is broadcasted from `defaultcalendar` module.
 ### Updated
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 ### Added
-- Add symbol and color properties of event when `CALENDAR_EVENTS` notification is broadcasted from `defaultcalendar` module.
+- Add symbol and color properties of event when `CALENDAR_EVENTS` notification is broadcasted from `default/calendar` module.
 ### Updated
 ### Fixed
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -522,6 +522,8 @@ Module.register("calendar", {
 			var calendar = this.calendarData[url];
 			for (var e in calendar) {
 				var event = cloneObject(calendar[e]);
+				event.symbol = this.symbolsForUrl(url);
+				event.color = this.colorForUrl(url);
 				delete event.url;
 				eventList.push(event);
 			}


### PR DESCRIPTION
Broadcasted calendar events have no symbol and color, so I add them.
I think it could be useful for who is listening to this broadcast. 
Because of deleted URL, the listener could not distinguish where events are driven from. symbol and color could be some help for that.

Anyway, I suggest one more thing. 
Broadcasted events need some unique identifier(like calendar UID and event UID). It could tell the listener not only the origin of events but also duplication of events. Currently, when the listener receives `CALENDAR_EVENTS`, he should compare previously received events with new events. It is not easy because of lack of information of events itself.
This suggestion is somewhat related to this topic, but most of out of ranges. However I hope you consider this.