### PR TITLE
Making the word "commit" localizable in the UpdateNotification module message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Mixup between german and spanish translation for newsfeed.
 - Fixed close dates to be absolute, if no configured in the config.js - module Calendar
+- The word "commit" in the message of the UpdateNotification module can be localized.
 - Fix for weatherforecast rainfall rounding [#1374](https://github.com/MichMich/MagicMirror/issues/1374)
 - Fix calendar parsing issue for Midori on RasperryPi Zero w, related to issue #694.
 - Fix weather city ID link in sample config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Mixup between german and spanish translation for newsfeed.
 - Fixed close dates to be absolute, if no configured in the config.js - module Calendar
-- The word "commit" in the message of the UpdateNotification module can be localized.
+- Fixed the UpdateNotification module message about new commits in the repository, so they can be correctly localized in singular and plural form.
 - Fix for weatherforecast rainfall rounding [#1374](https://github.com/MichMich/MagicMirror/issues/1374)
 - Fix calendar parsing issue for Midori on RasperryPi Zero w, related to issue #694.
 - Fix weather city ID link in sample config

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -59,7 +59,7 @@ Module.register("updatenotification", {
 			message.appendChild(icon);
 
 			var subtextHtml = this.translate("UPDATE_INFO", {
-				COMMIT_COUNT: this.status.behind + " " + ((this.status.behind == 1) ? "commit" : "commits"),
+				COMMIT_COUNT: this.status.behind,
 				BRANCH_NAME: this.status.current
 			});
 

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -58,7 +58,8 @@ Module.register("updatenotification", {
 			icon.innerHTML = "&nbsp;";
 			message.appendChild(icon);
 
-			var subtextHtml = this.translate("UPDATE_INFO", {
+			var updateInfoKeyName = this.status.behind == 1 ? "UPDATE_INFO_SINGLE" : "UPDATE_INFO_MULTIPLE";
+			var subtextHtml = this.translate(updateInfoKeyName, {
 				COMMIT_COUNT: this.status.behind,
 				BRANCH_NAME: this.status.current
 			});

--- a/tests/configs/data/TranslationTest.json
+++ b/tests/configs/data/TranslationTest.json
@@ -28,5 +28,5 @@
 
   "UPDATE_NOTIFICATION": "MagicMirror² update available.",
   "UPDATE_NOTIFICATION_MODULE": "Update available for MODULE_NAME module.",
-  "UPDATE_INFO": "The current installation is COMMIT_COUNT behind on the BRANCH_NAME branch."
+  "UPDATE_INFO": "The current installation is COMMIT_COUNT commit(s) behind on the BRANCH_NAME branch."
 }

--- a/tests/configs/data/TranslationTest.json
+++ b/tests/configs/data/TranslationTest.json
@@ -28,5 +28,6 @@
 
   "UPDATE_NOTIFICATION": "MagicMirror² update available.",
   "UPDATE_NOTIFICATION_MODULE": "Update available for MODULE_NAME module.",
-  "UPDATE_INFO": "The current installation is COMMIT_COUNT commit(s) behind on the BRANCH_NAME branch."
+  "UPDATE_INFO_SINGLE": "The current installation is COMMIT_COUNT commit behind on the BRANCH_NAME branch.",
+  "UPDATE_INFO_MULTIPLE": "The current installation is COMMIT_COUNT commits behind on the BRANCH_NAME branch."
 }

--- a/tests/configs/data/en.json
+++ b/tests/configs/data/en.json
@@ -28,5 +28,5 @@
 
   "UPDATE_NOTIFICATION": "MagicMirror² update available.",
   "UPDATE_NOTIFICATION_MODULE": "Update available for MODULE_NAME module.",
-  "UPDATE_INFO": "The current installation is COMMIT_COUNT behind on the BRANCH_NAME branch."
+  "UPDATE_INFO": "The current installation is COMMIT_COUNT commit(s) behind on the BRANCH_NAME branch."
 }

--- a/tests/configs/data/en.json
+++ b/tests/configs/data/en.json
@@ -28,5 +28,6 @@
 
   "UPDATE_NOTIFICATION": "MagicMirror² update available.",
   "UPDATE_NOTIFICATION_MODULE": "Update available for MODULE_NAME module.",
-  "UPDATE_INFO": "The current installation is COMMIT_COUNT commit(s) behind on the BRANCH_NAME branch."
+  "UPDATE_INFO_SINGLE": "The current installation is COMMIT_COUNT commit behind on the BRANCH_NAME branch.",
+  "UPDATE_INFO_MULTIPLE": "The current installation is COMMIT_COUNT commits behind on the BRANCH_NAME branch."
 }

--- a/translations/af.json
+++ b/translations/af.json
@@ -26,5 +26,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update beskikbaar.",
 	"UPDATE_NOTIFICATION_MODULE": "Update beskikbaar vir {MODULE_NAME} module.",
-	"UPDATE_INFO": "Die huidige installasie is {COMMIT_COUNT} agter op die {BRANCH_NAME} branch."
+	"UPDATE_INFO": "Die huidige installasie is {COMMIT_COUNT} commit(s) agter op die {BRANCH_NAME} branch."
 }

--- a/translations/af.json
+++ b/translations/af.json
@@ -26,5 +26,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update beskikbaar.",
 	"UPDATE_NOTIFICATION_MODULE": "Update beskikbaar vir {MODULE_NAME} module.",
-	"UPDATE_INFO": "Die huidige installasie is {COMMIT_COUNT} commit(s) agter op die {BRANCH_NAME} branch."
+	"UPDATE_INFO_SINGLE": "Die huidige installasie is {COMMIT_COUNT} commit agter op die {BRANCH_NAME} branch.",
+	"UPDATE_INFO_MULTIPLE": "Die huidige installasie is {COMMIT_COUNT} commits agter op die {BRANCH_NAME} branch."
 }

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "Налична актуализация за MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Налична актуализация за {MODULE_NAME} модул.",
-	"UPDATE_INFO": "Текущата инсталация е изостанала с {COMMIT_COUNT} къмита на клон {BRANCH_NAME}."
+	"UPDATE_INFO": "Текущата инсталация е изостанала с {COMMIT_COUNT} commit(s) къмита на клон {BRANCH_NAME}."
 }

--- a/translations/bg.json
+++ b/translations/bg.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "Налична актуализация за MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Налична актуализация за {MODULE_NAME} модул.",
-	"UPDATE_INFO": "Текущата инсталация е изостанала с {COMMIT_COUNT} commit(s) къмита на клон {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "Текущата инсталация е изостанала с {COMMIT_COUNT} commit къмита на клон {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Текущата инсталация е изостанала с {COMMIT_COUNT} commits къмита на клон {BRANCH_NAME}."
 }

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² actualizació disponible.",
 	"UPDATE_NOTIFICATION_MODULE": "Disponible una actualizació per al mòdul {MODULE_NAME}.",
-	"UPDATE_INFO": "La teva instal·lació actual està {COMMIT_COUNT} canvis darrere de la branca {BRANCH_NAME}."
+	"UPDATE_INFO": "La teva instal·lació actual està {COMMIT_COUNT} commit(s) canvis darrere de la branca {BRANCH_NAME}."
 }

