### PR TITLE
Node.js upgrade to 10.x (installer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)
 - Updated modernizr code in alert module, fixed a small typo there too
 - More verbose error message on console if the config is malformed
+- Updated installer script to install Node.js version 10.x
 
 ### Fixed
 - Fixed temperature displays in currentweather and weatherforecast modules [#1503](https://github.com/MichMich/MagicMirror/issues/1503), [#1511](https://github.com/MichMich/MagicMirror/issues/1511).

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -82,7 +82,7 @@ if $NODE_INSTALL; then
 	# The NODE_STABLE_BRANCH variable will need to be manually adjusted when a new branch is released. (e.g. 7.x)
 	# Only tested (stable) versions are recommended as newer versions could break MagicMirror.
 	
-	NODE_STABLE_BRANCH="9.x"
+	NODE_STABLE_BRANCH="10.x"
 	curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
 	sudo apt-get install -y nodejs
 	echo -e "\e[92mNode.js installation Done!\e[0m"


### PR DESCRIPTION
The manual install instruction refers to installing Node.js 10.x. This updates the installer script for Raspberry Pi to use that version.