### PR TITLE
Added ability to set a list of prohibited words that will be filtered…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add graceful shutdown of modules by calling `stop` function of each `node_helper` on SIGINT before exiting.
 - Link update subtext to Github diff of current version versus tracking branch.
 - Add Catalan translation.
+- Add ability to filter out newsfeed items based on prohibited words found in title (resolves #1071)
 
 ### Updated
 

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -76,6 +76,7 @@ The following properties can be configured:
 | `startTags`       | List the tags you would like to have removed at the beginning of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
 | `removeEndTags`   | Remove specified tags from the **end** of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
 | `endTags`         | List the tags you would like to have removed at the end of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
+| `prohibitedWords` | Remove news feed item if one of these words is found anywhere in the title (case insensitive and greedy matching) <br><br> **Possible values:** `['word']` or `['word1','word2',...]`
 
 The `feeds` property contains an array with multiple objects. These objects have the following properties:
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -33,7 +33,8 @@ Module.register("newsfeed",{
 		removeStartTags: "",
 		removeEndTags: "",
 		startTags: [],
-		endTags: []
+		endTags: [],
+		prohibitedWords: []
 
 	},
 
@@ -241,6 +242,18 @@ Module.register("newsfeed",{
 		if(this.config.maxNewsItems > 0) {
 			newsItems = newsItems.slice(0, this.config.maxNewsItems);
 		}
+
+		if(this.config.prohibitedWords.length > 0) {
+			newsItems = newsItems.filter(function(value){
+				for (var i=0; i < this.config.prohibitedWords.length; i++) {
+					if (value["title"].toLowerCase().indexOf(this.config.prohibitedWords[i].toLowerCase()) > -1) {
+						return false;
+					}
+				}
+				return true;
+			}, this);
+		}
+
 		this.newsItems = newsItems;
 	},
 


### PR DESCRIPTION
… out of newsfeed

Resolves #1071

`prohibitedWords` config parameter is an array of words. If set and case insensitive greedy match is found anywhere in the title then that newsfeed item will not be displayed. 

Readme updated with instructions.

Users should be careful on the words selection as careless setting may remove many or all items from the newsfeed. Some obvious mistakes like `space, comma, dot` etc. can be prevented programatically, but I left it out of this PR

Example:

with `prohibitedWords: ['dodgers']`

Original `newsItems`:
```
0:{title: "New York City, Russia, Los Angeles Dodgers: Your Wednesday Briefing", description: "Here’s what you need to know to start your day.", pubdate: "Wed, 01 Nov 2017 09:37:36 GMT", url: "https://www.nytimes.com/2017/11/01/briefing/new-yo…ssia-los-angeles-dodgers.html?partner=rss&emc=rss", sourceTitle: "New York Times"}
1:{title: "A Mangled School Bus, Bodies Everywhere; ‘It Was Surreal’", description: "A truck ramming bicyclists. The driver emerging wi…e attack, it was as confusing as it was gruesome.", pubdate: "Wed, 01 Nov 2017 09:27:41 GMT", url: "https://www.nytimes.com/2017/10/31/nyregion/nyc-sc…r-attack-truck-witnesses.html?partner=rss&emc=rss", sourceTitle: "New York Times"}
2:{title: "Dodgers 3, Astros 1 | Series tied, 3-3: With a Rally and a Romp, Dodgers Top Astros and Force Game 7", description: "Down by a run with just four innings left in Game …nst a dominating Justin Verlander. Game 7 awaits.", pubdate: "Wed, 01 Nov 2017 07:21:07 GMT", url: "https://www.nytimes.com/2017/11/01/sports/dodgers-win-game-6.html?partner=rss&emc=rss", sourceTitle: "New York Times"}
3:{title: "José Andrés Fed Puerto Rico, and May Change How Aid Is Given", description: "The chef’s huge effort is just the latest led by c…ocally based way to feed people after a disaster.", pubdate: "Wed, 01 Nov 2017 06:40:09 GMT", url: "https://www.nytimes.com/2017/10/30/dining/jose-andres-puerto-rico.html?partner=rss&emc=rss", sourceTitle: "New York Times"}
```

Filtered `newsItems`:
```
0:{title: "A Mangled School Bus, Bodies Everywhere; ‘It Was Surreal’", description: "A truck ramming bicyclists. The driver emerging wi…e attack, it was as confusing as it was gruesome.", pubdate: "Wed, 01 Nov 2017 09:27:41 GMT", url: "https://www.nytimes.com/2017/10/31/nyregion/nyc-sc…r-attack-truck-witnesses.html?partner=rss&emc=rss", sourceTitle: "New York Times"}
1:{title: "José Andrés Fed Puerto Rico, and May Change How Aid Is Given", description: "The chef’s huge effort is just the latest led by c…ocally based way to feed people after a disaster.", pubdate: "Wed, 01 Nov 2017 06:40:09 GMT", url: "https://www.nytimes.com/2017/10/30/dining/jose
```
