### PR TITLE
Added a padding between days in dateheader mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Timestamps in log output
+- Padding in dateheader mode of the calendar module 
 
 ### Updated
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -180,6 +180,7 @@ Module.register("calendar", {
 
 					dateCell.colSpan = "3";
 					dateCell.innerHTML = dateAsString;
+					dateCell.style.paddingTop = "10px";
 					dateRow.appendChild(dateCell);
 					wrapper.appendChild(dateRow);
 


### PR DESCRIPTION
Very tiny addition to the calendar module: in dateheader-mode there's now a padding between the days, which makes it look nicer IMO