### PR TITLE
Calendar: Absolute dates do not show absolute even if getRelative and urgency are set to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Mixup between german and spanish translation for newsfeed.
+- Fixed close dates to be absolute, if no configured in the config.js - module Calendar
 
 ### Updated
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -295,8 +295,12 @@ Module.register("calendar", {
 								// If event is within 6 hour, display 'in xxx' time format or moment.fromNow()
 								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 							} else {
-								// Otherwise just say 'Today/Tomorrow at such-n-such time'
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar());
+								if(this.config.timeFormat === "absolute") {
+									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
+								} else {
+									// Otherwise just say 'Today/Tomorrow at such-n-such time'
+									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar());
+								}
 							}
 						} else {
 							/* Check to see if the user displays absolute or relative dates with their events


### PR DESCRIPTION
Calendar module shows upcoming events with relative "today" and "tomorrow" even if the config defines all dates to be absolute - with the following configuration parameters:

getRelative: 0
timeFormat: "absolute"
urgency: 0

This patch adds an extra if to check whether timeFormat is absolute for events closer than 48 hours.

Further, it might make sense to refactor the whole time formatting function, as it has checks against both configurable and non-configurable values, and it uses different set of conditions for full day events and events with time frame.