### PR TITLE
Update current weather header only if not undefined

### DIFF
--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -71,7 +71,7 @@ Module.register("currentweather",{
 	firstEvent: false,
 
 	// create a variable to hold the location name based on the API result.
-	fetchedLocatioName: "",
+	fetchedLocationName: "",
 
 	// Define required scripts.
 	getScripts: function() {
@@ -266,7 +266,7 @@ Module.register("currentweather",{
 	// Override getHeader method.
 	getHeader: function() {
 		if (this.config.appendLocationNameToHeader) {
-			return this.data.header + " " + this.fetchedLocatioName;
+			return this.data.header + " " + this.fetchedLocationName;
 		}
 
 		return this.data.header;

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -265,7 +265,7 @@ Module.register("currentweather",{
 
 	// Override getHeader method.
 	getHeader: function() {
-		if (this.config.appendLocationNameToHeader) {
+		if (this.config.appendLocationNameToHeader && this.data.header !== undefined) {
 			return this.data.header + " " + this.fetchedLocationName;
 		}
 


### PR DESCRIPTION
Changes introduced in 84dc1fa1 changed the title of the currentweather module to `undefined`, if no title is set in the config.

If the currentweather module is shown without a title, this makes the title show just `undefined`.