### PR TITLE
DOM creation notifications in cases of async template rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.3] - 2018-01-03
+
+### Added
+
+- Add system notification `MODULE_DOM_CREATED` for notifying each module when their Dom has been fully loaded.
+
 ## [2.2.2] - 2018-01-02
 
 ### Added

--- a/js/main.js
+++ b/js/main.js
@@ -80,6 +80,7 @@ var MM = (function() {
 	 * argument notification string - The identifier of the notification.
 	 * argument payload mixed - The payload of the notification.
 	 * argument sender Module - The module that sent the notification.
+	 * argument sendTo Module - The module to send the notification to. (optional)
 	 */
 	var sendNotification = function(notification, payload, sender, sendTo) {
 		for (var module of modules) {
@@ -94,6 +95,8 @@ var MM = (function() {
 	 *
 	 * argument module Module - The module that needs an update.
 	 * argument speed Number - The number of microseconds for the animation. (optional)
+	 * 
+	 * return Promise - Resolved when the dom is fully updated.
 	 */
 	var updateDom = function(module, speed) {
 		return new Promise((resolve) => {
@@ -113,6 +116,16 @@ var MM = (function() {
 		});
 	};
 
+	/* updateDomWithContent(module, speed, newHeader, newContent)
+	 * Update the dom with the specified content
+	 * 
+	 * argument module Module - The module that needs an update.
+	 * argument speed Number - The number of microseconds for the animation. (optional)
+	 * argument newHeader String - The new header that is generated.
+	 * argument newContent Domobject - The new content that is generated.
+	 * 
+	 * return Promise - Resolved when the module dom has been updated.
+	 */
 	var updateDomWithContent = function(module, speed, newHeader, newContent) {
 		return new Promise((resolve) => {
 			if (module.hidden || !speed) {
@@ -146,6 +159,7 @@ var MM = (function() {
 	 * Check if the content has changed.
 	 *
 	 * argument module Module - The module to check.
+	 * argument newHeader String - The new header that is generated.
 	 * argument newContent Domobject - The new content that is generated.
 	 *
 	 * return bool - Does the module need an update?
@@ -173,6 +187,7 @@ var MM = (function() {
 	 * Update the content of a module on screen.
 	 *
 	 * argument module Module - The module to check.
+	 * argument newHeader String - The new header that is generated.
 	 * argument newContent Domobject - The new content that is generated.
 	 */
 	var updateModuleContent = function(module, newHeader, newContent) {

--- a/js/main.js
+++ b/js/main.js
@@ -95,22 +95,22 @@ var MM = (function() {
 	 *
 	 * argument module Module - The module that needs an update.
 	 * argument speed Number - The number of microseconds for the animation. (optional)
-	 * 
+	 *
 	 * return Promise - Resolved when the dom is fully updated.
 	 */
 	var updateDom = function(module, speed) {
 		return new Promise((resolve) => {
 			var newContentPromise = module.getDom();
 			var newHeader = module.getHeader();
-	
+
 			if (!(newContentPromise instanceof Promise)) {
 				// convert to a promise if not already one to avoid if/else's everywhere
 				newContentPromise = Promise.resolve(newContentPromise);
 			}
-	
+
 			newContentPromise.then((newContent) => {
 				var updatePromise = updateDomWithContent(module, speed, newHeader, newContent);
-	
+
 				updatePromise.then(resolve).catch(Log.error);
 			}).catch(Log.error);
 		});
@@ -118,12 +118,12 @@ var MM = (function() {
 
 	/* updateDomWithContent(module, speed, newHeader, newContent)
 	 * Update the dom with the specified content
-	 * 
+	 *
 	 * argument module Module - The module that needs an update.
 	 * argument speed Number - The number of microseconds for the animation. (optional)
 	 * argument newHeader String - The new header that is generated.
 	 * argument newContent Domobject - The new content that is generated.
-	 * 
+	 *
 	 * return Promise - Resolved when the module dom has been updated.
 	 */
 	var updateDomWithContent = function(module, speed, newHeader, newContent) {

--- a/js/module.js
+++ b/js/module.js
@@ -81,31 +81,30 @@ var Module = Class.extend({
 	 * return domobject - The dom to display.
 	 */
 	getDom: function () {
-		var div = document.createElement("div");
-		var template = this.getTemplate();
-		var templateData = this.getTemplateData();
+		return new Promise((resolve) => {
+			var div = document.createElement("div");
+			var template = this.getTemplate();
+			var templateData = this.getTemplateData();
+	
+			// Check to see if we need to render a template string or a file.
+			if (/^.*((\.html)|(\.njk))$/.test(template)) {
+				// the template is a filename
+				this.nunjucksEnvironment().render(template, templateData, function (err, res) {
+					if (err) {
+						Log.error(err)
+					}
 
-		// Check to see if we need to render a template string or a file.
-		if (/^.*((\.html)|(\.njk))$/.test(template)) {
-			// the template is a filename
-			this.nunjucksEnvironment().render(template, templateData, function (err, res) {
-				if (err) {
-					Log.error(err)
-				}
+					div.innerHTML = res;
 
-				// The inner content of the div will be set after the template is received.
-				// This isn't the most optimal way, but since it's near instant
-				// it probably won't be an issue.
-				// If it gives problems, we can always add a way to pre fetch the templates.
-				// Let's not over optimise this ... KISS! :)
-				div.innerHTML = res;
-			});
-		} else {
-			// the template is a template string.
-			div.innerHTML = this.nunjucksEnvironment().renderString(template, templateData);
-		}
+					resolve(div);
+				});
+			} else {
+				// the template is a template string.
+				div.innerHTML = this.nunjucksEnvironment().renderString(template, templateData);
 
-		return div;
+				resolve(div);
+			}
+		});
 	},
 
 	/* getHeader()

--- a/js/module.js
+++ b/js/module.js
@@ -85,7 +85,7 @@ var Module = Class.extend({
 			var div = document.createElement("div");
 			var template = this.getTemplate();
 			var templateData = this.getTemplateData();
-	
+
 			// Check to see if we need to render a template string or a file.
 			if (/^.*((\.html)|(\.njk))$/.test(template)) {
 				// the template is a filename

--- a/js/module.js
+++ b/js/module.js
@@ -78,7 +78,7 @@ var Module = Class.extend({
 	 * This method can to be subclassed if the module wants to display info on the mirror.
 	 * Alternatively, the getTemplete method could be subclassed.
 	 *
-	 * return domobject - The dom to display.
+	 * return DomObject | Promise - The dom or a promise with the dom to display.
 	 */
 	getDom: function () {
 		return new Promise((resolve) => {

--- a/modules/README.md
+++ b/modules/README.md
@@ -230,11 +230,12 @@ notificationReceived: function(notification, payload, sender) {
 }
 ````
 
-**Note:** the system sends two notifications when starting up. These notifications could come in handy!
+**Note:** the system sends three notifications when starting up. These notifications could come in handy!
 
 
 - `ALL_MODULES_STARTED` - All modules are started. You can now send notifications to other modules.
 - `DOM_OBJECTS_CREATED` - All dom objects are created. The system is now ready to perform visual changes.
+- `MODULE_DOM_CREATED` - This module's dom has been fully loaded. You can now access your module's dom objects.
 
 
 #### `socketNotificationReceived: function(notification, payload)`


### PR DESCRIPTION
Problem: The current way the `DOM_OBJECTS_CREATED` notification is sent out is after all doms are processed but not fully rendered in cases of async template doms.

I propose a solution to send a notification when that module's dom has been fully updated. This change does not break anything and only adds a notification to when a module's dom has been fully rendered.

This issue has surfaced for me because I was trying to render a chart on a div rendered by a template and when `DOM_OBJECTS_CREATED` was called, my dom had not actually been loaded yet since it was still being processed by the templating library.