### PR TITLE
Error handling for bad git data in updatenotification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed temperature displays in currentweather and weatherforecast modules [#1503](https://github.com/MichMich/MagicMirror/issues/1503).
+- Fixed unhandled error on bad git data in updatenotiifcation module [#1285](https://github.com/MichMich/MagicMirror/issues/1285).
 
 ## [2.6.0] - 2019-01-01
 

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -65,8 +65,10 @@ module.exports = NodeHelper.create({
 				data.module = sg.module;
 				if (!err) {
 					sg.git.log({"-1": null}, function(err, data2) {
-						data.hash = data2.latest.hash;
-						self.sendSocketNotification("STATUS", data);
+						if (!err) {
+							data.hash = data2.latest.hash;
+							self.sendSocketNotification("STATUS", data);
+						}
 					});
 				}
 			});


### PR DESCRIPTION
The updatenotification module did not ignore errors in the simple-git git.log() call.  After some module updates on my installation I started seeing frequent UnhandledPromiseRejectionWarning errors:

```shell
1|mm  | 2019-01-04T09:00:09 <error> (node:947) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'hash' of null
1|mm  |     at /home/pi/MagicMirror/modules/default/updatenotification/node_helper.js:68:32
1|mm  |     at Git.<anonymous> (/home/pi/MagicMirror/node_modules/simple-git/src/git.js:1560:10)
1|mm  |     at done (/home/pi/MagicMirror/node_modules/simple-git/src/git.js:1432:21)
1|mm  |     at /home/pi/MagicMirror/node_modules/simple-git/src/git.js:1457:16 (process/warning.js:18 writeOut)
1|mm  | 2019-01-04T09:00:09 <error> (node:947) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1) (process/warning.js:18 writeOut)
1|mm  | 2019-01-04T09:00:09 <error> (node:947) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code. (process/warning.js:18 writeOut)
```

This PR aborts the call if `data2.latest` is undefined for some reason. It is a nuisance error and the only negative side effect should be that we don't know if a module has an update; however, this is the same handling as if the fetch() call failed.

Related to closed issues #1164 and #1285.