### PR TITLE
Fix for weather module not refreshing data after exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Updatenotification module: Properly handle race conditions, prevent crash.
 - Send `NEWS_FEED` notification also for the first news messages which are shown
+- Fixed issue where weather module would not refresh data after a network or API outage [#1722](https://github.com/MichMich/MagicMirror/issues/1722)
 
 ## [2.8.0] - 2019-07-01
 

--- a/modules/default/weather/providers/darksky.js
+++ b/modules/default/weather/providers/darksky.js
@@ -32,7 +32,8 @@ WeatherProvider.register("darksky", {
 				this.setCurrentWeather(currentWeather);
 			}).catch(function(request) {
 				Log.error("Could not load data ... ", request);
-			});
+			})
+			.finally(() => this.updateAvailable())
 	},
 
 	fetchWeatherForecast() {
@@ -47,7 +48,8 @@ WeatherProvider.register("darksky", {
 				this.setWeatherForecast(forecast);
 			}).catch(function(request) {
 				Log.error("Could not load data ... ", request);
-			});
+			})
+			.finally(() => this.updateAvailable())
 	},
 
 	// Create a URL from the config and base URL.

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -34,6 +34,7 @@ WeatherProvider.register("openweathermap", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 	// Overwrite the fetchCurrentWeather method.
@@ -54,6 +55,7 @@ WeatherProvider.register("openweathermap", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 	/** OpenWeatherMap Specific Methods - These are not part of the default provider methods */

--- a/modules/default/weather/providers/ukmetoffice.js
+++ b/modules/default/weather/providers/ukmetoffice.js
@@ -41,6 +41,7 @@ WeatherProvider.register("ukmetoffice", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 	// Overwrite the fetchCurrentWeather method.
@@ -62,6 +63,7 @@ WeatherProvider.register("ukmetoffice", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -35,6 +35,7 @@ WeatherProvider.register("weathergov", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 	// Overwrite the fetchCurrentWeather method.
@@ -53,6 +54,7 @@ WeatherProvider.register("weathergov", {
 			.catch(function(request) {
 				Log.error("Could not load data ... ", request);
 			})
+			.finally(() => this.updateAvailable())
 	},
 
 	/** Weather.gov Specific Methods - These are not part of the default provider methods */

--- a/modules/default/weather/weatherprovider.js
+++ b/modules/default/weather/weatherprovider.js
@@ -79,16 +79,12 @@ var WeatherProvider = Class.extend({
 	setCurrentWeather: function(currentWeatherObject) {
 		// We should check here if we are passing a WeatherDay
 		this.currentWeatherObject = currentWeatherObject;
-
-		this.updateAvailable();
 	},
 
 	// Set the weatherForecastArray and notify the delegate that new information is available.
 	setWeatherForecast: function(weatherForecastArray) {
 		// We should check here if we are passing a WeatherDay
 		this.weatherForecastArray = weatherForecastArray;
-
-		this.updateAvailable();
 	},
 
 	// Set the fetched location name.


### PR DESCRIPTION
fix for #1722  When there is an exception in the API call for weather data, the code is never called again to execute a data refresh.  That part only occurs when there was a successful call.  This change has a finally block to do the notification that there is data available and sets the setTimeout interval to fetch data at the next try.