--- a/translations/ca.json
+++ b/translations/ca.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² actualizació disponible.",
 	"UPDATE_NOTIFICATION_MODULE": "Disponible una actualizació per al mòdul {MODULE_NAME}.",
-	"UPDATE_INFO": "La teva instal·lació actual està {COMMIT_COUNT} commit(s) canvis darrere de la branca {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "La teva instal·lació actual està {COMMIT_COUNT} commit canvis darrere de la branca {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "La teva instal·lació actual està {COMMIT_COUNT} commits canvis darrere de la branca {BRANCH_NAME}."
 }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "Dostupná aktualizace pro MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Dostupná aktualizace pro modul {MODULE_NAME}.",
-	"UPDATE_INFO": "Současná instalace je na větvi {BRANCH_NAME} pozadu o {COMMIT_COUNT} commit(s)."
+	"UPDATE_INFO_SINGLE": "Současná instalace je na větvi {BRANCH_NAME} pozadu o {COMMIT_COUNT} commit.",
+	"UPDATE_INFO_MULTIPLE": "Současná instalace je na větvi {BRANCH_NAME} pozadu o {COMMIT_COUNT} commits."
 }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "Dostupná aktualizace pro MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Dostupná aktualizace pro modul {MODULE_NAME}.",
-	"UPDATE_INFO": "Současná instalace je na větvi {BRANCH_NAME} pozadu o {COMMIT_COUNT}."
+	"UPDATE_INFO": "Současná instalace je na větvi {BRANCH_NAME} pozadu o {COMMIT_COUNT} commit(s)."
 }

