### PR TITLE
Fixed to work in Midori browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue where wind chill could not be displayed in Fahrenheit. [#1247](https://github.com/MichMich/MagicMirror/issues/1247)
 - Fixed issues where a module crashes when it tries to dismiss a non existing alert. [#1240](https://github.com/MichMich/MagicMirror/issues/1240)
 - In default module currentWeather/currentWeather.js line 296, 300, self.config.animationSpeed can not be found because the notificationReceived function does not have "self" variable.
+- Fixed browser-side code to work on the Midori browser.
 
 ### Updated
 - Updated Italian translation

--- a/js/main.js
+++ b/js/main.js
@@ -21,7 +21,7 @@ var MM = (function() {
 	var createDomObjects = function() {
 		var domCreationPromises = [];
 
-		modules.forEach(module => {
+		modules.forEach(function(module) {
 			if (typeof module.data.position !== "string") {
 				return;
 			}
@@ -52,14 +52,14 @@ var MM = (function() {
 
 			var domCreationPromise = updateDom(module, 0);
 			domCreationPromises.push(domCreationPromise);
-			domCreationPromise.then(() => {
+			domCreationPromise.then(function() {
 				sendNotification("MODULE_DOM_CREATED", null, null, module);
 			}).catch(Log.error);
 		});
 
 		updateWrapperStates();
 
-		Promise.all(domCreationPromises).then(() => {
+		Promise.all(domCreationPromises).then(function() {
 			sendNotification("DOM_OBJECTS_CREATED");
 		});
 	};
@@ -106,7 +106,7 @@ var MM = (function() {
 	 * return Promise - Resolved when the dom is fully updated.
 	 */
 	var updateDom = function(module, speed) {
-		return new Promise((resolve) => {
+		return new Promise(function(resolve) {
 			var newContentPromise = module.getDom();
 			var newHeader = module.getHeader();
 
@@ -115,7 +115,7 @@ var MM = (function() {
 				newContentPromise = Promise.resolve(newContentPromise);
 			}
 
-			newContentPromise.then((newContent) => {
+			newContentPromise.then(function(newContent) {
 				var updatePromise = updateDomWithContent(module, speed, newHeader, newContent);
 
 				updatePromise.then(resolve).catch(Log.error);
@@ -134,7 +134,7 @@ var MM = (function() {
 	 * return Promise - Resolved when the module dom has been updated.
 	 */
 	var updateDomWithContent = function(module, speed, newHeader, newContent) {
-		return new Promise((resolve) => {
+		return new Promise(function(resolve) {
 			if (module.hidden || !speed) {
 				updateModuleContent(module, newHeader, newContent);
 				resolve();

--- a/js/module.js
+++ b/js/module.js
@@ -81,15 +81,16 @@ var Module = Class.extend({
 	 * return DomObject | Promise - The dom or a promise with the dom to display.
 	 */
 	getDom: function () {
-		return new Promise((resolve) => {
+		var self = this;
+		return new Promise(function(resolve) {
 			var div = document.createElement("div");
-			var template = this.getTemplate();
-			var templateData = this.getTemplateData();
+			var template = self.getTemplate();
+			var templateData = self.getTemplateData();
 
 			// Check to see if we need to render a template string or a file.
 			if (/^.*((\.html)|(\.njk))$/.test(template)) {
 				// the template is a filename
-				this.nunjucksEnvironment().render(template, templateData, function (err, res) {
+				self.nunjucksEnvironment().render(template, templateData, function (err, res) {
 					if (err) {
 						Log.error(err)
 					}
@@ -100,7 +101,7 @@ var Module = Class.extend({
 				});
 			} else {
 				// the template is a template string.
-				div.innerHTML = this.nunjucksEnvironment().renderString(template, templateData);
+				div.innerHTML = self.nunjucksEnvironment().renderString(template, templateData);
 
 				resolve(div);
 			}

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -55,8 +55,8 @@ Module.register("compliments", {
 
 		var self = this;
 		if (this.config.remoteFile != null) {
-			this.complimentFile((response) => {
-				this.config.compliments = JSON.parse(response);
+			this.complimentFile(function(response) {
+				self.config.compliments = JSON.parse(response);
 				self.updateDom();
 			});
 		}


### PR DESCRIPTION
The Midori browser doesn't support new JS features. Midori is the only browser that I've found that's performant enough to be run on a Raspberry Pi Zero. MagicMirror v2.2.2 worked fine with Midori, but changes added in 2.3.0 broke it.

Compliments was broken in v2.2.2 as well, but I never made a pull request for my local changes at the time.