### PR TITLE
capitalize "y/n" for clearer intent

### DIFF
--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -149,7 +149,7 @@ else
 fi
 
 # Use pm2 control like a service MagicMirror
-read -p "Do you want use pm2 for auto starting of your MagicMirror (y/n)?" choice
+read -p "Do you want use pm2 for auto starting of your MagicMirror (y/N)?" choice
 if [[ $choice =~ ^[Yy]$ ]]; then
     sudo npm install -g pm2
     sudo su -c "env PATH=$PATH:/usr/bin pm2 startup linux -u pi --hp /home/pi"


### PR DESCRIPTION
First off, thank you for maintaining and making this project publicly available for others! Fist bump :fist_right: 

During the install script process, if you press enter, `choice` becomes an empty string and will default to "no". The convention in this case is to capitalize the default answer so users know what happens when they auto-accept prompts.

I figured this is such an insignificant change that it doesn't need a note in the CHANGELOG, but please let me know if you'd prefer I add this in.

Thanks! :)