### PR TITLE
Slice the list of all calendar events to honor config.maximumEntries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 
+### Fixed
+- Fixed issue with calendar module showing more than `maximumEntries` allows
+
 ## [2.1.3] - 2017-10-01
 
 **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -356,7 +356,7 @@ Module.register("calendar", {
 			return a.startDate - b.startDate;
 		});
 
-		return events;
+		return events.slice(0, this.config.maximumEntries);
 	},
 
 	/* createEventList(url)


### PR DESCRIPTION
Scenario:
* Specify more than one calendar in `config.calendars`
* Specify a maximum number of entries in `config.maximumEntries`

Result:
The module will show as many as maximumEntries for EACH calendar

Expected:
The module shall not show more than a total of maximumEntries, regardless of how many calendars I specify

Fixes #1043