### PR TITLE
ClientOnly: Global variable name used in callback function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+## [2.4.2] - 2018-08-26
+
+### Fixed
+
+- Fixed issue with clientonly not updating with IP address and port provided on command line.
+
 ## [2.4.1] - 2018-07-04
 
 ### Fixed

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -62,13 +62,13 @@
 	// Only start the client if a non-local server was provided
 	if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].indexOf(config.address) === -1) {
 		getServerConfig(`http://${config.address}:${config.port}/config/`)
-			.then(function (config) {
+			.then(function (configReturn) {
 				// Pass along the server config via an environment variable
 				var env = Object.create(process.env);
 				var options = { env: env };
-				config.address = config.address;
-				config.port = config.port;
-				env.config = JSON.stringify(config);
+				configReturn.address = config.address;
+				configReturn.port = config.port;
+				env.config = JSON.stringify(configReturn);
 
 				// Spawn electron application
 				const electron = require("electron");


### PR DESCRIPTION
The global 'config' variable is used in the callback function, changed to local one. Unwanted behaviour when accessing server on docker or if using 0.0.0.0 or blank address in config file as it just passes this to electron to display.
