### PR TITLE
Notifications delay time and background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added option to split multiple day events in calendar to separate numbered events
 - Slovakian translation
 - Alerts now can contain Font Awesome icons
+- Notifications display time can be set in request
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix null dereference in moduleNeedsUpdate when the module isn't visible
 - Calendar: Fixed event end times by setting default calendarEndTime to "LT" (Local time format). [#1479]
 - Calendar: Fixed missing calendar fetchers after server process restarts [#1589](https://github.com/MichMich/MagicMirror/issues/1589)
+- Notification: fixed background color (was white text on white background)
 
 ### New weather module
 - Fixed weather forecast table display [#1499](https://github.com/MichMich/MagicMirror/issues/1499).

--- a/modules/default/alert/README.md
+++ b/modules/default/alert/README.md
@@ -43,10 +43,11 @@ self.sendNotification("SHOW_ALERT", {});
 ```
 
 ### Notification params
-| Option    | Description
-| --------- | -----------
-| `title`   | The title of the notification. <br><br> **Possible values:** `text` or `html`
-| `message`	| The message of the notification. <br><br> **Possible values:** `text` or `html`
+| Option             | Description
+| ------------------ | -----------
+| `title`            | The title of the notification. <br><br> **Possible values:** `text` or `html`
+| `message`	         | The message of the notification. <br><br> **Possible values:** `text` or `html`
+| `timer` (optional) | How long the notification should stay visible in ms. <br> If absent, the default `display_time` is used. <br> **Possible values:** `int` `float`
 
 
 ### Alert params

--- a/modules/default/alert/alert.js
+++ b/modules/default/alert/alert.js
@@ -51,7 +51,7 @@ Module.register("alert",{
 			message: msg,
 			layout: "growl",
 			effect: this.config.effect,
-			ttl: this.config.display_time
+			ttl: message.timer !== undefined ? message.timer : this.config.display_time
 		}).show();
 	},
 	show_alert: function(params, sender) {

--- a/modules/default/alert/ns-default.css
+++ b/modules/default/alert/ns-default.css
@@ -1,7 +1,7 @@
 /* Based on work by http://tympanus.net/codrops/licensing/ */
 
 .ns-box {
-  background: #fff;
+  background-color: rgba(0, 0, 0, 0.93);
   padding: 17px;
   line-height: 1.4;
   margin-bottom: 10px;
@@ -12,7 +12,10 @@
   display: table;
   word-wrap: break-word;
   max-width: 100%;
+  border-width: 1px;
   border-radius: 5px;
+  border-style: solid;
+  border-color: #666;
 }
 
 .ns-alert {


### PR DESCRIPTION
- Notifications display time can be set in request
- Notification: fixed background color (was white text on white background)

**Before**
<img width="751" alt="MM-notice-before" src="https://user-images.githubusercontent.com/678500/54359175-6236ab00-4662-11e9-8e9f-869a949b22b7.png">

**After**
<img width="754" alt="MM-notice-after" src="https://user-images.githubusercontent.com/678500/54359189-6c58a980-4662-11e9-8baf-b8d6fe6e3196.png">
