### PR TITLE
Add option to newsfeed for logging errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ability to fetch compliments from a remote server
 - Add regex filtering to calendar module
 - Customize classes for table
+- Added option to newsfeed module to only log error parsing a news article if enabled
 
 ### Changed
 - Upgrade to Electron 2.0.0.

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -80,6 +80,7 @@ The following properties can be configured:
 | `endTags`          | List the tags you would like to have removed at the end of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
 | `prohibitedWords` | Remove news feed item if one of these words is found anywhere in the title (case insensitive and greedy matching) <br><br> **Possible values:** `['word']` or `['word1','word2',...]`
 | `scrollLength` | Scrolls the full news article page by a given number of pixels when a `ARTICLE_MORE_DETAILS` notification is received and the full news article is already displayed.<br><br> **Possible values:** `1` or `10000` <br> **Default value:** `500`
+| `logFeedWarnings` | Log warnings when there is an error parsing a news article. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 
 The `feeds` property contains an array with multiple objects. These objects have the following properties:
 

--- a/modules/default/newsfeed/fetcher.js
+++ b/modules/default/newsfeed/fetcher.js
@@ -14,9 +14,10 @@ var iconv = require("iconv-lite");
  *
  * attribute url string - URL of the news feed.
  * attribute reloadInterval number - Reload interval in milliseconds.
+ * attribute logFeedWarnings boolean - Log warnings when there is an error parsing a news article.
  */
 
-var Fetcher = function(url, reloadInterval, encoding) {
+var Fetcher = function(url, reloadInterval, encoding, logFeedWarnings) {
 	var self = this;
 	if (reloadInterval < 1000) {
 		reloadInterval = 1000;
@@ -60,7 +61,7 @@ var Fetcher = function(url, reloadInterval, encoding) {
 					url: url,
 				});
 
-			} else {
+			} else if (logFeedWarnings) {
 				console.log("Can't parse feed item:");
 				console.log(item);
 				console.log("Title: " + title);

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -37,7 +37,8 @@ Module.register("newsfeed",{
 		startTags: [],
 		endTags: [],
 		prohibitedWords: [],
-		scrollLength: 500
+		scrollLength: 500,
+		logFeedWarnings: false
 	},
 
 	// Define required scripts.

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -46,7 +46,7 @@ module.exports = NodeHelper.create({
 		var fetcher;
 		if (typeof self.fetchers[url] === "undefined") {
 			console.log("Create new news fetcher for url: " + url + " - Interval: " + reloadInterval);
-			fetcher = new Fetcher(url, reloadInterval, encoding);
+			fetcher = new Fetcher(url, reloadInterval, encoding, config.logFeedWarnings);
 
 			fetcher.onReceive(function(fetcher) {
 				self.broadcastFeeds();


### PR DESCRIPTION
- 'logFeedWarnings' added to newsfeed config, defaulted to false
- Only log parse feed errors when logFeedWarnings is true
- Updated README and CHANGELOG
- Fixes #1329 