### PR TITLE
Change spelling of parameter to match documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ignore entries with unparseable details in the calendar module
 - Bug showing FullDayEvents one day too long in calendar fixed
 - Bug in newsfeed when `removeStartTags` is used on the description [#1478](https://github.com/MichMich/MagicMirror/issues/1478)
+- Changed capitalisation of `useKMPHWind` parameter in Weather Forecast module to match the documentation
 
 ### Updated
 - The default calendar setting `showEnd` is changed to `false`.

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -23,7 +23,7 @@ Module.register("currentweather",{
 		showWindDirection: true,
 		showWindDirectionAsArrow: false,
 		useBeaufort: true,
-		useKMPHwind: false,
+		useKMPHWind: false,
 		lang: config.language,
 		decimalSymbol: ".",
 		showHumidity: false,
@@ -384,7 +384,7 @@ Module.register("currentweather",{
 
 		if (this.config.useBeaufort){
 			this.windSpeed = this.ms2Beaufort(this.roundValue(data.wind.speed));
-		} else if (this.config.useKMPHwind) {
+		} else if (this.config.useKMPHWind) {
 			this.windSpeed = parseFloat((data.wind.speed * 60 * 60) / 1000).toFixed(0);
 		} else {
 			this.windSpeed = parseFloat(data.wind.speed).toFixed(0);


### PR DESCRIPTION
According to the documentation, this setting is called "useKMPHWind" (not "useKMPHwind").  Changed the implementation rather than the documentation since this seems to be more consistent with the naming scheme used for the other parameters in the currentweather module.