### PR TITLE
Show remote compliments on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add types for module.
 - Implement Danger.js to notify contributors when CHANGELOG.md is missing in PR.
 - Allow to scroll in full page article view of default newsfeed module with gesture events from [MMM-Gestures](https://github.com/thobach/MMM-Gestures)
+- Changed 'compliments.js' - update DOM if remote compliments are loaded instead of waiting one updateInterval to show custom compliments
 
 ### Fixed
 - News article in fullscreen (iframe) is now shown in front of modules.

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -49,14 +49,15 @@ Module.register("compliments", {
 
 		this.lastComplimentIndex = -1;
 
+		var self = this;
 		if (this.config.remoteFile != null) {
 			this.complimentFile((response) => {
 				this.config.compliments = JSON.parse(response);
+				self.updateDom();
 			});
 		}
 
 		// Schedule update timer.
-		var self = this;
 		setInterval(function() {
 			self.updateDom(self.config.fadeSpeed);
 		}, this.config.updateInterval);


### PR DESCRIPTION
Minor change to compliments.js (default module). Previously the default compliments were being shown on boot even if remote_compliments.json exists. The remote compliments would then only be shown after one updateInterval, which may be several hours depending on the user's config preferences. 

This change updates the DOM to show remote compliments immediately after boot, allowing users to see their messages right after restarting MagicMirror.