### PR TITLE
Addition to .gitignore to ignore VS Code folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ jspm_modules
 .npm
 .node_repl_history
 
+# Visual Studio Code ignoramuses.
+.vscode/
+
 # Various Windows ignoramuses.
 Thumbs.db
 ehthumbs.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Add `clientonly` script to start only the electron client for a remote server.
 - Add symbol and color properties of event when `CALENDAR_EVENTS` notification is broadcasted from `default/calendar` module.
+- Add `.vscode/` folder to `.gitignore` to keep custom Visual Studio Code config out of git
 
 ### Updated
 - Changed 'default.js' - listen on all attached interfaces by default


### PR DESCRIPTION
Changed .gitignore to ignore Visual Studio Code project folder with custom launch configuration. (See issue #956)