### PR TITLE
Use config.decimalSymbol when displaying the predicted amount of rain in weatherforecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 
 ### Fixed
-- Fixed issue in weatherforecast module where predicated amount of rain was not using the decimal symbol specified in config.js.
+- Fixed issue in weatherforecast module where predicted amount of rain was not using the decimal symbol specified in config.js.
  
 ## [2.9.0] - 2019-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 
 ### Fixed
-
+- Fixed issue in weatherforecast module where predicated amount of rain was not using the decimal symbol specified in config.js.
+ 
 ## [2.9.0] - 2019-10-01
 
 ℹ️ **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`. If you are having issues running Electron, make sure your [Raspbian is up to date](https://www.raspberrypi.org/documentation/raspbian/updating.md).

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -180,9 +180,9 @@ Module.register("weatherforecast",{
 					rainCell.innerHTML = "";
 				} else {
 					if(config.units !== "imperial") {
-						rainCell.innerHTML = parseFloat(forecast.rain).toFixed(1) + " mm";
+						rainCell.innerHTML = parseFloat(forecast.rain).toFixed(1).replace(".", this.config.decimalSymbol) + " mm";
 					} else {
-						rainCell.innerHTML = (parseFloat(forecast.rain) / 25.4).toFixed(2) + " in";
+						rainCell.innerHTML = (parseFloat(forecast.rain) / 25.4).toFixed(2).replace(".", this.config.decimalSymbol) + " in";
 					}
 				}
 				rainCell.className = "align-right bright rain";


### PR DESCRIPTION
Fix for issue #1804 

I copied logic from the min/max temperature section and used it to display the correct decimal symbol in the rain amount section.

**Module specific parameters in config.js**
> config: {
>   ...
>   decimalSymbol: ",",
>   showRainAmount: true
> }

![image](https://user-images.githubusercontent.com/25535705/68731494-23584c80-0585-11ea-9e50-d38c77c12cc9.png)
