### PR TITLE
Put article iframe in front of modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add system notification `MODULE_DOM_CREATED` for notifying each module when their Dom has been fully loaded.
 - Add types for module.
 
+### Fixed
+- News article in fullscreen (iframe) is now shown in front of modules.
+
 *This release is scheduled to be released on 2018-04-01.*
 
 ## [2.2.2] - 2018-01-02

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -186,6 +186,7 @@ Module.register("newsfeed",{
 				fullArticle.height = window.innerHeight;
 				fullArticle.style.border = "none";
 				fullArticle.src = this.newsItems[this.activeItem].url;
+				fullArticle.style.zIndex = 1;
 				wrapper.appendChild(fullArticle);
 			}
 


### PR DESCRIPTION
Before this change the article was brought up in its ifram in fullscreen and you could still see the other modules in front of it