--- a/translations/cy.json
+++ b/translations/cy.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² mwy diweddar yn barod.",
 	"UPDATE_NOTIFICATION_MODULE": "Mae diweddaraiad ar gyfer y modiwl {MODULE_NAME}.",
-	"UPDATE_INFO": "Mae'r fersiwn bresenol {COMMIT_COUNT} commit tu ôl i'r gangen {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "Mae'r fersiwn bresenol {COMMIT_COUNT} commit tu ôl i'r gangen {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Mae'r fersiwn bresenol {COMMIT_COUNT} commit tu ôl i'r gangen {BRANCH_NAME}."
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -27,5 +27,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² opdatering tilgængelig.",
 	"UPDATE_NOTIFICATION_MODULE": "Opdatering tilgængelig for {MODULE_NAME} modulet.",
-	"UPDATE_INFO": "Den nuværende installation er {COMMIT_COUNT} commit(s) bagud på {BRANCH_NAME} branch'en."
+	"UPDATE_INFO_SINGLE": "Den nuværende installation er {COMMIT_COUNT} commit bagud på {BRANCH_NAME} branch'en.",
+	"UPDATE_INFO_MULTIPLE": "Den nuværende installation er {COMMIT_COUNT} commits bagud på {BRANCH_NAME} branch'en."
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -27,5 +27,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² opdatering tilgængelig.",
 	"UPDATE_NOTIFICATION_MODULE": "Opdatering tilgængelig for {MODULE_NAME} modulet.",
-	"UPDATE_INFO": "Den nuværende installation er {COMMIT_COUNT} bagud på {BRANCH_NAME} branch'en."
+	"UPDATE_INFO": "Den nuværende installation er {COMMIT_COUNT} commit(s) bagud på {BRANCH_NAME} branch'en."
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "Aktualisierung für MagicMirror² verfügbar.",
 	"UPDATE_NOTIFICATION_MODULE": "Aktualisierung für das {MODULE_NAME} Modul verfügbar.",
-	"UPDATE_INFO": "Die aktuelle Installation ist {COMMIT_COUNT} hinter dem {BRANCH_NAME} Branch.",
+	"UPDATE_INFO": "Die aktuelle Installation ist {COMMIT_COUNT} Commit(s) hinter dem {BRANCH_NAME} Branch.",
 	
 	"FEELS": "Gefühlt"
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "Aktualisierung für MagicMirror² verfügbar.",
 	"UPDATE_NOTIFICATION_MODULE": "Aktualisierung für das {MODULE_NAME} Modul verfügbar.",
-	"UPDATE_INFO": "Die aktuelle Installation ist {COMMIT_COUNT} Commit(s) hinter dem {BRANCH_NAME} Branch.",
+	"UPDATE_INFO_SINGLE": "Die aktuelle Installation ist {COMMIT_COUNT} Commit hinter dem {BRANCH_NAME} Branch.",
+	"UPDATE_INFO_MULTIPLE": "Die aktuelle Installation ist {COMMIT_COUNT} Commits hinter dem {BRANCH_NAME} Branch.",
 	
 	"FEELS": "Gefühlt"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update available.",
 	"UPDATE_NOTIFICATION_MODULE": "Update available for {MODULE_NAME} module.",
-	"UPDATE_INFO": "The current installation is {COMMIT_COUNT} behind on the {BRANCH_NAME} branch.",
+	"UPDATE_INFO": "The current installation is {COMMIT_COUNT} commit(s) behind on the {BRANCH_NAME} branch.",
 	
 	"FEELS": "Feels"
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update available.",
 	"UPDATE_NOTIFICATION_MODULE": "Update available for {MODULE_NAME} module.",
-	"UPDATE_INFO": "The current installation is {COMMIT_COUNT} commit(s) behind on the {BRANCH_NAME} branch.",
+	"UPDATE_INFO_SINGLE": "The current installation is {COMMIT_COUNT} commit behind on the {BRANCH_NAME} branch.",
+	"UPDATE_INFO_MULTIPLE": "The current installation is {COMMIT_COUNT} commits behind on the {BRANCH_NAME} branch.",
 	
 	"FEELS": "Feels"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² actualización disponible.",
 	"UPDATE_NOTIFICATION_MODULE": "Disponible una actualización para el módulo {MODULE_NAME}.",
-	"UPDATE_INFO": "Tu actual instalación está {COMMIT_COUNT} commit(s) cambios detrás de la rama {BRANCH_NAME}.",
+	"UPDATE_INFO_SINGLE": "Tu actual instalación está {COMMIT_COUNT} commit cambios detrás de la rama {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Tu actual instalación está {COMMIT_COUNT} commits cambios detrás de la rama {BRANCH_NAME}.",
 	
 	"FEELS": "Sensación térmica de"
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² actualización disponible.",
 	"UPDATE_NOTIFICATION_MODULE": "Disponible una actualización para el módulo {MODULE_NAME}.",
-	"UPDATE_INFO": "Tu actual instalación está {COMMIT_COUNT} cambios detrás de la rama {BRANCH_NAME}.",
+	"UPDATE_INFO": "Tu actual instalación está {COMMIT_COUNT} commit(s) cambios detrás de la rama {BRANCH_NAME}.",
 	
 	"FEELS": "Sensación térmica de"
 }

