### PR TITLE
More secure defaults.

### DIFF
--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -9,10 +9,11 @@
  */
 
 var config = {
-	address: "", // Address to listen on, can be
-	             // "localhost", "127.0.0.1", "::1" to listen on loopback interface
-	             // another specific IPv4/6 to listen on a specific interface
-	             // "", "0.0.0.0", "::" to listen on any interface
+	address: "", // Address to listen on, can be:
+	             // - "localhost", "127.0.0.1", "::1" to listen on loopback interface
+	             // - another specific IPv4/6 to listen on a specific interface
+	             // - "", "0.0.0.0", "::" to listen on any interface
+				 // Default, when address config is left out, is "localhost"
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], // Set [] to allow all IP addresses
 	                                                       // or add a specific IPv4 of 192.168.1.5 :

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -9,7 +9,10 @@
  */
 
 var config = {
-	address: "localhost",
+	address: "", // Address to listen on, can be
+	             // "localhost", "127.0.0.1", "::1" to listen on loopback interface
+	             // another specific IPv4/6 to listen on a specific interface
+	             // "", "0.0.0.0", "::" to listen on any interface
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], // Set [] to allow all IP addresses
 	                                                       // or add a specific IPv4 of 192.168.1.5 :

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -9,11 +9,11 @@
  */
 
 var config = {
-	address: "", // Address to listen on, can be:
-	             // - "localhost", "127.0.0.1", "::1" to listen on loopback interface
-	             // - another specific IPv4/6 to listen on a specific interface
-	             // - "", "0.0.0.0", "::" to listen on any interface
-				 // Default, when address config is left out, is "localhost"
+	address: "localhost", // Address to listen on, can be:
+	                      // - "localhost", "127.0.0.1", "::1" to listen on loopback interface
+	                      // - another specific IPv4/6 to listen on a specific interface
+	                      // - "", "0.0.0.0", "::" to listen on any interface
+	                      // Default, when address config is left out, is "localhost"
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], // Set [] to allow all IP addresses
 	                                                       // or add a specific IPv4 of 192.168.1.5 :

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -8,7 +8,7 @@
  */
 
 var port = 8080;
-var address = ""; // Default to listening on all interfaces
+var address = "localhost";
 if (typeof(mmPort) !== "undefined") {
 	port = mmPort;
 }


### PR DESCRIPTION
Related to #950. More secure suggestion.

Without config, listen only on looback interface. In sample config
listen on any interface, but use an IP whitelist.