### PR TITLE
Fix conflict between font awesome versions as per #1522

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed unhandled error on bad git data in updatenotiifcation module [#1285](https://github.com/MichMich/MagicMirror/issues/1285).
 - Weather forecast now works with openweathermap in new weather module. Daily data are displayed, see issue [#1504](https://github.com/MichMich/MagicMirror/issues/1504).
 - Fixed analogue clock border display issue where non-black backgrounds used (previous fix for issue 611)
+- Fixed compatibility issues caused when modules request different versions of Font Awesome, see issue [#1522](https://github.com/MichMich/MagicMirror/issues/1522). MagicMirror now uses [Font Awesome 5 with v4 shims included for backwards compatibility](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#shims).
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -51,7 +51,7 @@ Module.register("calendar", {
 
 	// Define required scripts.
 	getStyles: function () {
-		return ["calendar.css", "font-awesome5.css", "font-awesome5.v4shims.css"];
+		return ["calendar.css", "font-awesome.css"];
 	},
 
 	// Define required scripts.

--- a/vendor/css/font-awesome.css
+++ b/vendor/css/font-awesome.css
@@ -1,0 +1,2 @@
+@import url("../node_modules/@fortawesome/fontawesome-free/css/all.min.css");
+@import url("../node_modules/@fortawesome/fontawesome-free/css/v4-shims.min.css");

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.3.1",
-    "font-awesome": "^4.7.0",
     "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
     "nunjucks": "^3.0.1",

--- a/vendor/vendor.js
+++ b/vendor/vendor.js
@@ -12,9 +12,7 @@ var vendor = {
 	"moment-timezone.js" : "node_modules/moment-timezone/builds/moment-timezone-with-data.js",
 	"weather-icons.css": "node_modules/weathericons/css/weather-icons.css",
 	"weather-icons-wind.css": "node_modules/weathericons/css/weather-icons-wind.css",
-	"font-awesome.css": "node_modules/font-awesome/css/font-awesome.min.css",
-	"font-awesome5.css": "node_modules/@fortawesome/fontawesome-free/css/all.min.css",
-	"font-awesome5.v4shims.css": "node_modules/@fortawesome/fontawesome-free/css/v4-shims.min.css",
+	"font-awesome.css": "css/font-awesome.css",
 	"nunjucks.js": "node_modules/nunjucks/browser/nunjucks.min.js"
 };
 


### PR DESCRIPTION
Proposal to fix #1522 

* Remove font awesome 4 from dependencies in vendor/package.json
* Add custom font-awesome.css to allow multiple css to be included for one vendor i.e. both the full font awesome css (all.min.css) and the v4-shim css (v4-shims.min.css) for backward compatibility
* Modify vendor.js so font awesome 5 (with backwards compatibility) is used for all modules
* Revert font awesome references in default calendar module