### PR TITLE
Add news feed broadcast or update for default newsfeed module 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Russian translation for “Feels”
 - Calendar module: added `nextDaysRelative` config option
 - Add `broadcastPastEvents` config option for calendars to include events from the past `maximumNumberOfDays` in event broadcasts
+- Added feature to broadcast news feed items `NEWS_FEED` and updated news items `NEWS_FEED_UPDATED` in default [newsfeed](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/newsfeed) module (when news is updated) with documented default and `config.js` options in [README.md](https://github.com/MichMich/MagicMirror/blob/develop/modules/default/newsfeed/README.md)
 
 ### Updated
 - English translation for "Feels" to "Feels like"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Allowance HTML5 autoplay-policy (policy is changed from Chrome 66 updates)
 - Handle SIGTERM messages
 - Fixes sliceMultiDayEvents so it respects maximumNumberOfDays
+- Minor types in default NewsFeed [README.md](https://github.com/MichMich/MagicMirror/blob/develop/modules/default/newsfeed/README.md)
 
 ## [2.7.1] - 2019-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Calendar module: added `nextDaysRelative` config option
 - Add `broadcastPastEvents` config option for calendars to include events from the past `maximumNumberOfDays` in event broadcasts
 - Added feature to broadcast news feed items `NEWS_FEED` and updated news items `NEWS_FEED_UPDATED` in default [newsfeed](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/newsfeed) module (when news is updated) with documented default and `config.js` options in [README.md](https://github.com/MichMich/MagicMirror/blob/develop/modules/default/newsfeed/README.md)
+- Added notifications to default `clock` module broadcasting `CLOCK_SECOND` and `CLOCK_MINUTE` for the respective time elapsed.
 
 ### Updated
 - English translation for "Feels" to "Feels like"

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -83,7 +83,9 @@ var config = {
 					}
 				],
 				showSourceTitle: true,
-				showPublishDate: true
+				showPublishDate: true,
+				broadcastNewsFeeds: true,
+				broadcastNewsUpdates: true
 			}
 		},
 	]

