### PR TITLE
Fading for dateheaders, fixed bug for fulldayevents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Screenshot for the current weather
 - Screenshot for the weather forecast module
 - Portuguese translation for "Feels"
+- Fading for dateheaders timeFormat in Calendar [#1464](https://github.com/MichMich/MagicMirror/issues/1464)
 
 ### Fixed
 - Allow to parse recurring calendar events where the start date is before 1900
 - Fixed Polish translation for Single Update Info
 - Ignore entries with unparseable details in the calendar module
+- Bug showing FullDayEvents one day too long in calendar fixed 
 
 ### Updated
 - The default calendar setting `showEnd` is changed to `false`.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -144,6 +144,15 @@ Module.register("calendar", {
 			return wrapper;
 		}
 
+		if (this.config.fade && this.config.fadePoint < 1) {
+			if (this.config.fadePoint < 0) {
+				this.config.fadePoint = 0;
+			}
+			var startFade = events.length * this.config.fadePoint;
+			var fadeSteps = events.length - startFade;
+		}
+		
+		var currentFadeStep = 0;
 		var lastSeenDate = "";
 
 		for (var e in events) {
@@ -160,6 +169,10 @@ Module.register("calendar", {
 					dateRow.appendChild(dateCell);
 					wrapper.appendChild(dateRow);
 
+					if (e >= startFade) {			//fading
+						currentFadeStep = e - startFade;
+						dateRow.style.opacity = 1 - (1 / fadeSteps * currentFadeStep);
+					}
 
 					lastSeenDate = dateAsString;
 				}
@@ -242,22 +255,7 @@ Module.register("calendar", {
 					timeWrapper.className = "time light " + timeClass;
 					timeWrapper.align = "left";
 					timeWrapper.style.paddingLeft = "2px";
-					var timeFormatString = "";
-					switch (config.timeFormat) {
-					case 12: {
-						timeFormatString = "h:mm A";
-						break;
-					}
-					case 24: {
-						timeFormatString = "HH:mm";
-						break;
-					}
-					default: {
-						timeFormatString = "HH:mm";
-						break;
-					}
-					}
-					timeWrapper.innerHTML = moment(event.startDate, "x").format(timeFormatString);
+					timeWrapper.innerHTML = moment(event.startDate, "x").format('LT');
 					eventWrapper.appendChild(timeWrapper);
 					titleWrapper.align = "right";
 				}
@@ -275,6 +273,8 @@ Module.register("calendar", {
 				var oneHour = oneMinute * 60;
 				var oneDay = oneHour * 24;
 				if (event.fullDayEvent) {
+					//subtract one second so that fullDayEvents end at 23:59:59, and not at 0:00:00 one the next day
+					event.endDate -= oneSecond;		
 					if (event.today) {
 						timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
 					} else if (event.startDate - now < oneDay && event.startDate - now > 0) {
@@ -366,19 +366,12 @@ Module.register("calendar", {
 			wrapper.appendChild(eventWrapper);
 
 			// Create fade effect.
-			if (this.config.fade && this.config.fadePoint < 1) {
-				if (this.config.fadePoint < 0) {
-					this.config.fadePoint = 0;
-				}
-				var startingPoint = events.length * this.config.fadePoint;
-				var steps = events.length - startingPoint;
-				if (e >= startingPoint) {
-					var currentStep = e - startingPoint;
-					eventWrapper.style.opacity = 1 - (1 / steps * currentStep);
-				}
+			if (e >= startFade) {
+				currentFadeStep = e - startFade;
+				eventWrapper.style.opacity = 1 - (1 / fadeSteps * currentFadeStep);
 			}
 		}
-
+		
 		return wrapper;
 	},
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -151,7 +151,7 @@ Module.register("calendar", {
 			var startFade = events.length * this.config.fadePoint;
 			var fadeSteps = events.length - startFade;
 		}
-		
+
 		var currentFadeStep = 0;
 		var lastSeenDate = "";
 
@@ -255,7 +255,7 @@ Module.register("calendar", {
 					timeWrapper.className = "time light " + timeClass;
 					timeWrapper.align = "left";
 					timeWrapper.style.paddingLeft = "2px";
-					timeWrapper.innerHTML = moment(event.startDate, "x").format('LT');
+					timeWrapper.innerHTML = moment(event.startDate, "x").format("LT");
 					eventWrapper.appendChild(timeWrapper);
 					titleWrapper.align = "right";
 				}
@@ -274,7 +274,7 @@ Module.register("calendar", {
 				var oneDay = oneHour * 24;
 				if (event.fullDayEvent) {
 					//subtract one second so that fullDayEvents end at 23:59:59, and not at 0:00:00 one the next day
-					event.endDate -= oneSecond;		
+					event.endDate -= oneSecond;
 					if (event.today) {
 						timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
 					} else if (event.startDate - now < oneDay && event.startDate - now > 0) {
@@ -371,7 +371,7 @@ Module.register("calendar", {
 				eventWrapper.style.opacity = 1 - (1 / fadeSteps * currentFadeStep);
 			}
 		}
-		
+
 		return wrapper;
 	},
 


### PR DESCRIPTION
Included fading for dateheaders option (issue #1464)
Reworked the fading function, still included in the for loop. Now the fading opacity gets called twice, once for the date header and once for the event wrappers themselves

Removed unnecessary switch statement in dateheaders option

Fixed bug showing FullDayEvents one day too long by subtracting one Minute off FullDayEvents. Then they end at 23:59:59 on the respective ending day and not on 0:00:00 on the next day. Referring issue