### PR TITLE
fix relative date fulldate events to use start of day to start of day diff… issue 1572

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Installation script problems with raspbian
 - Calendar: only show repeating count if the event is actually repeating [#1534](https://github.com/MichMich/MagicMirror/pull/1534)
 - Calendar: Fix exdate handling when multiple values are specified (comma separated)
+- Calendar: Fix relative date handling for fulldate events, calculate difference always from start of day  [#1572] (https://github.com/MichMich/MagicMirror/issues/1572)
 - Fix null dereference in moduleNeedsUpdate when the module isn't visible
 
 ### New weather module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Installation script problems with raspbian
 - Calendar: only show repeating count if the event is actually repeating [#1534](https://github.com/MichMich/MagicMirror/pull/1534)
 - Calendar: Fix exdate handling when multiple values are specified (comma separated)
-- Calendar: Fix relative date handling for fulldate events, calculate difference always from start of day  [#1572] (https://github.com/MichMich/MagicMirror/issues/1572)
+- Calendar: Fix relative date handling for fulldate events, calculate difference always from start of day  [#1572](https://github.com/MichMich/MagicMirror/issues/1572)
 - Fix null dereference in moduleNeedsUpdate when the module isn't visible
 
 ### New weather module

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -297,7 +297,7 @@ Module.register("calendar", {
 						if (this.config.timeFormat === "absolute") {
 							if ((this.config.urgency > 1) && (event.startDate - now < (this.config.urgency * oneDay))) {
 								// This event falls within the config.urgency period that the user has set
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
+								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").from(moment().format("YYYYMMDD")));
 							} else {
 								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.fullDayEventDateFormat));
 							}

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -302,7 +302,7 @@ Module.register("calendar", {
 								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.fullDayEventDateFormat));
 							}
 						} else {
-							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").from(moment().format("YYYYMMDD")));
 						}
 					}
 					if(this.config.showEnd){


### PR DESCRIPTION
default calendar in relative mode uses a time based 'fromNow()' to compare against start of DAY for fulldate events..  this causes elapsed day rounding down when the current hours get past noon. 

change to use start of day from(date only, as it is midnight, start of day)