### PR TITLE
Fix issue #940

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -81,7 +81,7 @@ Module.register("calendar", {
 		case 24: {
 			moment.updateLocale(config.language, {
 				longDateFormat: {
-					LT: "hh:mm"
+					LT: "HH:mm"
 				}
 			});
 			break;


### PR DESCRIPTION
Fix for issue 940 - time was incorrectly displayed in a 12-hour fashion regardless of the 24 hour clock preference in config.js