### PR TITLE
Add name property to calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Slovakian translation
 - Alerts now can contain Font Awesome icons
 - Notifications display time can be set in request
+- Add `name` config option for calendars to be sent along with event broadcasts
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -90,6 +90,7 @@ config: {
 | `repeatingCountTitle`	| The count title for yearly repating events in this calendar.  <br><br> **Example:** `'Birthday'`
 | `maximumEntries`      | The maximum number of events shown.  Overrides global setting. **Possible values:** `0` - `100`
 | `maximumNumberOfDays` | The maximum number of days in the future.  Overrides global setting
+| `name`                | The name of the calendar.  Included in event broadcasts as `calendarName`.
 | `auth`                | The object containing options for authentication against the calendar.
 | `symbolClass`         | Add a class to the cell of symbol.
 | `titleClass`          | Add a class to the title's cell.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -569,6 +569,17 @@ Module.register("calendar", {
 		return this.getCalendarProperty(url, "timeClass", "");
 	},
 
+	/* calendarNameForUrl(url)
+	 * Retrieves the calendar name for a specific url.
+	 *
+	 * argument url string - Url to look for.
+	 *
+	 * return string - The name of the calendar
+	 */
+	calendarNameForUrl: function (url) {
+		return this.getCalendarProperty(url, "name", "");
+	},
+
 	/* colorForUrl(url)
 	 * Retrieves the color for a specific url.
 	 *
@@ -709,6 +720,7 @@ Module.register("calendar", {
 			for (var e in calendar) {
 				var event = cloneObject(calendar[e]);
 				event.symbol = this.symbolsForUrl(url);
+				event.calendarName = this.calendarNameForUrl(url);
 				event.color = this.colorForUrl(url);
 				delete event.url;
 				eventList.push(event);


### PR DESCRIPTION
When consuming CALENDAR_EVENTS broadcasts, it is useful for other
modules to be able to identify which calendar a specific event
came from, for filtering/display purposes.