--- a/translations/et.json
+++ b/translations/et.json
@@ -26,5 +26,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²´le uuendus saadaval.",
 	"UPDATE_NOTIFICATION_MODULE": "Uuendus saadaval {MODULE_NAME} moodulile.",
-	"UPDATE_INFO": "Praegune paigaldus on {COMMIT_COUNT} tagapool {BRANCH_NAME} harul."
+	"UPDATE_INFO": "Praegune paigaldus on {COMMIT_COUNT} commit(s) tagapool {BRANCH_NAME} harul."
 }

--- a/translations/et.json
+++ b/translations/et.json
@@ -26,5 +26,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²´le uuendus saadaval.",
 	"UPDATE_NOTIFICATION_MODULE": "Uuendus saadaval {MODULE_NAME} moodulile.",
-	"UPDATE_INFO": "Praegune paigaldus on {COMMIT_COUNT} commit(s) tagapool {BRANCH_NAME} harul."
+	"UPDATE_INFO_SINGLE": "Praegune paigaldus on {COMMIT_COUNT} commit tagapool {BRANCH_NAME} harul.",
+	"UPDATE_INFO_MULTIPLE": "Praegune paigaldus on {COMMIT_COUNT} commits tagapool {BRANCH_NAME} harul."
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "Une mise à jour de MagicMirror² est disponible",
 	"UPDATE_NOTIFICATION_MODULE": "Une mise à jour est disponible pour le module {MODULE_NAME} .",
-	"UPDATE_INFO": "L'installation actuelle est {COMMIT_COUNT} commit(s) en retard sur la branche {BRANCH_NAME} .",
+	"UPDATE_INFO_SINGLE": "L'installation actuelle est {COMMIT_COUNT} commit en retard sur la branche {BRANCH_NAME} .",
+	"UPDATE_INFO_MULTIPLE": "L'installation actuelle est {COMMIT_COUNT} commits en retard sur la branche {BRANCH_NAME} .",
 
 	"FEELS": "Ressenti"
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "Une mise à jour de MagicMirror² est disponible",
 	"UPDATE_NOTIFICATION_MODULE": "Une mise à jour est disponible pour le module {MODULE_NAME} .",
-	"UPDATE_INFO": "L'installation actuelle est {COMMIT_COUNT} en retard sur la branche {BRANCH_NAME} .",
+	"UPDATE_INFO": "L'installation actuelle est {COMMIT_COUNT} commit(s) en retard sur la branche {BRANCH_NAME} .",
 
 	"FEELS": "Ressenti"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²-hoz frissítés érhető el.",
 	"UPDATE_NOTIFICATION_MODULE": "A {MODULE_NAME} modulhoz frissítés érhető el.",
-	"UPDATE_INFO": "A jelenlegi telepítés óta {COMMIT_COUNT} commit jelent meg a {BRANCH_NAME} ágon.",
+	"UPDATE_INFO": "A jelenlegi telepítés óta {COMMIT_COUNT} új commit jelent meg a {BRANCH_NAME} ágon.",
 
 	"FEELS": "Érzet"
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²-hoz frissítés érhető el.",
 	"UPDATE_NOTIFICATION_MODULE": "A {MODULE_NAME} modulhoz frissítés érhető el.",
