### PR TITLE
Currentweather dev

### DIFF
--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -48,8 +48,8 @@ The following properties can be configured:
 | `showWindDirectionAsArrow`   | Show the wind direction as an arrow instead of abbreviation <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showHumidity`               | Show the current humidity <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showIndoorTemperature`      | If you have another module that emits the INDOOR_TEMPERATURE notification, the indoor temperature will be displayed <br> **Default value:** `false`
-| `onlyTemp`                   | Show only current Temperature and weather icon without windspeed, sunset, sunrise time and feels like. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `showFeelsLike`              | Shows the Feels like temperature weather. <br><br> **Possible values:**`true` or `false`<br>**Default value:** `true`
+| `showExtraWeatherInfo`       | Shows extra info above the temp: windspeed, sunset and sunrise time <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `useKMPHWind`                | Uses KMPH as units for windspeed. <br><br> **Possible values:**`true` or `false`<br>**Default value:** `false`
 | `useBeaufort`                | Pick between using the Beaufort scale for wind speed or using the default units. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `lang`                       | The language of the days. <br><br> **Possible values:** `en`, `nl`, `ru`, etc ... <br> **Default value:** uses value of _config.language_

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -31,6 +31,7 @@ Module.register("currentweather",{
 		showIndoorTemperature: false,
 		showIndoorHumidity: false,
 		showFeelsLike: true,
+		showExtraWeatherInfo: true,
 
 		initialLoadDelay: 0, // 0 seconds delay
 		retryDelay: 2500,
@@ -42,7 +43,7 @@ Module.register("currentweather",{
 		appendLocationNameToHeader: true,
 		calendarClass: "calendar",
 
-		onlyTemp: false,
+		onlyTemp: false, //deprecated. use showExtraWeatherInfo instead
 		roundTemp: false,
 
 		iconTable: {
@@ -186,7 +187,14 @@ Module.register("currentweather",{
 			return wrapper;
 		}
 
-		if (this.config.onlyTemp === false) {
+		// adding this here for legacy support of onlyTemp,
+		// but using the "showXXX: false" config options is more consistent
+		if (this.config.onlyTemp === "true") {
+			this.config.showExtraWeatherInfo = false;
+			this.config.showFeelsLike = false;
+		}
+
+		if (this.config.showExtraWeatherInfo == "true") {
 			this.addExtraInfoWeather(wrapper);
 		}
 
@@ -245,7 +253,7 @@ Module.register("currentweather",{
 
 		wrapper.appendChild(large);
 
-		if (this.config.showFeelsLike && this.config.onlyTemp === false){
+		if (this.config.showFeelsLike){
 			var small = document.createElement("div");
 			small.className = "normal medium";
 


### PR DESCRIPTION
Added a new config option called showExtraWeatherInfo because I wanted to 
display temp and feelsLike and nothing else. The onlyTemp option was the only 
way to turn off the extra weather info above the temp, but it also blocked the feelsLike.

onlyTemp still works, but it should be considered deprecated, since the same
behavior/results can be achieved by setting showExtraWeatherInfo and 
showFeelsLike to false.