### PR TITLE
Changed weatherforecast to use dt_txt field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - In default module currentWeather/currentWeather.js line 296, 300, self.config.animationSpeed can not be found because the notificationReceived function does not have "self" variable.
 - Fixed browser-side code to work on the Midori browser.
 - Fixed issue where heat index was reporting incorrect values in Celsius and Fahrenheit. [#1263](https://github.com/MichMich/MagicMirror/issues/1263)
+- Fixed weatherforecast to use dt_txt field instead of dt to handle timezones better
 
 ### Updated
 - Updated Italian translation

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -333,8 +333,8 @@ Module.register("weatherforecast",{
 			var forecast = data.list[i];
 			this.parserDataWeather(forecast); // hack issue #1017
 
-			var day = moment(forecast.dt, "X").format("ddd");
-			var hour = moment(forecast.dt, "X").format("H");
+			var day = moment(forecast.dt_txt, "YYYY-MM-DD hh:mm:ss").format("ddd");
+			var hour = moment(forecast.dt_txt, "YYYY-MM-DD hh:mm:ss").format("H");
 
 			if (day !== lastDay) {
 				var forecastData = {


### PR DESCRIPTION
Found an issue in weatherforecast module with timezones. Currently my timezone is GMT+3 and the times parsed from dt field are three hours off, thus skewing the forecast. I changed date parsing to dt_txt field that seems to have the local date and time.