-	"UPDATE_INFO": "A jelenlegi telepítés óta {COMMIT_COUNT} új commit jelent meg a {BRANCH_NAME} ágon.",
+	"UPDATE_INFO_SINGLE": "A jelenlegi telepítés óta {COMMIT_COUNT} új commit jelent meg a {BRANCH_NAME} ágon.",
+	"UPDATE_INFO_MULTIPLE": "A jelenlegi telepítés óta {COMMIT_COUNT} új commit jelent meg a {BRANCH_NAME} ágon.",
 
 	"FEELS": "Érzet"
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "Memperbarui MagicMirror² tersedia.",
 	"UPDATE_NOTIFICATION_MODULE": "Memperbarui tersedia untuk modul {MODULE_NAME}.",
-	"UPDATE_INFO": "Instalasi saat ini tertinggal {COMMIT_COUNT} pada cabang {BRANCH_NAME}."
+	"UPDATE_INFO": "Instalasi saat ini tertinggal {COMMIT_COUNT} commit(s) pada cabang {BRANCH_NAME}."
 }

--- a/translations/id.json
+++ b/translations/id.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "Memperbarui MagicMirror² tersedia.",
 	"UPDATE_NOTIFICATION_MODULE": "Memperbarui tersedia untuk modul {MODULE_NAME}.",
-	"UPDATE_INFO": "Instalasi saat ini tertinggal {COMMIT_COUNT} commit(s) pada cabang {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "Instalasi saat ini tertinggal {COMMIT_COUNT} commit pada cabang {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Instalasi saat ini tertinggal {COMMIT_COUNT} commits pada cabang {BRANCH_NAME}."
 }

--- a/translations/is.json
+++ b/translations/is.json
@@ -26,5 +26,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² uppfærsla í boði.",
 	"UPDATE_NOTIFICATION_MODULE": "Uppfærsla í boði fyrir {MODULE_NAME} module.",
-	"UPDATE_INFO": "Núverandi kerfi er {COMMIT_COUNT} á eftir {BRANCH_NAME} branchinu."
+	"UPDATE_INFO": "Núverandi kerfi er {COMMIT_COUNT} commit(s) á eftir {BRANCH_NAME} branchinu."
 }

--- a/translations/is.json
+++ b/translations/is.json
@@ -26,5 +26,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² uppfærsla í boði.",
 	"UPDATE_NOTIFICATION_MODULE": "Uppfærsla í boði fyrir {MODULE_NAME} module.",
-	"UPDATE_INFO": "Núverandi kerfi er {COMMIT_COUNT} commit(s) á eftir {BRANCH_NAME} branchinu."
+	"UPDATE_INFO_SINGLE": "Núverandi kerfi er {COMMIT_COUNT} commit á eftir {BRANCH_NAME} branchinu.",
+	"UPDATE_INFO_MULTIPLE": "Núverandi kerfi er {COMMIT_COUNT} commits á eftir {BRANCH_NAME} branchinu."
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "E' disponibile un aggiornamento di MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "E' disponibile un aggiornamento del modulo {MODULE_NAME}.",
-	"UPDATE_INFO": "L'installazione è {COMMIT_COUNT} commit(s) indietro rispetto all'attuale branch {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "L'installazione è {COMMIT_COUNT} commit indietro rispetto all'attuale branch {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "L'installazione è {COMMIT_COUNT} commits indietro rispetto all'attuale branch {BRANCH_NAME}."
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "E' disponibile un aggiornamento di MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "E' disponibile un aggiornamento del modulo {MODULE_NAME}.",
-	"UPDATE_INFO": "L'installazione è {COMMIT_COUNT} indietro rispetto all'attuale branch {BRANCH_NAME}."
+	"UPDATE_INFO": "L'installazione è {COMMIT_COUNT} commit(s) indietro rispetto all'attuale branch {BRANCH_NAME}."
 }

--- a/translations/kr.json
+++ b/translations/kr.json
@@ -26,5 +26,6 @@
 
 	"UPDATE_NOTIFICATION": "새로운 MagicMirror² 업데이트가 있습니다.",
 	"UPDATE_NOTIFICATION_MODULE": "{MODULE_NAME} 모듈에서 사용 가능한 업데이트 입니다.",
-	"UPDATE_INFO": "설치할 {COMMIT_COUNT} commit(s) 는 {BRANCH_NAME} 분기에 해당됩니다."
+	"UPDATE_INFO_SINGLE": "설치할 {COMMIT_COUNT} commit 는 {BRANCH_NAME} 분기에 해당됩니다.",
+	"UPDATE_INFO_MULTIPLE": "설치할 {COMMIT_COUNT} commits 는 {BRANCH_NAME} 분기에 해당됩니다."
 }

