### PR TITLE
Fix for #1140 - sendNotification module errors after #1116

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 /* global  Log, Loader, Module, config, defaults */
-/* jshint -W020 */
+/* jshint -W020, esversion: 6 */
 
 /* Magic Mirror
  * Main System
@@ -89,7 +89,8 @@ var MM = (function() {
 	 * argument sendTo Module - The module to send the notification to. (optional)
 	 */
 	var sendNotification = function(notification, payload, sender, sendTo) {
-		for (var module of modules) {
+		for (var m in modules) {
+			var module = modules[m];
 			if (module !== sender && (!sendTo || module === sendTo)) {
 				module.notificationReceived(notification, payload, sender);
 			}


### PR DESCRIPTION
Revert change to `js/main.js`'s `sendNotification` function back to original method.

```js
for (var module of modules) {
```
This ES6 method does not behave well with the `modules` array when `config.js` contains disabled modules. It results in an empty `module` variable for every disabled module, which causes an error when the function tries to send a notification to an undefined module.

Reverting back to the original:
```js
for (var m in modules) {
    var module = modules[m];
```