### PR TITLE
Skip from worktree the css/custom.css:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 - Updatenotification module: Display update notification for a limited (configurable) time.
+- The css/custom.css will be rename after the next release. We've add into `run-start.sh` a instruction by GIT to ignore with `--skip-worktree` and `rm --cached`. The history about this change [#1540].
+
 
 ### Fixed
 - Updatenotification module: Properly handle race conditions, prevent crash.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "sh run-start.sh",
     "install": "cd vendor && npm install",
     "install-fonts": "cd fonts && npm install",
-    "postinstall": "sh installers/postinstall/postinstall.sh && npm run install-fonts",
+    "postinstall": "sh untrack-css.sh && sh installers/postinstall/postinstall.sh && npm run install-fonts",
     "test": "NODE_ENV=test ./node_modules/mocha/bin/mocha tests --recursive",
     "test:unit": "NODE_ENV=test ./node_modules/mocha/bin/mocha tests/unit --recursive",
     "test:e2e": "NODE_ENV=test ./node_modules/mocha/bin/mocha tests/e2e --recursive",

--- a/run-start.sh
+++ b/run-start.sh
@@ -1,3 +1,6 @@
+
+./untrack-css.sh
+
 if [ -z "$DISPLAY" ]; then #If not set DISPLAY is SSH remote or tty
 	export DISPLAY=:0 # Set by default display
 fi

--- a/untrack-css.sh
+++ b/untrack-css.sh
@@ -1,0 +1,11 @@
+# Long history here
+# https://github.com/MichMich/MagicMirror/pull/1540
+STATUS_CUSTOM_CSS=$(git ls-files -v css/custom.css|cut -f 1 --delimiter=" ")
+
+if [ "$STATUS_CUSTOM_CSS" = "H" ]; then
+  echo "We'll remove from the repository the css/custom.css"
+  echo "This script apply git update-index --skip-worktree css/custom.css"
+  git update-index --skip-worktree css/custom.css
+  git rm --cached css/custom.css
+fi
+


### PR DESCRIPTION
On the next release the css/custom.css will rename to
css/custom.css.sample

This change run git instructions to detach the file from own local
repository. This instructions are called in untrack-css.sh file from
run-start.sh and npm postinstall step

Reference #1540
