### PR TITLE
Calendar: only slice multi-day events when they actually span midnight

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -493,11 +493,11 @@ Module.register("calendar", {
 				/* if sliceMultiDayEvents is set to true, multiday events (events exceeding at least one midnight) are sliced into days,
 				* otherwise, esp. in dateheaders mode it is not clear how long these events are.
 				*/
-				if (this.config.sliceMultiDayEvents) {
+				var maxCount = Math.ceil(((event.endDate - 1) - moment(event.startDate, "x").endOf("day").format("x"))/(1000*60*60*24)) + 1;
+				if (this.config.sliceMultiDayEvents && maxCount > 1) {
 					var splitEvents = [];
 					var midnight = moment(event.startDate, "x").clone().startOf("day").add(1, "day").format("x");
 					var count = 1;
-					var maxCount = Math.ceil(((event.endDate - 1) - moment(event.startDate, "x").endOf("day").format("x"))/(1000*60*60*24)) + 1;
 					while (event.endDate > midnight) {
 						var thisEvent = JSON.parse(JSON.stringify(event)) // clone object
 						thisEvent.today = thisEvent.startDate >= today && thisEvent.startDate < (today + 24 * 60 * 60 * 1000);


### PR DESCRIPTION
The changes made in #1652 mean that when the calendar's `sliceMultiDayEvents` config is set to `true`, *all* events display the split count appended to them, so 1 hour events in the middle of the day still have "(1/1)" appended to the title. This fix restores the expected behavior of only adding day split counts to those events spanning more than one day.

This fix checks that we are actually spanning multiple days before we enter the event slicing code. In order to do so, I did move the `maxCount` var and calculation up a level -- I'm not sure which style would be preferred: this way, or to add an intermediate logical level only run if `sliceMultiDayEvents` is true (e.g. nest another `if` within the current `sliceMultiDayEvents` check).



> Don't forget to add the change to CHANGELOG.md.

I'm unclear if I should update the Changelog, as this is a fix of an item in the current unreleased "Fixed" section?


