### PR TITLE
TestSuite: Show the missing strings for translations files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "feedme": "latest",
     "helmet": "^3.6.1",
     "iconv-lite": "latest",
+    "mocha-logger": "^1.0.5",
     "moment": "latest",
     "request": "^2.81.0",
     "rrule-alt": "^2.2.5",

--- a/tests/unit/translations/same_keys.js
+++ b/tests/unit/translations/same_keys.js
@@ -2,6 +2,7 @@ var fs = require("fs");
 var path = require("path");
 var chai = require("chai");
 var expect = chai.expect;
+var mlog = require("mocha-logger");
 
 describe("Translations have the same keys as en.js", function() {
 	var translations = require("../../../translations/translations.js");
@@ -31,6 +32,8 @@ describe("Translations have the same keys as en.js", function() {
 					expect(fileKeys).to.deep.equal(baseKeys);
 				} catch(e) {
 					if (e instanceof chai.AssertionError) {
+						diff = baseKeys.filter(function(x) { return fileKeys.indexOf(x) < 0 });
+						mlog.pending("Missing Translations for language " + tr + ": ", diff);
 						test.skip();
 					} else {
 						throw e;


### PR DESCRIPTION
In the translations test now when are missing some translations for
determinated language will be show the missing string.

This can help to identified and improved the translations files.

/me listening STP: Silvergun superman