### PR TITLE
Fixing weatherforecast module not displaying rain amount if using fal…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updatenotification module: Properly handle race conditions, prevent crash.
 - Send `NEWS_FEED` notification also for the first news messages which are shown
 - Fixed issue where weather module would not refresh data after a network or API outage [#1722](https://github.com/MichMich/MagicMirror/issues/1722)
+- Fixed weatherforecast module not displaying rain amount on fallback endpoint
 
 ## [2.8.0] - 2019-07-01
 


### PR DESCRIPTION
Added support for showing the amount of rain when using fallback endpoint.

The rain-property contains values like on fallback endpoint and not a numeric value directly:
`
"rain":{"3h":1.813}
`

So I made it sum it from all of that days forecasts since that rain forecast is for 3 hours and it returns a forecast for every 3 hours.
