### PR TITLE
 weather module adjustments for rain and snow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Weather forecast now works with openweathermap for both, `/forecast` and `/forecast/daily`, in new weather module. If you use the `/forecast`-weatherEndpoint, the hourly data are converted to daily data, see issues [#1504](https://github.com/MichMich/MagicMirror/issues/1504), [#1513](https://github.com/MichMich/MagicMirror/issues/1513).
 - Added fade, fadePoint and maxNumberOfDays properties to the forecast mode [#1516](https://github.com/MichMich/MagicMirror/issues/1516)
 - Fixed Loading string and decimalSymbol string replace [#1538](https://github.com/MichMich/MagicMirror/issues/1538)
+- Show Snow amounts in new weather module [#1545](https://github.com/MichMich/MagicMirror/issues/1545)
 
 ## [2.6.0] - 2019-01-01
 

--- a/modules/default/weather/README.md
+++ b/modules/default/weather/README.md
@@ -70,7 +70,7 @@ The following properties can be configured:
 | ---------------------------- | -----------
 | `tableClass`                 | The class for the forecast table. <br><br> **Default value:**  `'small'`
 | `colored`                    | If set to `true`, the min and max temperature are color coded. <br><br> **Default value:**  `false`
-| `showRainAmount`             | Show the amount of rain in the forecast <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `showPrecipitationAmount`    | Show the amount of rain/snow in the forecast <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `fade`                       | Fade the future events to black. (Gradient) <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `fadePoint`                  | Where to start fade? <br><br> **Possible values:** `0` (top of the list) - `1` (bottom of list) <br> **Default value:** `0.25`
 | `maxNumberOfDays`            | How many days of forecast to return. Specified by config.js <br><br> **Possible values:** `1` - `16` <br> **Default value:** `5` (5 days) <br> This value is optional. By default the weatherforecast module will return 5 days.

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -13,9 +13,9 @@
                 <td class="align-right min-temp">
                     {{ f.minTemperature | roundValue | unit("temperature") }}
                 </td>
-                {% if config.showRainAmount %}
-                    <td class="align-right bright rain">
-                        {{ f.rain | unit("rain") }}
+                {% if config.showPrecipitationAmount %}
+                    <td class="align-right bright precipitation">
+                        {{ f.precipitation | unit("precip") }}
                     </td>
                 {% endif %}
             </tr>

--- a/modules/default/weather/providers/README.md
+++ b/modules/default/weather/providers/README.md
@@ -103,6 +103,8 @@ A convinience function to make requests. It returns a promise.
 | weatherType | `string` | Icon name of the weather type. <br> Possible values: [WeatherIcons](https://www.npmjs.com/package/weathericons) |
 | humidity | `number` | Percentage of humidity |
 | rain | `number` | Metric: `millimeters` <br> Imperial: `inches` |
+| snow | `number` | Metric: `millimeters` <br> Imperial: `inches` |
+| precipitation | `number` | Metric: `millimeters` <br> Imperial: `inches` |
 
 #### Current weather
 

--- a/modules/default/weather/providers/darksky.js
+++ b/modules/default/weather/providers/darksky.js
@@ -8,6 +8,7 @@
  * MIT Licensed
  *
  * This class is a provider for Dark Sky.
+ * Note that the Dark Sky API does not provide rainfall.  Instead it provides snowfall and precipitation probability
  */
 WeatherProvider.register("darksky", {
 	// Set the name of the provider.
@@ -81,11 +82,19 @@ WeatherProvider.register("darksky", {
 			weather.minTemperature = forecast.temperatureMin;
 			weather.maxTemperature = forecast.temperatureMax;
 			weather.weatherType = this.convertWeatherType(forecast.icon);
-			if (this.config.units === "metric" && !isNaN(forecast.precipAccumulation)) {
-				weather.rain = forecast.precipAccumulation * 10;
-			} else {
-				weather.rain = forecast.precipAccumulation;
+			weather.snow = 0;
+
+			// The API will return centimeters if units is 'si' and will return inches for 'us'
+			// Note that the Dark Sky API does not provide rainfall.  Instead it provides snowfall and precipitation probability
+			if (forecast.hasOwnProperty("precipAccumulation")) {
+				if (this.config.units === "imperial" && !isNaN(forecast.precipAccumulation)) {
+					weather.snow = forecast.precipAccumulation;
+				} else if (!isNaN(forecast.precipAccumulation)) {
+					weather.snow = forecast.precipAccumulation * 10;
+				}
 			}
+
+			weather.precipitation = weather.snow;
 
 			days.push(weather);
 		}

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -106,6 +106,7 @@ WeatherProvider.register("openweathermap", {
 		var minTemp = [];
 		var maxTemp = [];
 		var rain = 0;
+		var snow = 0;
 		// variable for date
 		let date = "";
 		var weather = new WeatherObject(this.config.units);
@@ -117,6 +118,8 @@ WeatherProvider.register("openweathermap", {
 				weather.minTemperature = Math.min.apply(null, minTemp);
 				weather.maxTemperature = Math.max.apply(null, maxTemp);
 				weather.rain = rain;
+				weather.snow = snow;
+				weather.precipitation = weather.rain + weather.snow;
 				// push weather information to days array
 				days.push(weather);
 				// create new weather-object
@@ -125,6 +128,7 @@ WeatherProvider.register("openweathermap", {
 				minTemp = [];
 				maxTemp = [];
 				rain = 0;
+				snow = 0;
 
 				// set new date
 				date = moment(forecast.dt, "X").format("YYYY-MM-DD");
@@ -149,20 +153,27 @@ WeatherProvider.register("openweathermap", {
 			if (forecast.hasOwnProperty("rain")) {
 				if (this.config.units === "imperial" && !isNaN(forecast.rain["3h"])) {
 					rain += forecast.rain["3h"] / 25.4;
-				} else if (!isNaN(forecast.rain["3h"])){
+				} else if (!isNaN(forecast.rain["3h"])) {
 					rain += forecast.rain["3h"];
-				} else {
-					rain += 0;
 				}
-			} else {
-				rain += 0;
+			}
+
+			if (forecast.hasOwnProperty("snow")) {
+				if (this.config.units === "imperial" && !isNaN(forecast.snow["3h"])) {
+					snow += forecast.snow["3h"] / 25.4;
+				} else if (!isNaN(forecast.snow["3h"])) {
+					snow += forecast.snow["3h"];
+				}
 			}
 		}
+
 		// last day
 		// calculate minimum/maximum temperature, specify rain amount
 		weather.minTemperature = Math.min.apply(null, minTemp);
 		weather.maxTemperature = Math.max.apply(null, maxTemp);
 		weather.rain = rain;
+		weather.snow = snow;
+		weather.precipitation = weather.rain + weather.snow;
 		// push weather information to days array
 		days.push(weather);
 		return days.slice(1);
@@ -182,19 +193,30 @@ WeatherProvider.register("openweathermap", {
 			weather.minTemperature = forecast.temp.min;
 			weather.maxTemperature = forecast.temp.max;
 			weather.weatherType = this.convertWeatherType(forecast.weather[0].icon);
+			weather.rain = 0;
+			weather.snow = 0;
 
 			// forecast.rain not available if amount is zero
+			// The API always returns in millimeters
 			if (forecast.hasOwnProperty("rain")) {
 				if (this.config.units === "imperial" && !isNaN(forecast.rain)) {
 					weather.rain = forecast.rain / 25.4;
-				} else if (!isNaN(forecast.rain)){
+				} else if (!isNaN(forecast.rain)) {
 					weather.rain = forecast.rain;
-				} else {
-					weather.rain = 0;
 				}
-			} else {
-				weather.rain = 0;
 			}
+
+			// forecast.snow not available if amount is zero
+			// The API always returns in millimeters
+			if (forecast.hasOwnProperty("snow")) {
+				if (this.config.units === "imperial" && !isNaN(forecast.snow)) {
+					weather.snow = forecast.snow / 25.4;
+				} else if (!isNaN(forecast.snow)) {
+					weather.snow = forecast.snow;
+				}
+			}
+
+			weather.precipitation = weather.rain + weather.snow;
 
 			days.push(weather);
 		}

--- a/modules/default/weather/weather.css
+++ b/modules/default/weather/weather.css
@@ -31,7 +31,7 @@
   padding-right: 0;
 }
 
-.weather .rain {
+.weather .precipitation {
   padding-left: 20px;
   padding-right: 0;
 }

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -49,7 +49,7 @@ Module.register("weather",{
 		tableClass: "small",
 
 		onlyTemp: false,
-		showRainAmount: true,
+		showPrecipitationAmount: false,
 		colored: false,
 		showFeelsLike: true
 	},
@@ -200,8 +200,8 @@ Module.register("weather",{
 						value += "K";
 					}
 				}
-			} else if (type === "rain") {
-				if (isNaN(value) || value === 0) {
+			} else if (type === "precip") {
+				if (isNaN(value) || value === 0 || value.toFixed(2) === "0.00") {
 					value = "";
 				} else {
 					value = `${value.toFixed(2)} ${this.config.units === "imperial" ? "in" : "mm"}`;

--- a/modules/default/weather/weatherobject.js
+++ b/modules/default/weather/weatherobject.js
@@ -26,6 +26,8 @@ class WeatherObject {
 		this.weatherType = null;
 		this.humidity = null;
 		this.rain = null;
+		this.snow = null;
+		this.precipitation = null;
 	}
 
 	cardinalWindDirection() {


### PR DESCRIPTION
Here's the update to the new weather module with some refactoring of rain and snow.  I've kept them separate in case in the future there is desire to split it out.  For now, both will be added together into precipitation property of weatherobject.  I think precipitation is a better way to reflect the data from the various APIs.  I've added some comments to the provider js so that others can understand what is/isnt in the JSON in terms of precipitation.  Ex: DarkSky doesnt give back rainfall, but it does for snowfall.

showPrecipitationAmount is the new flag.  I've set it back to default false as this was the behavior in the weatherforecast module.