### PR TITLE
Update config.js.sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 - English translation for "Feels" to "Feels like"
+- Fixed the example calender url in `config.js.sample`
 
 ### Fixed
 - Handle SIGTERM messages

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -45,8 +45,7 @@ var config = {
 				calendars: [
 					{
 						symbol: "calendar-check",
-						url: "webcal://www.calendarlabs.com/templates/ical/US-Holidays.ics"
-					}
+						url: "webcal://www.calendarlabs.com/ical-calendar/ics/76/US_Holidays.ics"					}
 				]
 			}
 		},


### PR DESCRIPTION
Changes the URL to show the default calendar since the old URL was bad
