### PR TITLE
Timestamp log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *This release is scheduled to be released on 2020-01-01.*
 
 ### Added
+- Timestamps in log output
 
 ### Updated
 

--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,9 @@ var Utils = require(__dirname + "/utils.js");
 var defaultModules = require(__dirname + "/../modules/default/defaultmodules.js");
 var path = require("path");
 
+// add timestamps in front of log messages
+require('console-stamp')(console, 'HH:MM:ss.l');
+
 // Get version number.
 global.version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
 console.log("Starting MagicMirror: v" + global.version);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1632,6 +1632,40 @@
         "date-now": "^0.1.4"
       }
     },
+    "console-stamp": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/console-stamp/-/console-stamp-0.2.9.tgz",
+      "integrity": "sha512-jtgd1Fx3Im+pWN54mF269ptunkzF5Lpct2LBTbtyNoK2A4XjcxLM+TQW+e+XE/bLwLQNGRqPqlxm9JMixFntRA==",
+      "requires": {
+        "chalk": "^1.1.1",
+        "dateformat": "^1.0.11",
+        "merge": "^1.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5226,6 +5226,11 @@
         "trim-newlines": "^1.0.0"
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "colors": "^1.1.2",
+    "console-stamp": "^0.2.9",
     "electron": "^3.0.13",
     "express": "^4.16.2",
     "express-ipfilter": "^1.0.1",


### PR DESCRIPTION
This PR adds a timestamp to the logging/stdout. This is helpful for troubleshooting. It works for output on the console (like with `node serveronly`) and for the log file `.pms/logs/mm-out.log` when using pm2.

The timestamp is in UTC, which is how the module I've found for this, uses. If that's an issue and you'd prefer local time, please let me know and I'll see what I can do.