### PR TITLE
fixed calendar, issue 1696, ics file start date is not date type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Only update clock once per minute when seconds aren't shown
 
 ### Fixed
+- fixed issue #1696(https://github.com/MichMich/MagicMirror/issues/1696), some ical files start date to not parse to date type 
 - Allowance HTML5 autoplay-policy (policy is changed from Chrome 66 updates)
 - Handle SIGTERM messages
 - Fixes sliceMultiDayEvents so it respects maximumNumberOfDays

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Only update clock once per minute when seconds aren't shown
 
 ### Fixed
-- fixed issue #1696(https://github.com/MichMich/MagicMirror/issues/1696), some ical files start date to not parse to date type 
+- fixed issue [#1696](https://github.com/MichMich/MagicMirror/issues/1696), some ical files start date to not parse to date type 
 - Allowance HTML5 autoplay-policy (policy is changed from Chrome 66 updates)
 - Handle SIGTERM messages
 - Fixes sliceMultiDayEvents so it respects maximumNumberOfDays

--- a/modules/default/calendar/vendor/ical.js/node-ical.js
+++ b/modules/default/calendar/vendor/ical.js/node-ical.js
@@ -43,8 +43,10 @@ ical.objectHandlers['END'] = function(val, params, curr, stack){
       }
     }
     for (var i in curr.exdates) {
-      rule += ' EXDATE:' + curr.exdates[i].toISOString().replace(/[-:]/g, '');
-      rule = rule.replace(/\.[0-9]{3}/, '');
+        if( typeof (curr.exdates[i]) === "date") {
+            rule += ' EXDATE:' + curr.exdates[i].toISOString().replace(/[-:]/g, '');
+            rule = rule.replace(/\.[0-9]{3}/, '');
+        }
     }
     try {
       curr.rrule = rrulestr(rule);

--- a/modules/default/calendar/vendor/ical.js/node-ical.js
+++ b/modules/default/calendar/vendor/ical.js/node-ical.js
@@ -37,8 +37,10 @@ ical.objectHandlers['END'] = function(val, params, curr, stack){
         }
       }
 
-      rule += ' DTSTART:' + curr.start.toISOString().replace(/[-:]/g, '');
-      rule = rule.replace(/\.[0-9]{3}/, '');
+      if( typeof (curr.start) === "date") {
+          rule += ' DTSTART:' + curr.start.toISOString().replace(/[-:]/g, '');
+          rule = rule.replace(/\.[0-9]{3}/, '');
+      }
     }
     for (var i in curr.exdates) {
       rule += ' EXDATE:' + curr.exdates[i].toISOString().replace(/[-:]/g, '');


### PR DESCRIPTION
Fixes issue #1696
Symptom: calendar does not sync. But has not relation to authentication. The start date was simply not a date so` toISOString()` failed.
Same fix applied to `exdates[i]`

Tested with this calendar:
[personal.zip](https://github.com/MichMich/MagicMirror/files/3278665/personal.zip)


On the other hand might be that the code above, L33-38, failed, unfortunately I can't debug yet:
```
    if (curr.start.length === 8) {
        var comps = /^(\d{4})(\d{2})(\d{2})$/.exec(curr.start);
        if (comps) {
         curr.start = new Date (comps[1], comps[2] - 1, comps[3]);
        }
      }
```