### PR TITLE
Fix issue #933

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 ### Fixed
 
+- Fixed issue with incorrect allignment of analog clock when displayed in the center column of the MM
+
 ## [2.1.2] - 2017-07-01
 
 ### Changed

--- a/modules/default/clock/clock_styles.css
+++ b/modules/default/clock/clock_styles.css
@@ -1,5 +1,5 @@
 .clockCircle {
-  margin: 0;
+  margin: 0 auto;
   position: relative;
   border-radius: 50%;
   background-size: 100%;


### PR DESCRIPTION
This is a fix for issue 933 which restores the original alligment of the analog clock; the analog clock still does not properly align to the left of the left sidebar when content of other left sidebar modules is too wide.