### PR TITLE
Correct timeFormat for 24h format

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -81,7 +81,7 @@ Module.register("calendar", {
 		case 24: {
 			moment.updateLocale(config.language, {
 				longDateFormat: {
-					LT: "hh:mm"
+					LT: "HH:mm"
 				}
 			});
 			break;


### PR DESCRIPTION
In the momentjs doc:

HH	00 01 ... 22 23
hh	01 02 ... 11 12

The small 'h' is only for 12h format.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!


* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.
