### PR TITLE
allow location property in config,js to be used as header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - optionally display probability of precipitation (PoP) in current weather (UK Met Office data)
 - automatically try to fix eslint errors by passing `--fix` option to it
 - Added sunrise and sunset times to weathergov weather provider [#1705](https://github.com/MichMich/MagicMirror/issues/1705)
+- Added "useLocationAsHeader" to display "location" in `config.js` as header when location name is not returned
 
 ### Updated
 - English translation for "Feels" to "Feels like"

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -60,6 +60,7 @@ The following properties can be configured:
 | `apiBase`                    | The OpenWeatherMap base URL. <br><br> **Default value:**  `'http://api.openweathermap.org/data/'`
 | `weatherEndpoint`	           | The OpenWeatherMap API endPoint. <br><br> **Default value:**  `'weather'`
 | `appendLocationNameToHeader` | If set to `true`, the returned location name will be appended to the header of the module, if the header is enabled. This is mainly intresting when using calender based weather. <br><br> **Default value:**  `true`
+| `useLocationAsHeader` | If set to `true` and location is given a value, the value of location will be used as the header. This is useful if `locationName` was not returned. <br><br> **Default value:** `false`
 | `calendarClass`              | The class for the calender module to base the event based weather information on. <br><br> **Default value:**  `'calendar'`
 | `iconTable`                  | The conversion table to convert the weather conditions to weather-icons. <br><br> **Default value:**  view tabel below.
 

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -23,6 +23,7 @@ Module.register("currentweather",{
 		showWindDirection: true,
 		showWindDirectionAsArrow: false,
 		useBeaufort: true,
+		appendLocationNameToHeader: false,
 		useKMPHwind: false,
 		lang: config.language,
 		decimalSymbol: ".",
@@ -269,6 +270,10 @@ Module.register("currentweather",{
 			return this.data.header + " " + this.fetchedLocationName;
 		}
 
+		if (this.config.useLocationAsHeader && this.config.location !== false) {
+			return this.config.location;
+		}
+		
 		return this.data.header;
 	},
 


### PR DESCRIPTION
I was not getting location name back on the header, and wanted to reuse the formatting, so I added a `useLocationAsHeader` (defaulted to false) property to allow the use of the `location` property given in `config.js`  
  
If `appendLocationNameToHeader` is true and a locationName is returned we use that, otherwise we use the location assuming it was given and `useLocationAsHeader` is `true` 
