### PR TITLE
Adding Font Awesome Version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
+## [2.5.0] - Unreleased
+
+*This release is scheduled to be released on 2018-10-01.*
+
+### Added
+
+### Fixed
+
+### Updated
 
 ## [2.4.1] - 2018-07-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "magicmirror",
-  "version": "2.4.1",
+  "version": "2.5.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magicmirror",
-  "version": "2.4.1",
+  "version": "2.5.0-dev",
   "description": "The open source modular smart mirror platform.",
   "main": "js/electron.js",
   "scripts": {


### PR DESCRIPTION
Refer to the following [Issue #1344](https://github.com/MichMich/MagicMirror/issues/1344)

This pull request will give the user the added flexibility to use Font Awesome V5 icons as well as maintaining Font Awesome V4. 

Add FA5 folder to MagicMirror/vendor/node_modules/ file path:
[font-awesome_5.zip](https://github.com/MichMich/MagicMirror/files/2168355/font-awesome_5.zip)

Add FA5 to MagicMirror/vendor/vendor.js file [Line 16]:

`var vendor = {
	"moment.js" : "node_modules/moment/min/moment-with-locales.js",
	"moment-timezone.js" : "node_modules/moment-timezone/builds/moment-timezone-with-data.js",
	"weather-icons.css": "node_modules/weathericons/css/weather-icons.css",
	"weather-icons-wind.css": "node_modules/weathericons/css/weather-icons-wind.css",
    "font-awesome.css": "node_modules/font-awesome/css/font-awesome.min.css",
	"font-awesome5.css": "node_modules/font-awesome_5/css/all.css",
	"nunjucks.js": "node_modules/nunjucks/browser/nunjucks.min.js"
};`

Add to styles list in the MagicMirror/modules/default/calendar/calendar.js file [~Line 51]:

`	// Define required scripts.
	getStyles: function () {
		return ["calendar.css", "font-awesome.css", "font-awesome5.css"];
	},`

This would give the user the ability to select symbols from either FA4 or FA5 within the config.js file, just formatting them correctly as shown below:

```
{
    symbol: "calendar", //FA4 format
    symbol: "fas fa-baseball-ball", //FA5 format
},
```

I'm unsure how to update the changelog? First pull request, so bear with me...