### PR TITLE
update installer to handle non-pi and other issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
+### Updated installer
+- give non-pi2+ users (pi0, odroid, jetson nano, mac, windows, ...) option to continue install
+- use current username vs hardcoded 'pi' to support non-pi install
+- check for npm installed. node install doesn't do npm anymore
+- check for mac as part of PM2 install, add install option string
+- update pm2 config with current username instead of hard coded 'pi'
+- check for screen saver config, "/etc/xdg/lxsession", bypass if not setup
 
 ❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror² core.
 

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # This is an installer script for MagicMirror2. It works well enough
 # that it can detect if you have Node installed, run a binary script
@@ -20,21 +20,29 @@ echo -e "\e[0m"
 
 # Define the tested version of Node.js.
 NODE_TESTED="v5.1.0"
+NPM_TESTED="V6.0.0"
+USER=`whoami`
+PM2_FILE=~/MagicMirror/installers/pm2_MagicMirror.json
 
 # Determine which Pi is running.
 ARM=$(uname -m) 
 
 # Check the Raspberry Pi version.
 if [ "$ARM" != "armv7l" ]; then
-	echo -e "\e[91mSorry, your Raspberry Pi is not supported."
-	echo -e "\e[91mPlease run MagicMirror on a Raspberry Pi 2 or 3."
-	echo -e "\e[91mIf this is a Pi Zero, you are in the same boat as the original Raspberry Pi. You must run in server only mode."
+  read -p "this appears not to be a Raspberry Pi 2 or 3, do you want to continue installtion (y/N)?" choice 
+	if [[ $choice =~ ^[Nn]$ ]]; then 
+		echo -e "\e[91mSorry, your Raspberry Pi is not supported."
+		echo -e "\e[91mPlease run MagicMirror on a Raspberry Pi 2 or 3."
+		echo -e "\e[91mIf this is a Pi Zero, you are in the same boat as the original Raspberry Pi. You must run in server only mode."
 	exit;
+	fi
 fi
 
+    
 # Define helper methods.
-function version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
 function command_exists () { type "$1" &> /dev/null ;}
+function verlte() {  [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ];}
+function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 
 # Update before first apt-get
 echo -e "\e[96mUpdating packages ...\e[90m"
@@ -47,12 +55,12 @@ sudo apt-get --assume-yes install curl wget git build-essential unzip || exit
 # Check if we need to install or upgrade Node.js.
 echo -e "\e[96mCheck current Node installation ...\e[0m"
 NODE_INSTALL=false
-if command_exists node && command_exists npm; then
+if command_exists node; then
 	echo -e "\e[0mNode currently installed. Checking version number.";
 	NODE_CURRENT=$(node -v)
 	echo -e "\e[0mMinimum Node version: \e[1m$NODE_TESTED\e[0m"
 	echo -e "\e[0mInstalled Node version: \e[1m$NODE_CURRENT\e[0m"
-	if version_gt $NODE_TESTED $NODE_CURRENT; then
+	if verlte $NODE_CURRENT $NODE_TESTED; then
 		echo -e "\e[96mNode should be upgraded.\e[0m"
 		NODE_INSTALL=true
 
@@ -83,9 +91,54 @@ if $NODE_INSTALL; then
 	# Only tested (stable) versions are recommended as newer versions could break MagicMirror.
 	
 	NODE_STABLE_BRANCH="10.x"
-	curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
-	sudo apt-get install -y nodejs
+ 	curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
+ 	sudo apt-get install -y nodejs
 	echo -e "\e[92mNode.js installation Done!\e[0m"
