### PR TITLE
Handle SIGTERM messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 
 ### Fixed
+- Handle SIGTERM messages
 
 ## [2.7.1] - 2019-04-02
 

--- a/js/app.js
+++ b/js/app.js
@@ -263,6 +263,15 @@ var App = function() {
 		this.stop();
 		process.exit(0);
 	});
+	
+	/* We also need to listen to SIGTERM signals so we stop everything when we are asked to stop by the OS.
+	 */
+	process.on("SIGTERM", () => {
+		console.log("[SIGTERM] Received. Shutting down server...");
+		setTimeout(() => { process.exit(0); }, 3000);  // Force quit after 3 seconds
+		this.stop();
+		process.exit(0);
+	});
 };
 
 module.exports = new App();

--- a/js/app.js
+++ b/js/app.js
@@ -263,7 +263,7 @@ var App = function() {
 		this.stop();
 		process.exit(0);
 	});
-	
+
 	/* We also need to listen to SIGTERM signals so we stop everything when we are asked to stop by the OS.
 	 */
 	process.on("SIGTERM", () => {


### PR DESCRIPTION
This adds a handler for SIGTERM messages. They currently are ignored. This causes the app to keep on running when asked by the operating system to stop (like during a reboot) or when docker wants it to stop.

Related pull request is https://github.com/bastilimbach/docker-MagicMirror/pull/22
