### PR TITLE
Feature/alert fontawesome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Danish translation for "Feels" and "Weeks"
 - Added option to split multiple day events in calendar to separate numbered events
 - Slovakian translation
+- Alerts now can contain Font Awesome icons
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/modules/default/alert/alert.js
+++ b/modules/default/alert/alert.js
@@ -24,7 +24,7 @@ Module.register("alert",{
 		return ["classie.js", "modernizr.custom.js", "notificationFx.js"];
 	},
 	getStyles: function() {
-		return ["ns-default.css"];
+		return ["ns-default.css", "font-awesome.css"];
 	},
 	// Define required translations.
 	getTranslations: function() {


### PR DESCRIPTION
A small change to getStyles function in alert.js makes it possible to use Font Awesome icons in alerts. I want to display alerts which contain the bluetooth icon for example. The Font Awesome icons are already include in the vendor stuff so they only need to be included.
