### PR TITLE
Fix css being versioned, rename to custom.css.sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed compatibility issues caused when modules request different versions of Font Awesome, see issue [#1522](https://github.com/MichMich/MagicMirror/issues/1522). MagicMirror now uses [Font Awesome 5 with v4 shims included for backwards compatibility](https://fontawesome.com/how-to-use/on-the-web/setup/upgrading-from-version-4#shims).
 - Installation script problems with raspbian
 - Calendar: only show repeating count if the event is actually repeating [#1534](https://github.com/MichMich/MagicMirror/pull/1534)
+- Rename `custom.css` to `custom.css.sample`, similar to `config.js.sample` [#1540](https://github.com/MichMich/MagicMirror/pull/1540)
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/css/custom.css.sample
+++ b/css/custom.css.sample
@@ -5,10 +5,10 @@
  * By Michael Teeuw http://michaelteeuw.nl           *
  * MIT Licensed.                                     *
  *                                                   *
- * Add any custom CSS below.                         *
- * Changes to this files will be ignored by GIT. *
+ * Make a copy of this file named custom.css and     *
+ * then add your own rules to it.                    *
  *****************************************************/
 
- body {
- 	
- }
+body {
+
+}


### PR DESCRIPTION
At the current moment, the file `custom.css` is versioned in git but also has an entry in the `.gitignore` file. Since it was versioned first, modifications to said file make it look like there are changes from git. This PR renames that file to `custom.css.sample` to match with the config file. If a user wants custom css, they can make a copy of the file and no more changes from the git perspective!