### PR TITLE
allow html5 autoplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Update `ical.js` to solve various calendar issues.
 
 ### Fixed
+- Allowance HTML5 autoplay-policy (policy is changed from Chrome 66 updates)
 - Handle SIGTERM messages
 - Fixes sliceMultiDayEvents so it respects maximumNumberOfDays
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -17,7 +17,7 @@ const BrowserWindow = electron.BrowserWindow;
 let mainWindow;
 
 function createWindow() {
-	app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
+	app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 	var electronOptionsDefaults = {
 		width: 800,
 		height: 600,

--- a/js/electron.js
+++ b/js/electron.js
@@ -17,6 +17,7 @@ const BrowserWindow = electron.BrowserWindow;
 let mainWindow;
 
 function createWindow() {
+	app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
 	var electronOptionsDefaults = {
 		width: 800,
 		height: 600,


### PR DESCRIPTION
From Chrome 66 updated, autoplay-policy is changed. This 1 line added can help MM to play HTML5 audio and video without user's direct allowance.

I think it might be better to make it configurable, but that could be excessive solicitude.