### PR TITLE
Check trailing white space in comments too

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
 		"max-len": ["error", 250],
 		"curly": "error",
 		"camelcase": ["error", {"properties": "never"}],
-		"no-trailing-spaces": ["error"],
+		"no-trailing-spaces": ["error", {"ignoreComments": false }],
 		"no-irregular-whitespace": ["error"]
 	},
 	"env": {

--- a/js/module.js
+++ b/js/module.js
@@ -27,7 +27,7 @@ var Module = Class.extend({
 	// visibility when hiding and showing module.
 	lockStrings: [],
 
-	// Storage of the nunjuck Environment, 
+	// Storage of the nunjuck Environment,
 	// This should not be referenced directly.
 	// Use the nunjucksEnvironment() to get it.
 	_nunjucksEnvironment: null,
@@ -156,7 +156,7 @@ var Module = Class.extend({
 	/** nunjucksEnvironment()
 	 * Returns the nunjucks environment for the current module.
 	 * The environment is checked in the _nunjucksEnvironment instance variable.
-	 * 
+
 	 * @returns Nunjucks Environment
 	 */
 	nunjucksEnvironment: function() {

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -289,9 +289,9 @@ Module.register("calendar", {
 	 * This function accepts a number (either 12 or 24) and returns a moment.js LocaleSpecification with the
 	 * corresponding timeformat to be used in the calendar display. If no number is given (or otherwise invalid input)
 	 * it will a localeSpecification object with the system locale time format.
-	 * 
+	 *
 	 * @param {number} timeFormat Specifies either 12 or 24 hour time format
-	 * @returns {moment.LocaleSpecification} 
+	 * @returns {moment.LocaleSpecification}
 	 */
 	getLocaleSpecification: function(timeFormat) {
 		switch (timeFormat) {
@@ -430,7 +430,7 @@ Module.register("calendar", {
 
 	/**
 	 * Shortens a string if it's longer than maxLength and add a ellipsis to the end
-	 * 
+	 *
 	 * @param {string} string Text string to shorten
 	 * @param {number} maxLength The max length of the string
 	 * @param {boolean} wrapEvents Wrap the text after the line has reached maxLength

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -25,7 +25,7 @@ describe("Check configuration without modules", function () {
 	});
 
 	before(function () {
-		// Set config sample for use in test 
+		// Set config sample for use in test
 		process.env.MM_CONFIG_FILE = "tests/configs/without_modules.js";
 	});
 


### PR DESCRIPTION
As mentioned in https://github.com/MichMich/MagicMirror/pull/1054, trailing white space is ignored in comments by default. Even though the docs state otherwise.

This PR adds a configuration setting for eslint to also check for trailing white space in comments.