--- a/translations/kr.json
+++ b/translations/kr.json
@@ -26,5 +26,5 @@
 
 	"UPDATE_NOTIFICATION": "새로운 MagicMirror² 업데이트가 있습니다.",
 	"UPDATE_NOTIFICATION_MODULE": "{MODULE_NAME} 모듈에서 사용 가능한 업데이트 입니다.",
-	"UPDATE_INFO": "설치할 {COMMIT_COUNT} 는 {BRANCH_NAME} 분기에 해당됩니다."
+	"UPDATE_INFO": "설치할 {COMMIT_COUNT} commit(s) 는 {BRANCH_NAME} 분기에 해당됩니다."
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²-oppdatering er tilgjengelig.",
 	"UPDATE_NOTIFICATION_MODULE": "Oppdatering tilgjengelig for modulen {MODULE_NAME}.",
-	"UPDATE_INFO": "Nåværende installasjon er {COMMIT_COUNT} commit(s) bak {BRANCH_NAME} grenen.",
+	"UPDATE_INFO_SINGLE": "Nåværende installasjon er {COMMIT_COUNT} commit bak {BRANCH_NAME} grenen.",
+	"UPDATE_INFO_MULTIPLE": "Nåværende installasjon er {COMMIT_COUNT} commits bak {BRANCH_NAME} grenen.",
 	
 	"FEELS": "Føles som"
 }

--- a/translations/nb.json
+++ b/translations/nb.json
@@ -28,7 +28,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror²-oppdatering er tilgjengelig.",
 	"UPDATE_NOTIFICATION_MODULE": "Oppdatering tilgjengelig for modulen {MODULE_NAME}.",
-	"UPDATE_INFO": "Nåværende installasjon er {COMMIT_COUNT} bak {BRANCH_NAME} grenen.",
+	"UPDATE_INFO": "Nåværende installasjon er {COMMIT_COUNT} commit(s) bak {BRANCH_NAME} grenen.",
 	
 	"FEELS": "Føles som"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -26,7 +26,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update beschikbaar.",
 	"UPDATE_NOTIFICATION_MODULE": "Update beschikbaar voor {MODULE_NAME} module.",
-	"UPDATE_INFO": "De huidige installatie loopt {COMMIT_COUNT} achter op de {BRANCH_NAME} branch.",
+	"UPDATE_INFO": "De huidige installatie loopt {COMMIT_COUNT} commit(s) achter op de {BRANCH_NAME} branch.",
 	
 	"FEELS": "Gevoelstemperatuur"
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -26,7 +26,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² update beschikbaar.",
 	"UPDATE_NOTIFICATION_MODULE": "Update beschikbaar voor {MODULE_NAME} module.",
-	"UPDATE_INFO": "De huidige installatie loopt {COMMIT_COUNT} commit(s) achter op de {BRANCH_NAME} branch.",
+	"UPDATE_INFO_SINGLE": "De huidige installatie loopt {COMMIT_COUNT} commit achter op de {BRANCH_NAME} branch.",
+	"UPDATE_INFO_MULTIPLE": "De huidige installatie loopt {COMMIT_COUNT} commits achter op de {BRANCH_NAME} branch.",
 	
 	"FEELS": "Gevoelstemperatuur"
 }

--- a/translations/nn.json
+++ b/translations/nn.json
@@ -26,7 +26,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² oppdatering er tilgjengeleg.",
 	"UPDATE_NOTIFICATION_MODULE": "Oppdatering tilgjengeleg for modulen {MODULE_NAME}.",
-	"UPDATE_INFO": "noverande installasjon er {COMMIT_COUNT} commit(s) bak {BRANCH_NAME} greinen.",
+	"UPDATE_INFO_SINGLE": "noverande installasjon er {COMMIT_COUNT} commit bak {BRANCH_NAME} greinen.",
+	"UPDATE_INFO_MULTIPLE": "noverande installasjon er {COMMIT_COUNT} commits bak {BRANCH_NAME} greinen.",
 	
 	"FEELS": "Kjenst som"
 }

--- a/translations/nn.json
+++ b/translations/nn.json
@@ -26,7 +26,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² oppdatering er tilgjengeleg.",
 	"UPDATE_NOTIFICATION_MODULE": "Oppdatering tilgjengeleg for modulen {MODULE_NAME}.",
