### PR TITLE
newsfeed now remembers user configuration settings for descriptions after fullscreen view. Fixes #1282.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed browser-side code to work on the Midori browser.
 - Fixed issue where heat index was reporting incorrect values in Celsius and Fahrenheit. [#1263](https://github.com/MichMich/MagicMirror/issues/1263)
 - Fixed weatherforecast to use dt_txt field instead of dt to handle timezones better
+- newsfeed now remembers to show the description when `"ARTICLE_LESS_DETAILS"` is called if the user wants to always show the description. [#1282](https://github.com/MichMich/MagicMirror/issues/1282)
 
 ### Updated
 - Updated Italian translation

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -67,6 +67,7 @@ Module.register("newsfeed",{
 
 		this.registerFeeds();
 
+		this.isShowingDescription = this.config.showDescription;
 	},
 
 	// Override socket notification handler.
@@ -133,7 +134,7 @@ Module.register("newsfeed",{
 
 			if (this.config.removeStartTags == "description" || this.config.removeStartTags == "both") {
 
-				if (this.config.showDescription) {
+				if (this.isShowingDescription) {
 					for (f=0; f<this.config.startTags.length;f++) {
 						if (this.newsItems[this.activeItem].description.slice(0,this.config.startTags[f].length) == this.config.startTags[f]) {
 							this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].description.slice(this.config.startTags[f].length,this.newsItems[this.activeItem].description.length);
@@ -152,7 +153,7 @@ Module.register("newsfeed",{
 					}
 				}
 
-				if (this.config.showDescription) {
+				if (this.isShowingDescription) {
 					for (f=0; f<this.config.endTags.length;f++) {
 						if (this.newsItems[this.activeItem].description.slice(-this.config.endTags[f].length)==this.config.endTags[f]) {
 							this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0,-this.config.endTags[f].length);
@@ -169,7 +170,7 @@ Module.register("newsfeed",{
 				wrapper.appendChild(title);
 			}
 
-			if (this.config.showDescription) {
+			if (this.isShowingDescription) {
 				var description = document.createElement("div");
 				description.className = "small light" + (!this.config.wrapDescription ? " no-wrap" : "");
 				var txtDesc = this.newsItems[this.activeItem].description;
@@ -323,7 +324,7 @@ Module.register("newsfeed",{
 	},
 
 	resetDescrOrFullArticleAndTimer: function() {
-		this.config.showDescription = false;
+		this.isShowingDescription = this.config.showDescription;
 		this.config.showFullArticle = false;
 		this.scrollPosition = 0;
 		// reset bottom bar alignment
@@ -366,8 +367,8 @@ Module.register("newsfeed",{
 			}
 			// display full article
 			else {
-				this.config.showDescription = !this.config.showDescription;
-				this.config.showFullArticle = !this.config.showDescription;
+				this.isShowingDescription = !this.isShowingDescription;
+				this.config.showFullArticle = !this.isShowingDescription;
 				// make bottom bar align to top to allow scrolling
 				if(this.config.showFullArticle == true){
 					document.getElementsByClassName("region bottom bar")[0].style.bottom = "inherit";
@@ -375,7 +376,7 @@ Module.register("newsfeed",{
 				}
 				clearInterval(timer);
 				timer = null;
-				Log.info(this.name + " - showing " + this.config.showDescription ? "article description" : "full article");
+				Log.info(this.name + " - showing " + this.isShowingDescription ? "article description" : "full article");
 				this.updateDom(100);
 			}
 		} else if(notification == "ARTICLE_SCROLL_UP"){


### PR DESCRIPTION
Added a runtime var `isShowingDescription` that gets reset to user config.
this.config.showDescription no longer mutates during runtime.
Changelog has been updated to include this fix.

Sorry about the notification spam in #1282; the actual PR only has one commit.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!


* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.
