### PR TITLE
Multi-line compliments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *This release is scheduled to be released on 2018-10-01.*
 
 ### Added
+- Support multi-line compliments
 - Simplified Chinese translation for "Feels"
 - Polish translate for "Feels"
 - French translate for "Feels"

--- a/css/main.css
+++ b/css/main.css
@@ -128,6 +128,10 @@ sup {
   text-overflow: ellipsis;
 }
 
+.pre-line {
+  white-space: pre-line;
+}
+
 /**
  * Region Definitions.
  */

--- a/modules/default/compliments/README.md
+++ b/modules/default/compliments/README.md
@@ -107,6 +107,13 @@ config: {
 }
 ````
 
+#### Multi-line compliments:
+Use `\n` to split compliment text into multiple lines, e.g. `First line.\nSecond line.` will be shown as:
+```
+First line.
+Second line.
+```
+
 ### External Compliment File
 You may specify an external file that contains the three compliment arrays. This is particularly useful if you have a
 large number of compliments and do not wish to crowd your `config.js` file with a large array of compliments.

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -160,7 +160,7 @@ Module.register("compliments", {
 		var compliment = document.createTextNode(complimentText);
 		var wrapper = document.createElement("div");
 		wrapper.className = this.config.classes ? this.config.classes : "thin xlarge bright";
-		wrapper.appendChild(compliment);
+		wrapper.innerHTML = complimentText.replace(/\n/g, '<br>');
 
 		return wrapper;
 	},

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -157,15 +157,10 @@ Module.register("compliments", {
 	getDom: function() {
 		var complimentText = this.randomCompliment();
 
+		var compliment = document.createTextNode(complimentText);
 		var wrapper = document.createElement("div");
-		wrapper.className = this.config.classes ? this.config.classes : "thin xlarge bright";
-		complimentText.split("\n").forEach(function(line, index) {
-			if (index > 0) {
-				wrapper.appendChild(document.createElement("br"));
-			}
-			wrapper.appendChild(document.createTextNode(line));
-
-		});
+		wrapper.className = this.config.classes ? this.config.classes : "thin xlarge bright pre-line";
+		wrapper.appendChild(compliment);
 
 		return wrapper;
 	},

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -157,10 +157,15 @@ Module.register("compliments", {
 	getDom: function() {
 		var complimentText = this.randomCompliment();
 
-		var compliment = document.createTextNode(complimentText);
 		var wrapper = document.createElement("div");
 		wrapper.className = this.config.classes ? this.config.classes : "thin xlarge bright";
-		wrapper.innerHTML = complimentText.replace(/\n/g, '<br>');
+		complimentText.split("\n").forEach(function(line, index) {
+			if (index > 0) {
+				wrapper.appendChild(document.createElement("br"));
+			}
+			wrapper.appendChild(document.createTextNode(line));
+
+		});
 
 		return wrapper;
 	},


### PR DESCRIPTION
Allows multi-line compliments by supporting `\n` (newline) character in compliment text.

For example, in your `config.js`:
```JavaScript
{
    module: "compliments",
    position: "lower_third",
    config: {
        compliments: {
            anytime: [ 'Blackbird singing in the dead of night\nTake these broken wings and learn to fly.' ]
        }
    }
}
```

Will be shown in two lines:
```
Blackbird singing in the dead of night
Take these broken wings and learn to fly.
```

This is ideal for lyrics or poems.