-	"UPDATE_INFO": "noverande installasjon er {COMMIT_COUNT} bak {BRANCH_NAME} greinen.",
+	"UPDATE_INFO": "noverande installasjon er {COMMIT_COUNT} commit(s) bak {BRANCH_NAME} greinen.",
 	
 	"FEELS": "Kjenst som"
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -28,8 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "DostÄ™pna jest aktualizacja MagicMirrorÂ².",
 	"UPDATE_NOTIFICATION_MODULE": "DostÄ™pna jest aktualizacja moduÅ‚u {MODULE_NAME}.",
-	"UPDATE_INFO_SINGLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitów od ga³êzi {BRANCH_NAME}.", 
-	"UPDATE_INFO_MULTIPLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitów od ga³êzi {BRANCH_NAME}.",	
-		
+	"UPDATE_INFO_SINGLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitÃ³w od gaÅ‚Ä™zi {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitÃ³w od gaÅ‚Ä™zi {BRANCH_NAME}.",
+
 	"FEELS": "Odczuwalna"
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -28,7 +28,8 @@
 
 	"UPDATE_NOTIFICATION": "DostÄ™pna jest aktualizacja MagicMirrorÂ².",
 	"UPDATE_NOTIFICATION_MODULE": "DostÄ™pna jest aktualizacja moduÅ‚u {MODULE_NAME}.",
-	"UPDATE_INFO": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitÃ³w od gaÅ‚Ä™zi {BRANCH_NAME}.",
+	"UPDATE_INFO_SINGLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitów od ga³êzi {BRANCH_NAME}.", 
+	"UPDATE_INFO_MULTIPLE": "Zainstalowana wersja odbiega o {COMMIT_COUNT} commitów od ga³êzi {BRANCH_NAME}.",	
 		
 	"FEELS": "Odczuwalna"
 }

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -25,5 +25,6 @@
 
 	"UPDATE_NOTIFICATION": "Nova atualização para MagicMirror disponível.",
 	"UPDATE_NOTIFICATION_MODULE": "Atualização para o módulo {MODULE_NAME} disponível.",
-	"UPDATE_INFO": "Sua versão atual é a {COMMIT_COUNT} commit(s) dentro do seguinte branch {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "Sua versão atual é a {COMMIT_COUNT} commit dentro do seguinte branch {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Sua versão atual é a {COMMIT_COUNT} commits dentro do seguinte branch {BRANCH_NAME}."
 }

--- a/translations/pt-br.json
+++ b/translations/pt-br.json
@@ -25,5 +25,5 @@
 
 	"UPDATE_NOTIFICATION": "Nova atualização para MagicMirror disponível.",
 	"UPDATE_NOTIFICATION_MODULE": "Atualização para o módulo {MODULE_NAME} disponível.",
-	"UPDATE_INFO": "Sua versão atual é a {COMMIT_COUNT} dentro do seguinte branch {BRANCH_NAME}."
+	"UPDATE_INFO": "Sua versão atual é a {COMMIT_COUNT} commit(s) dentro do seguinte branch {BRANCH_NAME}."
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -27,5 +27,6 @@
   
 	"UPDATE_NOTIFICATION": "Atualização do MagicMirror² disponível.",
 	"UPDATE_NOTIFICATION_MODULE": "Atualização para o módulo {MODULE_NAME} disponível.",
-	"UPDATE_INFO": "A instalação atual está {COMMIT_COUNT} commit(s) atrasada no branch {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "A instalação atual está {COMMIT_COUNT} commit atrasada no branch {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "A instalação atual está {COMMIT_COUNT} commits atrasada no branch {BRANCH_NAME}."
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -27,5 +27,5 @@
   
 	"UPDATE_NOTIFICATION": "Atualização do MagicMirror² disponível.",
 	"UPDATE_NOTIFICATION_MODULE": "Atualização para o módulo {MODULE_NAME} disponível.",
-	"UPDATE_INFO": "A instalação atual está {COMMIT_COUNT} atrasada no branch {BRANCH_NAME}."
+	"UPDATE_INFO": "A instalação atual está {COMMIT_COUNT} commit(s) atrasada no branch {BRANCH_NAME}."
 }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "Un update este disponibil pentru MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Un update este disponibil pentru modulul {MODULE_NAME}.",
-	"UPDATE_INFO": "Există {COMMIT_COUNT} commit-uri noi pe branch-ul {BRANCH_NAME}."
+	"UPDATE_INFO_SINGLE": "Există {COMMIT_COUNT} commit-uri noi pe branch-ul {BRANCH_NAME}.",
+	"UPDATE_INFO_MULTIPLE": "Există {COMMIT_COUNT} commit-uri noi pe branch-ul {BRANCH_NAME}."
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -28,5 +28,5 @@
 
 	"UPDATE_NOTIFICATION": "Есть обновление для MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Есть обновление для {MODULE_NAME} модуля.",
