### PR TITLE
Regularly trigger ADD_CALENDAR to ensure calendar fetcher is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Calendar: Fix relative date handling for fulldate events, calculate difference always from start of day  [#1572](https://github.com/MichMich/MagicMirror/issues/1572)
 - Fix null dereference in moduleNeedsUpdate when the module isn't visible
 - Calendar: Fixed event end times by setting default calendarEndTime to "LT" (Local time format). [#1479]
+- Calendar: Fixed missing calendar fetchers after server process restarts [#1589](https://github.com/MichMich/MagicMirror/issues/1589)
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -105,6 +105,13 @@ Module.register("calendar", {
 			}
 
 			this.addCalendar(calendar.url, calendar.auth, calendarConfig);
+
+			// Trigger ADD_CALENDAR every fetchInterval to make sure there is always a calendar
+			// fetcher running on the server side.
+			var self = this;
+			setInterval(function() {
+				self.addCalendar(calendar.url, calendar.auth, calendarConfig);
+			}, self.config.fetchInterval);
 		}
 
 		this.calendarData = {};


### PR DESCRIPTION
Currently an `ADD_CALENDAR` notification is only sent once when the calendar module is started in the UI. This notification creates a calendar fetcher on the server side that is used to regularly update the calendar.

When MagicMirror is running in `serveronly` mode, the server process can be restarted even while the UI keeps running. When the server process restarts, it launches with no calendar fetchers running, and there is currently no way to start them again other than to refresh the UI.

This change just fires an `ADD_CALENDAR` event every fetch interval. When such event is received by the server that already has a fetcher running, it's [effectively ignored](https://github.com/MichMich/MagicMirror/blob/de57daa3cd881ce1a14b88307bf61e8109879c81/modules/default/calendar/node_helper.js#L72) (i.e. no duplicate fetcher is started), however if there is no fetcher running (because the server has been restarted) this makes sure it gets started.