### PR TITLE
Fixed coloredSymbolOnly

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -146,7 +146,7 @@ Module.register("calendar", {
 				var symbolWrapper = document.createElement("td");
 
 				if (this.config.colored && this.config.coloredSymbolOnly) {
-					symbolWrapper.style.cssText = "color:" + this.colorForUrl(event.ulr);
+					symbolWrapper.style.cssText = "color:" + this.colorForUrl(event.url);
 				}
 
 				symbolWrapper.className = "symbol align-right";


### PR DESCRIPTION
I couldn't get @john3300's change from #1275 working, so I looked into it. The event for the color was using the wrong property.

No CHANGELOG update since the original PR had the changelog note already.