--- a/modules/default/clock/README.md
+++ b/modules/default/clock/README.md
@@ -44,3 +44,14 @@ The following properties can be configured:
 | `analogPlacement` | **Specific to the analog clock. _(requires displayType set to `'both'`)_** Specifies where the analog clock is in relation to the digital clock <br><br> **Possible values:** `top`, `right`, `bottom`, or `left` <br> **Default value:** `bottom`
 | `analogShowDate`  | **Specific to the analog clock.** If the clock is used as a separate module and set to analog only, this configures whether a date is also displayed with the clock. <br><br> **Possible values:** `false`, `top`, or `bottom` <br> **Default value:** `top`
 | `timezone`        | Specific a timezone to show clock. <br><br> **Possible examples values:** `America/New_York`, `America/Santiago`, `Etc/GMT+10` <br> **Default value:** `none`. See more informations about configuration value [here](https://momentjs.com/timezone/docs/#/data-formats/packed-format/)
+
+## Notifications
+
+The clock makes use of the built-in [Notification Mechanism](https://github.com/michMich/MagicMirror/wiki/notifications) to relay notifications to all modules.
+
+Current notifications are:
+
+| Notification      | Description
+| ----------------- | -----------
+| `CLOCK_SECOND`    | A second has elapsed. <br> *Parameter*: second value
+| `CLOCK_MINUTE`    | A minute has elapsed <br> *Parameter*: minute value

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -41,10 +41,24 @@ Module.register("clock",{
 
 		// Schedule update interval.
 		var self = this;
+		self.second = 0;
+		self.minute = 0;
 		self.lastDisplayedMinute = null;
 		setInterval(function() {
 			if (self.config.displaySeconds || self.lastDisplayedMinute !== moment().minute()) {
 				self.updateDom();
+			}
+			if (self.second === 59) {
+				self.second = 0;
+				if (self.minute === 59){
+					self.minute = 0;
+				} else {
+					self.minute++;
+				}
+				self.sendNotification("CLOCK_MINUTE", self.minute);
+			} else {
+				self.second++;
+				self.sendNotification("CLOCK_SECOND", self.second);
 			}
 		}, 1000);
 

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -48,6 +48,14 @@ MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/t
 | `ARTICLE_TOGGLE_FULL`   | Toggles article in fullscreen.
 | `ARTICLE_INFO_REQUEST`  | Causes `newsfeed` to respond with the notification `ARTICLE_INFO_RESPONSE`, the payload of which provides the `title`, `source`, `date`, `desc` and `url` of the current news title.
 
+#### Notifications sent by the module
+MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/tree/master/modules#thissendnotificationnotification-payload) can also be used to send notifications from the current module to all other modules. The following notifications are broadcasted from this module:
+
+| Notification Identifier | Description
+| ----------------------- | -----------
+| `NEWS_FEED`             | Broadcast the current list of news items.
+| `NEWS_FEED_UPDATE`      | Broadcasts the list of updates news items.
+
 Note the payload of the sent notification event is ignored.
 
 #### Example
@@ -68,6 +76,8 @@ The following properties can be configured:
 | `feeds`            | An array of feed urls that will be used as source. <br> More info about this object can be found below. <br> **Default value:** `[{ title: "New York Times", url: "http://www.nytimes.com/services/xml/rss/nyt/HomePage.xml", encoding: "UTF-8" }]`<br>You can add `reloadInterval` option to set particular reloadInterval to a feed.
 | `showSourceTitle`  | Display the title of the source. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showPublishDate`  | Display the publish date of an headline. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `broadcastNewsFeeds`   | Gives the ability to broadcast news feeds to all modules, by using ```sendNotification()``` when set to `true`, rather than ```sendSocketNotification()``` when `false` <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
+| `broadcastNewsUpdates`   | Gives the ability to broadcast news feed updates to all modules <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `showDescription`  | Display the description of an item. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `false`
 | `wrapTitle`        | Wrap the title of the item to multiple lines. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`
 | `wrapDescription`  | Wrap the description of the item to multiple lines. <br><br> **Possible values:** `true` or `false` <br> **Default value:** `true`

--- a/modules/default/newsfeed/README.md
+++ b/modules/default/newsfeed/README.md
@@ -45,7 +45,7 @@ MagicMirror's [notification mechanism](https://github.com/MichMich/MagicMirror/t
 | `ARTICLE_PREVIOUS`      | Shows the previous news title (hiding the summary or previously fully displayed article)
 | `ARTICLE_MORE_DETAILS`  | When received the _first time_, shows the corresponding description of the currently displayed news title. <br> The module expects that the module's configuration option `showDescription` is set to `false` (default value). <br><br> When received a _second consecutive time_, shows the full news article in an IFRAME. <br> This requires that the news page can be embedded in an IFRAME, e.g. doesn't have the HTTP response header [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) set to e.g. `DENY`.<br><br>When received the _next consecutive times_, reloads the page and scrolls down by `scrollLength` pixels to paginate through the article.
 | `ARTICLE_LESS_DETAILS`  | Hides the summary or full news article and only displays the news title of the currently viewed news item.
-| `ARTICLE_TOGGLE_FULL`   | Toogles article in fullscreen.
+| `ARTICLE_TOGGLE_FULL`   | Toggles article in fullscreen.
 | `ARTICLE_INFO_REQUEST`  | Causes `newsfeed` to respond with the notification `ARTICLE_INFO_RESPONSE`, the payload of which provides the `title`, `source`, `date`, `desc` and `url` of the current news title.
 
 Note the payload of the sent notification event is ignored.
@@ -80,7 +80,7 @@ The following properties can be configured:
 | `maxNewsItems`     | Total amount of news items to cycle through. (0 for unlimited) <br><br> **Possible values:**`0` - `...` <br> **Default value:** `0`
 | `ignoreOldItems`   | Ignore news items that are outdated. <br><br> **Possible values:**`true` or `false` <br> **Default value:** `false`
 | `ignoreOlderThan`  | How old should news items be before they are considered outdated? (Milliseconds) <br><br> **Possible values:**`1` - `...` <br> **Default value:** `86400000` (1 day)
-| `removeStartTags`  | Some newsfeeds feature tags at the **beginning** of their titles or descriptions, such as _[VIDEO]_. This setting allows for the removal of specified tags from the beginning of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
+| `removeStartTags`  | Some news feeds feature tags at the **beginning** of their titles or descriptions, such as _[VIDEO]_. This setting allows for the removal of specified tags from the beginning of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
 | `startTags`        | List the tags you would like to have removed at the beginning of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`
 | `removeEndTags`    | Remove specified tags from the **end** of an item's description and/or title. <br><br> **Possible values:**`'title'`, `'description'`, `'both'`
 | `endTags`          | List the tags you would like to have removed at the end of the feed item <br><br> **Possible values:** `['TAG']` or `['TAG1','TAG2',...]`

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -20,6 +20,8 @@ Module.register("newsfeed",{
 		],
 		showSourceTitle: true,
 		showPublishDate: true,
+		broadcastNewsFeeds: true,
+		broadcastNewsUpdates: true,
 		showDescription: false,
 		wrapTitle: true,
 		wrapDescription: true,
@@ -266,6 +268,20 @@ Module.register("newsfeed",{
 			}, this);
 		}
 
+		// get updated news items and broadcast them
+		var updatedItems = [];
+		newsItems.forEach(value => {
+			if (this.newsItems.findIndex(value1 => value1 === value) === -1) {
+				// Add item to updated items list
+				updatedItems.push(value)
+			}
+		});
+
+		// check if updated items exist, if so and if we should broadcast these updates, then lets do so
+		if (this.config.broadcastNewsUpdates && updatedItems.length > 0) {
+			this.sendNotification("NEWS_FEED_UPDATE", {items: updatedItems})
+		}
+
 		this.newsItems = newsItems;
 	},
 
@@ -314,6 +330,11 @@ Module.register("newsfeed",{
 		timer = setInterval(function() {
 			self.activeItem++;
 			self.updateDom(self.config.animationSpeed);
+
+			// Broadcast NewsFeed if needed
+			if (self.config.broadcastNewsFeeds) {
+				self.sendNotification("NEWS_FEED", {items: self.newsItems});
+			}
 		}, this.config.updateInterval);
 	},
 


### PR DESCRIPTION
* Does the pull request solve a **related** issue?
Nope.

* What does the pull request accomplish? Use a list if needed.
Using the default `newsfeed` module, it can now broadcast news feed items to other modules, alternatively broadcast only news feed updates.

A minor feature, yet it is something useful.