### PR TITLE
Add support for the ARTICLE_INFO_REQUEST notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Slovakian translation
 - Alerts now can contain Font Awesome icons
 - Notifications display time can be set in request
+- newsfeed: added support for `ARTICLE_INFO_REQUEST` notification
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -46,6 +46,7 @@ MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/t
 | `ARTICLE_MORE_DETAILS`  | When received the _first time_, shows the corresponding description of the currently displayed news title. <br> The module expects that the module's configuration option `showDescription` is set to `false` (default value). <br><br> When received a _second consecutive time_, shows the full news article in an IFRAME. <br> This requires that the news page can be embedded in an IFRAME, e.g. doesn't have the HTTP response header [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) set to e.g. `DENY`.<br><br>When received the _next consecutive times_, reloads the page and scrolls down by `scrollLength` pixels to paginate through the article.
 | `ARTICLE_LESS_DETAILS`  | Hides the summary or full news article and only displays the news title of the currently viewed news item.
 | `ARTICLE_TOGGLE_FULL`   | Toogles article in fullscreen.
+| `ARTICLE_INFO_REQUEST`  | Causes `newsfeed` to respond with the notification `ARTICLE_INFO_RESPONSE`, the payload of which provides the `title`, `source`, `date`, `desc` and `url` of the current news title.
 
 Note the payload of the sent notification event is ignored.
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -189,7 +189,7 @@ Module.register("newsfeed",{
 				fullArticle.style.top = "0";
 				fullArticle.style.left = "0";
 				fullArticle.style.border = "none";
-				fullArticle.src = typeof this.newsItems[this.activeItem].url  === "string" ? this.newsItems[this.activeItem].url : this.newsItems[this.activeItem].url.href;
+				fullArticle.src = this.getActiveItemURL()
 				fullArticle.style.zIndex = 1;
 				wrapper.appendChild(fullArticle);
 			}
@@ -208,6 +208,10 @@ Module.register("newsfeed",{
 		}
 
 		return wrapper;
+	},
+
+	getActiveItemURL: function() {
+		return typeof this.newsItems[this.activeItem].url  === "string" ? this.newsItems[this.activeItem].url : this.newsItems[this.activeItem].url.href;
 	},
 
 	/* registerFeeds()
@@ -387,6 +391,14 @@ Module.register("newsfeed",{
 			} else {
 				this.showFullArticle();
 			}
+		} else if (notification === "ARTICLE_INFO_REQUEST"){
+			this.sendNotification("ARTICLE_INFO_RESPONSE", {
+				title:  this.newsItems[this.activeItem].title,
+				source: this.newsItems[this.activeItem].sourceTitle,
+				date:   this.newsItems[this.activeItem].pubdate,
+				desc:   this.newsItems[this.activeItem].description,
+				url:    this.getActiveItemURL()
+			})
 		} else {
 			Log.info(this.name + " - unknown notification, ignoring: " + notification);
 		}


### PR DESCRIPTION
Upon reception of an ARTICLE_INFO_REQUEST notification, newsfeed will respond with the notification ARTICLE_INFO_RESPONSE, containing the fields 'title', 'source', 'date', 'desc' and 'url'.  This allows other modules to interrogate the currently displayed headline and do something with the information (in my case, use it as TTS input). 

