### PR TITLE
Ignore RRULE errors for unparseable elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Allow to parse recurring calendar events where the start date is before 1900
 - Fixed Polish translation for Single Update Info
+- Ignore entries with unparseable details in the calendar module
 
 ### Updated
 - The default calendar setting `showEnd` is changed to `false`.

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -171,7 +171,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 					var geo = event.geo || false;
 					var description = event.description || false;
 
-					if (typeof event.rrule != "undefined" && !isFacebookBirthday) {
+					if (typeof event.rrule != "undefined" && event.rrule != null && !isFacebookBirthday) {
 						var rule = event.rrule;
 
 						// can cause problems with e.g. birthdays before 1900

--- a/modules/default/calendar/vendor/ical.js/node-ical.js
+++ b/modules/default/calendar/vendor/ical.js/node-ical.js
@@ -44,7 +44,13 @@ ical.objectHandlers['END'] = function(val, params, curr, stack){
       rule += ' EXDATE:' + curr.exdates[i].toISOString().replace(/[-:]/g, '');
       rule = rule.replace(/\.[0-9]{3}/, '');
     }
-    curr.rrule = rrulestr(rule);
+    try {
+      curr.rrule = rrulestr(rule);
+    }
+    catch(err) {
+      console.log("Unrecognised element in calendar feed, ignoring: " + rule);
+      curr.rrule = null;
+    }
   }
   return originalEnd.call(this, val, params, curr, stack);
 }


### PR DESCRIPTION
While using the calendar module with my private ICS google calendar field, I got errors from an event that was created many years ago via Evolution:

```
Error: unsupported RRULE parm: X-EVOLUTION-ENDDATE=20110725T140000Z
```

This PR catches the rrule error at the point of parsing in ical.js and ignores them, with a log message including the element that has been ignored.
This allows the calendar module to display the events that are validly parseable as otherwise the exception halts the parsing of the feed and no calendar is ever displayed.

