### PR TITLE
Add Github diff link to update info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add option to use [Nunjucks](https://mozilla.github.io/nunjucks/) templates in modules. (See `helloworld` module as an example.)
 - Add Bulgarian translations for MagicMirror² and Alert module
 - Add graceful shutdown of modules by calling `stop` function of each `node_helper` on SIGINT before exiting.
+- Link update subtext to Github diff of current version versus tracking branch.
 
 ### Updated
 

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -64,7 +64,10 @@ module.exports = NodeHelper.create({
 			sg.git.fetch().status(function(err, data) {
 				data.module = sg.module;
 				if (!err) {
-					self.sendSocketNotification("STATUS", data);
+					sg.git.log({"-1": null}, function(err, data2) {
+						data.hash = data2.latest.hash;
+						self.sendSocketNotification("STATUS", data);
+					});
 				}
 			});
 		});

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -34,6 +34,17 @@ Module.register("updatenotification", {
 		}
 	},
 
+	diffLink: function(text) {
+		var localRef = this.status.hash;
+		var remoteRef = this.status.tracking.replace(/.*\//, "");
+		return "<a href=\"https://github.com/MichMich/MagicMirror/compare/"+localRef+"..."+remoteRef+"\" "+
+			"class=\"xsmall dimmed\" "+
+			"style=\"text-decoration: none;\" "+
+			"target=\"_blank\" >" +
+			text +
+			"</a>";
+	},
+
 	// Override dom generator.
 	getDom: function () {
 		var wrapper = document.createElement("div");
@@ -47,9 +58,14 @@ Module.register("updatenotification", {
 			icon.innerHTML = "&nbsp;";
 			message.appendChild(icon);
 
+			var subtextHtml = this.translate("UPDATE_INFO")
+				.replace("COMMIT_COUNT", this.status.behind + " " + ((this.status.behind == 1) ? "commit" : "commits"))
+				.replace("BRANCH_NAME", this.status.current);
+
 			var text = document.createElement("span");
 			if (this.status.module == "default") {
 				text.innerHTML = this.translate("UPDATE_NOTIFICATION");
+				subtextHtml = this.diffLink(subtextHtml);
 			} else {
 				text.innerHTML = this.translate("UPDATE_NOTIFICATION_MODULE").replace("MODULE_NAME", this.status.module);
 			}
@@ -58,9 +74,7 @@ Module.register("updatenotification", {
 			wrapper.appendChild(message);
 
 			var subtext = document.createElement("div");
-			subtext.innerHTML = this.translate("UPDATE_INFO")
-				.replace("COMMIT_COUNT", this.status.behind + " " + ((this.status.behind == 1) ? "commit" : "commits"))
-				.replace("BRANCH_NAME", this.status.current);
+			subtext.innerHTML = subtextHtml;
 			subtext.className = "xsmall dimmed";
 			wrapper.appendChild(subtext);
 		}


### PR DESCRIPTION
This PR adds a link to the subtext for a MagicMirror update. (Not for modules).
The link will show a diff between the current HEAD and the tracked remote branch.

Personally I find it useful to have a quick look at the changes, especially while using the *develop* branch.. This link facilitates an easy and quick way to find these changes.

- The module data send from the server to the client is extended with the hash from `git log -1`. This is the current HEAD.
- The old subtext is now constructed in a var `subtextHtml`.
- If the text is for the `default` module (MagicMirror itself), the function `diffLink` is called to wrap the text in a link to the diff page.