### PR TITLE
Updating the Hungarian localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - French translate for "Feels"
 - Translations for newsfeed module
 - Support for toggling news article in fullscreen
+- Hungarian translation for "Feels" and "Week"
 
 ### Fixed
 - Mixup between german and spanish translation for newsfeed.
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 
 - Swedish translations
+- Hungarian translations for the updatenotification module
 
 ## [2.4.1] - 2018-07-04
 

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -26,9 +26,9 @@
 	"NW": "ÉNy",
 	"NNW": "ÉÉNy",
 
-	"UPDATE_NOTIFICATION": "MagicMirror² elérhető egy frissítés!",
-	"UPDATE_NOTIFICATION_MODULE": "A frissítés {MODULE_NAME} modul néven érhető el.",
-	"UPDATE_INFO": "A jelenlegi telepítés {COMMIT_COUNT} mögött {BRANCH_NAME} ágon található.",
+	"UPDATE_NOTIFICATION": "MagicMirror²-hoz frissítés érhető el.",
+	"UPDATE_NOTIFICATION_MODULE": "A {MODULE_NAME} modulhoz frissítés érhető el.",
+	"UPDATE_INFO": "A jelenlegi telepítés óta {COMMIT_COUNT} commit jelent meg a {BRANCH_NAME} ágon.",
 
 	"FEELS": "Érzet"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -28,5 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² elérhető egy frissítés!",
 	"UPDATE_NOTIFICATION_MODULE": "A frissítés {MODULE_NAME} modul néven érhető el.",
-	"UPDATE_INFO": "A jelenlegi telepítés {COMMIT_COUNT} mögött {BRANCH_NAME} ágon található."
+	"UPDATE_INFO": "A jelenlegi telepítés {COMMIT_COUNT} mögött {BRANCH_NAME} ágon található.",
+
+	"FEELS": "Érzet"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -7,6 +7,8 @@
 	"RUNNING": "Vége lesz",
 	"EMPTY": "Nincs közelgő esemény.",
 
+	"WEEK": "{weekNumber}. hét",
+
 	"N": "É",
 	"NNE": "ÉÉK",
 	"NE": "ÉK",


### PR DESCRIPTION
This PR updates the Hungarian localization with the following:
- ADDED: Missing Hungarian localization for the "WEEK" resource key. 
- ADDED: Missing Hungarian localization for the "FEELS" resource key. 
- CHANGED: The Hungarian localization of the updatenotification module is changed to be more natural, because the existing messages felt like they were created with machine translation, and they were not only unnatural, but also misleading.

The changes are added to the CHANGELOG.md file.

Thanks for creating and maintaining this project open source!