### PR TITLE
Fix openweather forecast in new weather module, fetch daily data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 
 ### Fixed
+- Weather forecast now works with openweathermap in new weather module. Daily data are displayed, see issue [#1504](https://github.com/MichMich/MagicMirror/issues/1504).
 
 ## [2.6.0] - 2019-01-01
 

--- a/modules/default/weather/README.md
+++ b/modules/default/weather/README.md
@@ -78,7 +78,7 @@ The following properties can be configured:
 | ---------------------------- | -----------
 | `apiVersion`                 | The OpenWeatherMap API version to use. <br><br> **Default value:**  `2.5`
 | `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
-| `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Possible values:** `/weather` or `/forecast/daily` <br> **Default value:**  `'/weather'`
+| `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Possible values:** `/weather`, `/forecast` or `/forecast/daily` (paying users only) <br> **Default value:**  `'/weather'`
 | `locationID`                 | Location ID from [OpenWeatherMap](https://openweathermap.org/find) **This will override anything you put in location.** <br> Leave blank if you want to use location. <br> **Example:** `1234567` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 | `location`                   | The location used for weather information. <br><br> **Example:** `'Amsterdam,Netherlands'` <br> **Default value:** `false` <br><br> **Note:** When the `location` and `locationID` are both not set, the location will be based on the information provided by the calendar module. The first upcoming event with location data will be used.
 | `apiKey`                      | The [OpenWeatherMap](https://home.openweathermap.org) API key, which can be obtained by creating an OpenWeatherMap account. <br><br>  This value is **REQUIRED**

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -87,16 +87,21 @@ WeatherProvider.register("openweathermap", {
 	 * Generate WeatherObjects based on forecast information
 	 */
 	generateWeatherObjectsFromForecast(forecasts) {
+		// initial variable declaration
 		const days = [];
+		// variables for temperature range and rain
 		var minTemp = [];
 		var maxTemp = [];
 		var rain = 0;
+		// variable for date
 		let date = "";
 		var weather = new WeatherObject(this.config.units);
 
 		for (const forecast of forecasts) {
 			
 			if (date === moment(forecast.dt, "X").format("YYYY-MM-DD")) {
+				// the same day as before
+				// add values from forecast to corresponding variables
 				minTemp.push(forecast.main.temp_min);
 				maxTemp.push(forecast.main.temp_max);
 				if (this.config.units === "imperial" && !isNaN(forecast.rain["3h"])) {
@@ -105,20 +110,30 @@ WeatherProvider.register("openweathermap", {
 					rain += forecast.rain["3h"];
 				}
 			} else {
+				// a new day
+				// calculate minimum/maximum temperature, specify rain amount
 				weather.minTemperature = Math.min.apply(null, minTemp);
 				weather.maxTemperature = Math.max.apply(null, maxTemp);
 				weather.rain = rain;
+				// push weather information to days array
 				days.push(weather);
+				// create new weather-object
 				weather = new WeatherObject(this.config.units);
 				
 				minTemp = [];
 				maxTemp = [];
 				rain *= 0;
+				
+				// set new date
 				date = moment(forecast.dt, "X").format("YYYY-MM-DD");
 				
+				// specify date
 				weather.date = moment(forecast.dt, "X");
+				
+				// select weather type by first forecast value of a day, is this reasonable?
 				weather.weatherType = this.convertWeatherType(forecast.weather[0].icon);
 				
+				// add values from first forecast of this day to corresponding variables
 				minTemp.push(forecast.main.temp_min);
 				maxTemp.push(forecast.main.temp_max);
 				if (this.config.units === "imperial" && !isNaN(forecast.rain["3h"])) {


### PR DESCRIPTION
See #1504 

Example

```
{
	module: "weather",
	position: "top_right",
	header: "Wetter",
	config: {
		type: "current",
		degreeLabel: true,
		location: "Oldenburg",
		locationID: "2857458",
		apiKey: "myapiKey"
	}
},
{
	module: "weather",
	position: "top_right",
	header: "Vorhersage",
	config: {
		type: "forecast",
		degreeLabel: true,
		weatherEndpoint: "/forecast",
		location: "Oldenburg",
		locationID: "2857458",
		apiKey: "myapiKey"
	}
},
```
looks like this now:
![grafik](https://user-images.githubusercontent.com/20252362/50685966-b34f7080-101b-11e9-9a4d-2140efd7d9db.png)

Note that for the forecast to work with a **free API-subscription** from openweathermap, you must provide `weatherEndpoint: "/forecast"`! `weatherEndpoint: "/forecast/daily"` returns error 401, as it is used for the 16-day forecast and requires the Startup-subscription at minimum!
