### PR TITLE
Use before after vendors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Changed 'default.js' - listen on all attached interfaces by default.
 - Add execution of `npm list` after the test are ran in Travis CI.
+- Change hooks for the vendors e2e tests.
 
 ### Fixed
 - Fixed issue with incorrect allignment of analog clock when displayed in the center column of the MM.

--- a/tests/e2e/vendor_spec.js
+++ b/tests/e2e/vendor_spec.js
@@ -6,21 +6,21 @@ const expect = require("chai").expect;
 
 const describe = global.describe;
 const it = global.it;
-const beforeEach = global.beforeEach;
-const afterEach = global.afterEach;
+const before = global.before;
+const after = global.after;
 
 describe("Vendors", function () {
 	helpers.setupTimeout(this);
 
 	var app = null;
 
-	beforeEach(function () {
+	before(function () {
 		return helpers.startApplication({
 			args: ["js/electron.js"]
 		}).then(function (startedApp) { app = startedApp; })
 	});
 
-	afterEach(function () {
+	after(function () {
 		return helpers.stopApplication(app);
 	});
 


### PR DESCRIPTION
Use the hooks `before` and `after` in the vendor_spec instead of use `beforeAll` and
`afterAll` in the e2e test to prevent failure in CI.

