### PR TITLE
Fix null dereference in moduleNeedsUpdate when the module isn't visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Installation script problems with raspbian
 - Calendar: only show repeating count if the event is actually repeating [#1534](https://github.com/MichMich/MagicMirror/pull/1534)
 - Calendar: Fix exdate handling when multiple values are specified (comma separated)
+- Fix null dereference in moduleNeedsUpdate when the module isn't visible
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/js/main.js
+++ b/js/main.js
@@ -173,6 +173,10 @@ var MM = (function() {
 	 */
 	var moduleNeedsUpdate = function(module, newHeader, newContent) {
 		var moduleWrapper = document.getElementById(module.identifier);
+		if (moduleWrapper === null) {
+			return false;
+		}
+
 		var contentWrapper = moduleWrapper.getElementsByClassName("module-content");
 		var headerWrapper = moduleWrapper.getElementsByClassName("module-header");
 


### PR DESCRIPTION
I have my own custom modules for displaying calendar events, but still want to use the default calendar module to fetch my events.  If I add the calendar module to my config, but do not assign it a position, moduleNeedsUpdate() will get a null moduleWrapper, and does not check before using it, which logs an error.
