### PR TITLE
 Fixed to work in Midori 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - News article in fullscreen (iframe) is now shown in front of modules.
+- Compliments module now loads properly in Midori 0.4.3.
 
 *This release is scheduled to be released on 2018-04-01.*
 

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -55,7 +55,7 @@ Module.register("compliments", {
 
 		var self = this;
 		if (this.config.remoteFile != null) {
-			this.complimentFile((response) => {
+			this.complimentFile(function(response) {
 				this.config.compliments = JSON.parse(response);
 				self.updateDom();
 			});


### PR DESCRIPTION
Was getting an error trying to run this on Midori:
http://localhost:8080/modules/default/compliments//compliments.js @53: SyntaxError: Unexpected token '>'
so I replaced it with the old-style syntax. I use Midori instead of Chromium for performance reasons on my Pi Zero running Raspbian Jessie.