### PR TITLE
Fix calendar.js bug issue #963

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -366,7 +366,7 @@ Module.register("calendar", {
 			return a.startDate - b.startDate;
 		});
 
-		return events.slice(0, this.config.maximumEntries);
+		return events;
 	},
 
 	/* createEventList(url)


### PR DESCRIPTION
Fixed calendar specific configuration settings maximumEntries and maximumNumberOfDays not overriding global setting