### PR TITLE
Prioritize the address provided instead of the server version

### DIFF
--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -62,13 +62,13 @@
 	// Only start the client if a non-local server was provided
 	if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].indexOf(config.address) === -1) {
 		getServerConfig(`http://${config.address}:${config.port}/config/`)
-			.then(function (config) {
+			.then(function (serverconfig) {
 				// Pass along the server config via an environment variable
 				var env = Object.create(process.env);
 				var options = { env: env };
-				config.address = config.address;
-				config.port = config.port;
-				env.config = JSON.stringify(config);
+				serverconfig.address = config.address;
+				serverconfig.port = config.port;
+				env.config = JSON.stringify(serverconfig);
 
 				// Spawn electron application
 				const electron = require("electron");


### PR DESCRIPTION
The address variable on the remote server can be set differently (e.g to localhost) than the one provided when calling node clientonly. This is especially true, if MM is running in a Docker. 
The address variable was overwritten with the one fetched from the remote server before spawning the electron application which could not find the server in return.

This is my first ever contribution to a collaborative coding project and I am not sure, what the request below means. I hope, switching the base from master to develop was, what you meant.

Thanks for this great project! 

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!


* Does the pull request solve a **related** issue?
* If so, can you reference the issue?
* What does the pull request accomplish? Use a list if needed.
* If it includes major visual changes please add screenshots.