### PR TITLE
Changes to the clock module regarding the notifications sent.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Updatenotification module: Display update notification for a limited (configurable) time.
 - The css/custom.css will be rename after the next release. We've add into `run-start.sh` a instruction by GIT to ignore with `--skip-worktree` and `rm --cached`. The history about this change [#1540].
+- Disable sending of notification CLOCK_SECOND when displaySeconds is false
 
 ### Fixed
 - Updatenotification module: Properly handle race conditions, prevent crash.
 - Send `NEWS_FEED` notification also for the first news messages which are shown
 - Fixed issue where weather module would not refresh data after a network or API outage [#1722](https://github.com/MichMich/MagicMirror/issues/1722)
 - Fixed weatherforecast module not displaying rain amount on fallback endpoint
+- Notifications CLOCK_SECOND & CLOCK_MINUTE being from startup instead of matched against the clock and avoid drifting
 
 ## [2.8.0] - 2019-07-01
 


### PR DESCRIPTION
Noticed that the CLOCK_SECOND and CLOCK_MINUTE always started at 0 and counted up, seems more useful to actually send the actual minute and second and not minute and seconds since startup.

Also there's a fix for the notifications drifting after a while, since setInterval schedules how much time should be between the end of the first call and start of the second, not the start for both.

Also disabled the sending of CLOCK_SECOND-notification if displaySeconds is not set in configs since it should be no use then if it isn't even displayed? I wanted this to avoid the logging of those notifications when debugging and also trying to lower the cpu usage since I'm running my client on a Raspberry Pi Zero W. Maybe it should be a configuration-option to enable this event even when not displaying seconds?