### PR TITLE
Per-feed CSS class for default newsfeed module

### DIFF
--- a/tests/configs/modules/newsfeed/default.js
+++ b/tests/configs/modules/newsfeed/default.js
@@ -26,7 +26,8 @@ var config = {
 				feeds: [
 					{
 						title: "Rodrigo Ramirez Blog",
-						url: "http://localhost:8080/tests/configs/data/feed_test_rodrigoramirez.xml"
+						url: "http://localhost:8080/tests/configs/data/feed_test_rodrigoramirez.xml",
+						className: "rod"
 					},
 				]
 			}

--- a/tests/e2e/modules/newsfeed_class.js
+++ b/tests/e2e/modules/newsfeed_class.js
@@ -34,7 +34,7 @@ describe("Newsfeed module", function() {
 		});
 
 		it("checks for newsfeed class", function() {
-			expect(vm.$el.querySelector('.rod') !== null).to.be.true;
+			return app.client.waitForExist(".rod", 10000).should.be.fulfilled;
 		});
 	});
 });

--- a/tests/e2e/modules/newsfeed_class.js
+++ b/tests/e2e/modules/newsfeed_class.js
@@ -1,0 +1,40 @@
+const helpers = require("../global-setup");
+const path = require("path");
+const request = require("request");
+
+const expect = require("chai").expect;
+
+const describe = global.describe;
+const it = global.it;
+const beforeEach = global.beforeEach;
+const afterEach = global.afterEach;
+
+describe("Newsfeed module", function() {
+	helpers.setupTimeout(this);
+
+	var app = null;
+
+	beforeEach(function() {
+		return helpers
+			.startApplication({
+				args: ["js/electron.js"]
+			})
+			.then(function(startedApp) {
+				app = startedApp;
+			});
+	});
+
+	afterEach(function() {
+		return helpers.stopApplication(app);
+	});
+
+	describe("Default configuration", function() {
+		before(function() {
+			process.env.MM_CONFIG_FILE = "tests/configs/modules/newsfeed/default.js";
+		});
+
+		it("checks for newsfeed class", function() {
+			expect(vm.$el.querySelector('.rod') !== null).to.be.true;
+		});
+	});
+});


### PR DESCRIPTION
- Added CSS class support for default newsfeed module as requested on the forum here (and elsewhere): https://forum.magicmirror.builders/topic/6014/change-colors-on-each-news-feed
- Updated default module config with second feed (I feel this may overcomplicate default config)
- Updated `CHANGELOG.md` and the module's `README.md`, some sample CSS, and an e2e test for the class
- Added all default module CSS to `Gruntfile.js`, fixed the consequent linting errors

First PR to MM, so certainly welcome all feedback.