### PR TITLE
Fix exception on translation of objects

### DIFF
--- a/js/translator.js
+++ b/js/translator.js
@@ -126,7 +126,7 @@ var Translator = (function() {
 			// variables: {timeToWait: "2 hours", work: "painting"}
 			// to: "Please wait for 2 hours before continuing with painting."
 			function createStringFromTemplate(template, variables) {
-				if(Object.prototype.toString.call(template) !== '[object String]') {
+				if(Object.prototype.toString.call(template) !== "[object String]") {
 					return template;
 				}
 				if(variables.fallback && !template.match(new RegExp("\{.+\}"))) {

--- a/js/translator.js
+++ b/js/translator.js
@@ -126,6 +126,9 @@ var Translator = (function() {
 			// variables: {timeToWait: "2 hours", work: "painting"}
 			// to: "Please wait for 2 hours before continuing with painting."
 			function createStringFromTemplate(template, variables) {
+				if(Object.prototype.toString.call(template) !== '[object String]') {
+					return template;
+				}
 				if(variables.fallback && !template.match(new RegExp("\{.+\}"))) {
 					template = variables.fallback;
 				}


### PR DESCRIPTION
Sometimes, the content of translations[module.name][key] is not a string but an entire object. Since the previous commit, it cause a crash on template.replace(...) of createStringFromTemplate(...).  10 month ago... I am surprised to be the first to found it.

It is currently the case in MMM-Voice-Control (copy annyang.js as precised in https://forum.magicmirror.builders/topic/1690/mmm-voice-control-only-black-screen-after-installation)
