### PR TITLE
Only call updateDom in clock.js when the content has changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed the example calender url in `config.js.sample`
 - Update `ical.js` to solve various calendar issues.
 - Update weather city list url [#1676](https://github.com/MichMich/MagicMirror/issues/1676) 
+- Only update clock once per minute when seconds aren't shown
 
 ### Fixed
 - Allowance HTML5 autoplay-policy (policy is changed from Chrome 66 updates)

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -41,8 +41,11 @@ Module.register("clock",{
 
 		// Schedule update interval.
 		var self = this;
+		self.lastDisplayedMinute = null;
 		setInterval(function() {
-			self.updateDom();
+			if (self.config.displaySeconds || self.lastDisplayedMinute !== moment().minute()) {
+				self.updateDom();
+			}
 		}, 1000);
 
 		// Set locale.
@@ -75,6 +78,7 @@ Module.register("clock",{
 		// See issue: https://github.com/MichMich/MagicMirror/issues/181
 		var timeString;
 		var now = moment();
+		this.lastDisplayedMinute = now.minute();
 		if (this.config.timezone) {
 			now.tz(this.config.timezone);
 		}


### PR DESCRIPTION
I'm running my magicmirror on a pi zero w, and having the clock call updateDom every second can cause noticeable lag when any other widgets update.  If seconds are hidden, we should only call updateDom once per minute, when the clock content is actually changing.