### PR TITLE
Use getHeader instead of data.header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix null dereference in moduleNeedsUpdate when the module isn't visible
 - Calendar: Fixed event end times by setting default calendarEndTime to "LT" (Local time format). [#1479]
 - Calendar: Fixed missing calendar fetchers after server process restarts [#1589](https://github.com/MichMich/MagicMirror/issues/1589)
+- Use getHeader instead of data.header when creating the DOM so overwriting the function also propagates into it
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/js/main.js
+++ b/js/main.js
@@ -44,7 +44,7 @@ var MM = (function() {
 				moduleHeader.innerHTML = module.getHeader();
 				moduleHeader.className = "module-header";
 				dom.appendChild(moduleHeader);
-			} 
+			}
 
 			var moduleContent = document.createElement("div");
 			moduleContent.className = "module-content";

--- a/js/main.js
+++ b/js/main.js
@@ -39,12 +39,12 @@ var MM = (function() {
 			dom.opacity = 0;
 			wrapper.appendChild(dom);
 
-			if (typeof module.data.header !== "undefined" && module.data.header !== "") {
+			if (typeof module.getHeader() !== "undefined" && module.getHeader() !== "") {
 				var moduleHeader = document.createElement("header");
-				moduleHeader.innerHTML = module.data.header;
+				moduleHeader.innerHTML = module.getHeader();
 				moduleHeader.className = "module-header";
 				dom.appendChild(moduleHeader);
-			}
+			} 
 
 			var moduleContent = document.createElement("div");
 			moduleContent.className = "module-content";

--- a/js/module.js
+++ b/js/module.js
@@ -212,7 +212,7 @@ var Module = Class.extend({
 	/* setData(data)
 	 * Set the module data.
 	 *
-	 * argument data obejct - Module data.
+	 * argument data object - Module data.
 	 */
 	setData: function (data) {
 		this.data = data;
@@ -226,7 +226,7 @@ var Module = Class.extend({
 	/* setConfig(config)
 	 * Set the module config and combine it with the module defaults.
 	 *
-	 * argument config obejct - Module config.
+	 * argument config object - Module config.
 	 */
 	setConfig: function (config) {
 		this.config = Object.assign({}, this.defaults, config);

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -273,7 +273,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 	/* isFullDayEvent(event)
 	 * Checks if an event is a fullday event.
 	 *
-	 * argument event obejct - The event object to check.
+	 * argument event object - The event object to check.
 	 *
 	 * return bool - The event is a fullday event.
 	 */


### PR DESCRIPTION
My MMM-MotionDetector modules uses a njk template for displaying some status. 
But overwriting the getHeader function didnt produce a Header line in the resulting DOM, only manually setting `this.data.header = "foo bar"`

Turns out creating the header in module.js uses not the method but the data itself. This PR changes that by using the getHeader method so modules can overwrite it