### PR TITLE
Fix sliceMultiDayEvents so it respects maximumNumberOfDays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Handle SIGTERM messages
+- Fixes sliceMultiDayEvents so it respects maximumNumberOfDays
 
 ## [2.7.1] - 2019-04-02
 


### PR DESCRIPTION
Fixes #1651 

This MR fixes sliceMultiDayEvents. There were a few issues with it:
* maximumNumberOfDays wasn't respected since only the startDate was taken into account
* past days of a multi-day event were still displayed (problematic with an event that spans a whole week for example)
* today wasn't set on the correct day
* the `var event` wasn't cloned so changes were made pass by reference, therefore, it was already splitted in the next iteration of a call to `createEventList`.