### PR TITLE
Fix this.file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed ipWhitelist behaviour to make empty whitelist ([]) allow any and all hosts access to the MM.
 - Fixed issue with calendar module where 'excludedEvents' count towards 'maximumEntries'.
 - Fixed issue with calendar module where global configuration of maximumEntries was not overridden by calendar specific config (see module doc).
+- Fixed issue where `this.file(filename)` returns a path with two hashes
 
 ## [2.1.2] - 2017-07-01
 

--- a/js/module.js
+++ b/js/module.js
@@ -194,7 +194,7 @@ var Module = Class.extend({
 	 * return string - File path.
 	 */
 	file: function (file) {
-		return this.data.path + "/" + file;
+		return (this.data.path + "/" + file).replace("//", "/");
 	},
 
 	/* loadStyles()


### PR DESCRIPTION
I made a small fix to make sure `this.file(filename)` don't return double hash'es ( / ). 

An alternative solution would be to skip manually adding the hash, but I'm not 100% sure `this.data.path` allways ends with a hash.