+fi
+
+# Check if we need to install or upgrade npm.
+echo -e "\e[96mCheck current NPM installation ...\e[0m"
+NPM_INSTALL=false
+if command_exists npm; then
+	echo -e "\e[0mNPM currently installed. Checking version number.";
+	NPM_CURRENT='V'$(npm -v)
+	echo -e "\e[0mMinimum npm version: \e[1m$NPM_TESTED\e[0m"
+	echo -e "\e[0mInstalled npm version: \e[1m$NPM_CURRENT\e[0m"
+	if verlte $NPM_CURRENT $NPM_TESTED; then
+		echo -e "\e[96mnpm should be upgraded.\e[0m"
+		NPM_INSTALL=true
+
+		# Check if a node process is currently running.
+		# If so abort installation.
+		if pgrep "npm" > /dev/null; then
+			echo -e "\e[91mA npm process is currently running. Can't upgrade."
+			echo "Please quit all npm processes and restart the installer."
+			exit;
+		fi
+
+	else
+		echo -e "\e[92mNo npm upgrade necessary.\e[0m"
+	fi
+
+else
+	echo -e "\e[93mnpm is not installed.\e[0m";
+	NPM_INSTALL=true
+fi
+
+# Install or upgrade node if necessary.
+if $NPM_INSTALL; then
+	
+	echo -e "\e[96mInstalling npm ...\e[90m"
+
+	# Fetch the latest version of npm from the selected branch
+	# The NODE_STABLE_BRANCH variable will need to be manually adjusted when a new branch is released. (e.g. 7.x)
+	# Only tested (stable) versions are recommended as newer versions could break MagicMirror.
+	
+	#NODE_STABLE_BRANCH="9.x"
+	#curl -sL https://deb.nodesource.com/setup_$NODE_STABLE_BRANCH | sudo -E bash -
+  #
+  sudo apt-get install -y npm
+	echo -e "\e[92mnpm installation Done!\e[0m"
 fi
 
 # Install MagicMirror
@@ -151,20 +204,38 @@ fi
 # Use pm2 control like a service MagicMirror
 read -p "Do you want use pm2 for auto starting of your MagicMirror (y/N)?" choice
 if [[ $choice =~ ^[Yy]$ ]]; then
-    sudo npm install -g pm2
+    #
+    #  check if this is a mac
+    #
+    mac=$(uname -s)
+    up=""
+    if [ $mac == 'Darwin' ]; then 
+       up="--unsafe-perm"
+    fi
+    sudo npm install $up -g pm2
 	if [[ "$(ps --no-headers -o comm 1)" =~ systemd ]]; then #Checking for systemd
-		sudo pm2 startup systemd -u pi --hp /home/pi
+		pm2 startup systemd -u $USER --hp /home/$USER
 	else
-		sudo su -c "env PATH=$PATH:/usr/bin pm2 startup linux -u pi --hp /home/pi"
+		sudo su -c "env PATH=$PATH:/usr/bin pm2 startup linux -u $USER --hp /home/$USER"
 	fi
-	pm2 start ~/MagicMirror/installers/pm2_MagicMirror.json
+  if [ "USER"  != "pi" ]; then 
+		sed 's/pi/'$USER'/g' mm.sh >mm.sh
+    sed 's/pi/'$USER'/g' $PM2_FILE > ~/MagicMirror/installers/pm2_MagicMirror_new.json
+    PM2_FILE=~/MagicMirror/installers/pm2_MagicMirror_new.json
+  fi
+	pm2 start $PM2_FILE 
 	pm2 save
 fi
 # Disable Screensaver
-read -p "Do you want to disable the screen saver? (y/N)?" choice
-if [[ $choice =~ ^[Yy]$ ]]; then
-	sudo su -c "echo -e '@xset s noblank\n@xset s off\n@xset -dpms' >> /etc/xdg/lxsession/LXDE-pi/autostart"
-	export DISPLAY=:0; xset s noblank;xset s off;xset -dpms
+if [ -d "/etc/xdg/lxsession" ]; then
+	read -p "Do you want to disable the screen saver? (y/N)?" choice
+	if [[ $choice =~ ^[Yy]$ ]]; then
+		sudo su -c "echo -e '@xset s noblank\n@xset s off\n@xset -dpms' >> /etc/xdg/lxsession/LXDE-pi/autostart"
+		export DISPLAY=:0; xset s noblank;xset s off;xset -dpms
+	fi
+else
+	echo " "
+	echo -e "unable to disable screen saver, /etc/xdg/lxsession does not exist"
 fi
 
 echo " "


### PR DESCRIPTION
Updated installer
give non-pi2+ users (pi0, odroid, jetson nano, mac, windows, ...) option to continue install
use current username vs hardcoded 'pi' to support non-pi install
check for npm installed. node install doesn't do npm anymore
check for mac as part of PM2 install, add install option string
update pm2 config with current username instead of hard coded 'pi'
check for screen saver config, "/etc/xdg/lxsession", bypass if not setup