-	"UPDATE_INFO": "Данная инсталляция позади {BRANCH_NAME} ветки на {COMMIT_COUNT} коммитов."
+	"UPDATE_INFO": "Данная инсталляция позади {BRANCH_NAME} commit(s) ветки на {COMMIT_COUNT} коммитов."
 }

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -28,5 +28,6 @@
 
 	"UPDATE_NOTIFICATION": "Есть обновление для MagicMirror².",
 	"UPDATE_NOTIFICATION_MODULE": "Есть обновление для {MODULE_NAME} модуля.",
-	"UPDATE_INFO": "Данная инсталляция позади {BRANCH_NAME} commit(s) ветки на {COMMIT_COUNT} коммитов."
+	"UPDATE_INFO_SINGLE": "Данная инсталляция позади {BRANCH_NAME} commit ветки на {COMMIT_COUNT} коммитов.",
+	"UPDATE_INFO_MULTIPLE": "Данная инсталляция позади {BRANCH_NAME} commits ветки на {COMMIT_COUNT} коммитов."
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -29,7 +29,8 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² uppdatering finns tillgänglig.",
 	"UPDATE_NOTIFICATION_MODULE": "Uppdatering finns tillgänglig av {MODULE_NAME} modulen.",
-	"UPDATE_INFO": "Denna installation ligger {COMMIT_COUNT} commit(s) steg bakom {BRANCH_NAME} grenen.",
+	"UPDATE_INFO_SINGLE": "Denna installation ligger {COMMIT_COUNT} commit steg bakom {BRANCH_NAME} grenen.",
+	"UPDATE_INFO_MULTIPLE": "Denna installation ligger {COMMIT_COUNT} commits steg bakom {BRANCH_NAME} grenen.",
 
 	"FEELS": "Känns som"
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -29,7 +29,7 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² uppdatering finns tillgänglig.",
 	"UPDATE_NOTIFICATION_MODULE": "Uppdatering finns tillgänglig av {MODULE_NAME} modulen.",
-	"UPDATE_INFO": "Denna installation ligger {COMMIT_COUNT} steg bakom {BRANCH_NAME} grenen.",
+	"UPDATE_INFO": "Denna installation ligger {COMMIT_COUNT} commit(s) steg bakom {BRANCH_NAME} grenen.",
 
 	"FEELS": "Känns som"
 }

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -26,5 +26,5 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² 有新的更新",
 	"UPDATE_NOTIFICATION_MODULE": "模块 {MODULE_NAME} 可更新",
-	"UPDATE_INFO": "当前已安装版本为 {COMMIT_COUNT} 落后于分支 {BRANCH_NAME} "
+	"UPDATE_INFO": "当前已安装版本为 {COMMIT_COUNT} commit(s) 落后于分支 {BRANCH_NAME} "
 }

--- a/translations/zh-cn.json
+++ b/translations/zh-cn.json
@@ -26,5 +26,6 @@
 
 	"UPDATE_NOTIFICATION": "MagicMirror² 有新的更新",
 	"UPDATE_NOTIFICATION_MODULE": "模块 {MODULE_NAME} 可更新",
-	"UPDATE_INFO": "当前已安装版本为 {COMMIT_COUNT} commit(s) 落后于分支 {BRANCH_NAME} "
+	"UPDATE_INFO_SINGLE": "当前已安装版本为 {COMMIT_COUNT} commit 落后于分支 {BRANCH_NAME} ",
+	"UPDATE_INFO_MULTIPLE": "当前已安装版本为 {COMMIT_COUNT} commits 落后于分支 {BRANCH_NAME} "
 }


### PR DESCRIPTION
This PR changes the UPDATE_INFO message used by the UpdateNotification module: the COMMIT_COUNT placeholder does not contain the word "commit" or "commits" any more, so language files can independently localize them.

Instead of introducing a logic to use the singular or the plural form of the word ("commit" or "commits"), I added the word "commit(s)" to the language files.

Note that some language files already contained this word in some form, that's why not all language files are affected by this change. I can confirm that the Hungarian localization is perfect after this change.

This PR may fix Issue #1368 .

Thanks for reviewing!