### PR TITLE
Weather (Current/Forecast): Use HTTPS instead of HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed issue with calendar module showing more than `maximumEntries` allows
+- WeatherForecast and CurrentWeather are now using HTTPS instead of HTTP
 
 ## [2.1.3] - 2017-10-01
 

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -33,7 +33,7 @@ Module.register("currentweather",{
 		retryDelay: 2500,
 
 		apiVersion: "2.5",
-		apiBase: "http://api.openweathermap.org/data/",
+		apiBase: "https://api.openweathermap.org/data/",
 		weatherEndpoint: "weather",
 
 		appendLocationNameToHeader: true,

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -30,7 +30,7 @@ Module.register("weatherforecast",{
 		retryDelay: 2500,
 
 		apiVersion: "2.5",
-		apiBase: "http://api.openweathermap.org/data/",
+		apiBase: "https://api.openweathermap.org/data/",
 		forecastEndpoint: "forecast/daily",
 
 		appendLocationNameToHeader: true,


### PR DESCRIPTION
Chrome blocks insecure requests (HTTP) when MagicMirror is loaded
via HTTPS. This commit changes the protocol used for OpenWeatherMap.