### PR TITLE
Change English translation to "In 2 days"

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -3,7 +3,7 @@
 
 	"TODAY": "Today",
 	"TOMORROW": "Tomorrow",
-	"DAYAFTERTOMORROW": "The day after tomorrow",
+	"DAYAFTERTOMORROW": "In 2 days",
 	"RUNNING": "Ends in",
 	"EMPTY": "No upcoming events.",
 


### PR DESCRIPTION
Modify english translation to say "In 2 days" instead of "The day after tomorrow". Started from issue: #1130