### PR TITLE
Add includePastEvents global and calendar-specific settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Russian translation for “Feels”
 
+- Add `broadcastPastEvents` config option for calendars to include events from the past `maximumNumberOfDays` in event broadcasts
+
 ### Updated
 
 ### Fixed
@@ -44,7 +46,6 @@ Fixed `package.json` version number.
 - Notifications display time can be set in request
 - Newsfeed: added support for `ARTICLE_INFO_REQUEST` notification
 - Add `name` config option for calendars to be sent along with event broadcasts
-- Add `includePastEvents` config option for calendars to include events from the past `maximumNumberOfDays` in event broadcasts
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Fixed `package.json` version number.
 - Notifications display time can be set in request
 - Newsfeed: added support for `ARTICLE_INFO_REQUEST` notification
 - Add `name` config option for calendars to be sent along with event broadcasts
+- Add `includePastEvents` config option for calendars to include events from the past `maximumNumberOfDays` in event broadcasts
 
 ### Updated
 - Bumped the Electron dependency to v3.0.13 to support the most recent Raspbian. [#1500](https://github.com/MichMich/MagicMirror/issues/1500)

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -55,7 +55,7 @@ The following properties can be configured:
 | `hideOngoing`                | Hides calendar events that have already started. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `excludedEvents`             | An array of words / phrases from event titles that will be excluded from being shown. <br><br>Additionally advanced filter objects can be passed in. Below is the configuration for the advance filtering object.<br>**Required**<br>`filterBy` - string used to determine if filter is applied.<br>**Optional**<br>`until` - Time before an event to display it  Ex: [`'3 days'`, `'2 months'`, `'1 week'`]<br>`caseSensitive` - By default, excludedEvents are case insensitive, set this to true to enforce case sensitivity<br>`regex` - set to `true` if filterBy is a regex. For those not familiar with regex it is used for pattern matching, please see [here](https://regexr.com/) for more info.<br><br> **Example:** `['Birthday', 'Hide This Event', {filterBy: 'Payment', until: '6 days', caseSensitive: true}, {filterBy: '^[0-9]{1,}.*', regex: true}]` <br> **Default value:** `[]`
 | `sliceMultiDayEvents`        | If this is set to true, events exceeding at least one midnight will be sliced into separate events including a counter like (1/2). This is especially helpful in "dateheaders" mode. Events will be sliced at midnight, end time for all events but the last will be 23:59 **Default value:** `false`
-| `includePastEvents`          | If this is set to true, events from the past `maximumNumberOfDays` will be included in event broadcasts <br> **Default value:** `false`
+| `broadcastPastEvents`        | If this is set to true, events from the past `maximumNumberOfDays` will be included in event broadcasts <br> **Default value:** `false`
 
 
 ### Calendar configuration
@@ -97,7 +97,7 @@ config: {
 | `symbolClass`         | Add a class to the cell of symbol.
 | `titleClass`          | Add a class to the title's cell.
 | `timeClass`           | Add a class to the time's cell.
-| `includePastEvents`   | Whether to include past events from this calendar.  Overrides global setting
+| `broadcastPastEvents` | Whether to include past events from this calendar.  Overrides global setting
 
 
 #### Calendar authentication options:

--- a/modules/default/calendar/README.md
+++ b/modules/default/calendar/README.md
@@ -55,6 +55,7 @@ The following properties can be configured:
 | `hideOngoing`                | Hides calendar events that have already started. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `excludedEvents`             | An array of words / phrases from event titles that will be excluded from being shown. <br><br>Additionally advanced filter objects can be passed in. Below is the configuration for the advance filtering object.<br>**Required**<br>`filterBy` - string used to determine if filter is applied.<br>**Optional**<br>`until` - Time before an event to display it  Ex: [`'3 days'`, `'2 months'`, `'1 week'`]<br>`caseSensitive` - By default, excludedEvents are case insensitive, set this to true to enforce case sensitivity<br>`regex` - set to `true` if filterBy is a regex. For those not familiar with regex it is used for pattern matching, please see [here](https://regexr.com/) for more info.<br><br> **Example:** `['Birthday', 'Hide This Event', {filterBy: 'Payment', until: '6 days', caseSensitive: true}, {filterBy: '^[0-9]{1,}.*', regex: true}]` <br> **Default value:** `[]`
 | `sliceMultiDayEvents`        | If this is set to true, events exceeding at least one midnight will be sliced into separate events including a counter like (1/2). This is especially helpful in "dateheaders" mode. Events will be sliced at midnight, end time for all events but the last will be 23:59 **Default value:** `false`
+| `includePastEvents`          | If this is set to true, events from the past `maximumNumberOfDays` will be included in event broadcasts <br> **Default value:** `false`
 
 
 ### Calendar configuration
@@ -96,6 +97,7 @@ config: {
 | `symbolClass`         | Add a class to the cell of symbol.
 | `titleClass`          | Add a class to the title's cell.
 | `timeClass`           | Add a class to the time's cell.
+| `includePastEvents`   | Whether to include past events from this calendar.  Overrides global setting
 
 
 #### Calendar authentication options:

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -50,7 +50,7 @@ Module.register("calendar", {
 		broadcastEvents: true,
 		excludedEvents: [],
 		sliceMultiDayEvents: false,
-		includePastEvents: false,
+		broadcastPastEvents: false,
 	},
 
 	// Define required scripts.
@@ -85,7 +85,7 @@ Module.register("calendar", {
 			var calendarConfig = {
 				maximumEntries: calendar.maximumEntries,
 				maximumNumberOfDays: calendar.maximumNumberOfDays,
-				includePastEvents: calendar.includePastEvents,
+				broadcastPastEvents: calendar.broadcastPastEvents,
 			};
 			if (calendar.symbolClass === "undefined" || calendar.symbolClass === null) {
 				calendarConfig.symbolClass = "";
@@ -556,7 +556,7 @@ Module.register("calendar", {
 			titleClass: calendarConfig.titleClass,
 			timeClass: calendarConfig.timeClass,
 			auth: auth,
-			includePastEvents: calendarConfig.includePastEvents || this.config.includePastEvents,
+			broadcastPastEvents: calendarConfig.broadcastPastEvents || this.config.broadcastPastEvents,
 		});
 	},
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -49,7 +49,8 @@ Module.register("calendar", {
 		},
 		broadcastEvents: true,
 		excludedEvents: [],
-		sliceMultiDayEvents: false
+		sliceMultiDayEvents: false,
+		includePastEvents: false,
 	},
 
 	// Define required scripts.
@@ -83,7 +84,8 @@ Module.register("calendar", {
 
 			var calendarConfig = {
 				maximumEntries: calendar.maximumEntries,
-				maximumNumberOfDays: calendar.maximumNumberOfDays
+				maximumNumberOfDays: calendar.maximumNumberOfDays,
+				includePastEvents: calendar.includePastEvents,
 			};
 			if (calendar.symbolClass === "undefined" || calendar.symbolClass === null) {
 				calendarConfig.symbolClass = "";
@@ -467,6 +469,9 @@ Module.register("calendar", {
 			var calendar = this.calendarData[c];
 			for (var e in calendar) {
 				var event = JSON.parse(JSON.stringify(calendar[e])); // clone object
+				if(event.endDate < now) {
+					continue;
+				}
 				if(this.config.hidePrivate) {
 					if(event.class === "PRIVATE") {
 						  // do not add the current event, skip it
@@ -550,7 +555,8 @@ Module.register("calendar", {
 			symbolClass: calendarConfig.symbolClass,
 			titleClass: calendarConfig.titleClass,
 			timeClass: calendarConfig.timeClass,
-			auth: auth
+			auth: auth,
+			includePastEvents: calendarConfig.includePastEvents || this.config.includePastEvents,
 		});
 	},
 

--- a/modules/default/calendar/debug.js
+++ b/modules/default/calendar/debug.js
@@ -15,6 +15,7 @@ var maximumEntries = 10;
 var maximumNumberOfDays = 365;
 var user = "magicmirror";
 var pass = "MyStrongPass";
+var includePastEvents = false;
 
 var auth = {
 	user: user,

--- a/modules/default/calendar/debug.js
+++ b/modules/default/calendar/debug.js
@@ -15,7 +15,7 @@ var maximumEntries = 10;
 var maximumNumberOfDays = 365;
 var user = "magicmirror";
 var pass = "MyStrongPass";
-var includePastEvents = false;
+var broadcastPastEvents = false;
 
 var auth = {
 	user: user,

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -24,7 +24,7 @@ module.exports = NodeHelper.create({
 	socketNotificationReceived: function(notification, payload) {
 		if (notification === "ADD_CALENDAR") {
 			//console.log('ADD_CALENDAR: ');
-			this.createFetcher(payload.url, payload.fetchInterval, payload.excludedEvents, payload.maximumEntries, payload.maximumNumberOfDays, payload.auth);
+			this.createFetcher(payload.url, payload.fetchInterval, payload.excludedEvents, payload.maximumEntries, payload.maximumNumberOfDays, payload.auth, payload.includePastEvents);
 		}
 	},
 
@@ -36,7 +36,7 @@ module.exports = NodeHelper.create({
 	 * attribute reloadInterval number - Reload interval in milliseconds.
 	 */
 
-	createFetcher: function(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth) {
+	createFetcher: function(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, includePastEvents) {
 		var self = this;
 
 		if (!validUrl.isUri(url)) {
@@ -47,7 +47,7 @@ module.exports = NodeHelper.create({
 		var fetcher;
 		if (typeof self.fetchers[url] === "undefined") {
 			console.log("Create new calendar fetcher for url: " + url + " - Interval: " + fetchInterval);
-			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth);
+			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, includePastEvents);
 
 			fetcher.onReceive(function(fetcher) {
 				//console.log('Broadcast events.');

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -24,7 +24,7 @@ module.exports = NodeHelper.create({
 	socketNotificationReceived: function(notification, payload) {
 		if (notification === "ADD_CALENDAR") {
 			//console.log('ADD_CALENDAR: ');
-			this.createFetcher(payload.url, payload.fetchInterval, payload.excludedEvents, payload.maximumEntries, payload.maximumNumberOfDays, payload.auth, payload.includePastEvents);
+			this.createFetcher(payload.url, payload.fetchInterval, payload.excludedEvents, payload.maximumEntries, payload.maximumNumberOfDays, payload.auth, payload.broadcastPastEvents);
 		}
 	},
 
@@ -36,7 +36,7 @@ module.exports = NodeHelper.create({
 	 * attribute reloadInterval number - Reload interval in milliseconds.
 	 */
 
-	createFetcher: function(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, includePastEvents) {
+	createFetcher: function(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents) {
 		var self = this;
 
 		if (!validUrl.isUri(url)) {
@@ -47,7 +47,7 @@ module.exports = NodeHelper.create({
 		var fetcher;
 		if (typeof self.fetchers[url] === "undefined") {
 			console.log("Create new calendar fetcher for url: " + url + " - Interval: " + fetchInterval);
-			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, includePastEvents);
+			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents);
 
 			fetcher.onReceive(function(fetcher) {
 				//console.log('Broadcast events.');


### PR DESCRIPTION
For my module MMM-MonthlyCalendar, I need access to events that have already past.  This change will allow users to broadcast those events, while still only displaying future events in the default calendar module.