### PR TITLE
RaspBerry Pi Zero W default calendar module fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
+## [2.4.2] - 2018-08-16
+
+### Fixed
+
+- Fix calendar parsing issue for Midori on RasperryPi Zero w, realted to issue #694.
 
 ## [2.4.1] - 2018-07-04
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -436,7 +436,7 @@ Module.register("calendar", {
 
 
 	listContainsEvent: function(eventList, event){
-		for(let evt of eventList){
+		for(var evt of eventList){
 			if(evt.title === event.title && parseInt(evt.startDate) === parseInt(event.startDate)){
 				return true;
 			}


### PR DESCRIPTION
#### Description: ✍️ 
Following this issue https://github.com/MichMich/MagicMirror/issues/694 it seems that the Midori Browser does not recoginize ES6 syntax. Further, the use of 'var' is seen throughout the calendar module excpet on line 439, where the error is reported

#### Issue(s): 🎟 
* #694

#### Example(s): 🔍 

![img_8170](https://user-images.githubusercontent.com/710847/44220483-b9b47d00-a14c-11e8-8bed-8cedc8a5e8de.JPG)
![img_8167](https://user-images.githubusercontent.com/710847/44220489-bd480400-a14c-11e8-9238-6c25b869f2b7.JPG)

#### Documentation/Reference: 📄 
* https://answers.launchpad.net/midori/+question/452559
* https://www.gtk.org/documentation.php
* http://midori-browser.org/faqs/#webkit_version_numbers