### PR TITLE
Added option to calendar module that colors only the symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Enabled translation of feelsLike for module currentweather
 - Added support for on-going calendar events
+- Added option to calendar module that colors only the symbol instead of the whole line
 
 ### Changed
 - Use Electron 2 Beta. **Please test!**

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -53,11 +53,13 @@ The following properties can be configured:
 
 The `calendars` property contains an array of the configured calendars.
 The `colored` property gives the option for an individual color for each calendar.
+The `coloredSymbolOnly` property will apply color to the symbol only, not the whole line. This is only applicable when `colored` is also enabled.
 
 #### Default value:
 ````javascript
 config: {
 	colored: false,
+	coloredSymbolOnly: false,
 	calendars: [
 		{
 			url: 'http://www.calendarlabs.com/templates/ical/US-Holidays.ics',

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -31,6 +31,7 @@ Module.register("calendar", {
 		hidePrivate: false,
 		hideOngoing: false,
 		colored: false,
+		coloredSymbolOnly: false,
 		calendars: [
 			{
 				symbol: "calendar",
@@ -135,7 +136,7 @@ Module.register("calendar", {
 			var event = events[e];
 			var eventWrapper = document.createElement("tr");
 
-			if (this.config.colored) {
+			if (this.config.colored && !this.config.coloredSymbolOnly) {
 				eventWrapper.style.cssText = "color:" + this.colorForUrl(event.url);
 			}
 
@@ -143,6 +144,11 @@ Module.register("calendar", {
 
 			if (this.config.displaySymbol) {
 				var symbolWrapper = document.createElement("td");
+
+				if (this.config.colored && this.config.coloredSymbolOnly) {
+					symbolWrapper.style.cssText = "color:" + this.colorForUrl(event.ulr);
+				}
+
 				symbolWrapper.className = "symbol align-right";
 				var symbols = this.symbolsForUrl(event.url);
 				if(typeof symbols === "string") {


### PR DESCRIPTION
This adds a new config option, 'coloredSymbolOnly', to the calendar module that makes only the symbol be colored, and not the whole line.  I found having the whole line be colored was too much when everything else on the screen was white.  So coloring just the symbol still gives me the visual indication that I need, but with a smaller impact on the whole.

Before and after screenshots are attached.
![before](https://user-images.githubusercontent.com/10662490/39373882-a548381a-4a0e-11e8-870d-734dbb827c73.png)
![after](https://user-images.githubusercontent.com/10662490/39373892-ab19ee82-4a0e-11e8-9880-2cdb9ec664e7.png)

