### PR TITLE
Module header updates correctly, if a module need to dynamically show/hide its header based on a condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fixed issue in weatherforecast module where predicted amount of rain was not using the decimal symbol specified in config.js.
- 
+- Module header now updates correctly, if a module need to dynamically show/hide its header based on a condition.
+
 ## [2.9.0] - 2019-10-01
 
 ℹ️ **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`. If you are having issues running Electron, make sure your [Raspbian is up to date](https://www.raspberrypi.org/documentation/raspbian/updating.md).

--- a/js/main.js
+++ b/js/main.js
@@ -39,11 +39,13 @@ var MM = (function() {
 			dom.opacity = 0;
 			wrapper.appendChild(dom);
 
-			if (typeof module.getHeader() !== "undefined" && module.getHeader() !== "") {
-				var moduleHeader = document.createElement("header");
-				moduleHeader.innerHTML = module.getHeader();
-				moduleHeader.className = "module-header";
-				dom.appendChild(moduleHeader);
+			var moduleHeader = document.createElement("header");
+			moduleHeader.innerHTML = module.getHeader();
+			moduleHeader.className = "module-header";
+			dom.appendChild(moduleHeader);
+
+			if (typeof module.getHeader() === "undefined" || module.getHeader() !== "") {
+				moduleHeader.style = "display: none;";
 			}
 
 			var moduleContent = document.createElement("div");
@@ -210,9 +212,8 @@ var MM = (function() {
 		contentWrapper[0].innerHTML = "";
 		contentWrapper[0].appendChild(newContent);
 
-		if( headerWrapper.length > 0 && newHeader) {
-			headerWrapper[0].innerHTML = newHeader;
-		}
+		headerWrapper[0].innerHTML = newHeader;
+		headerWrapper[0].style = headerWrapper.length > 0 && newHeader ? undefined : "display: none;";
 	};
 
 	/* hideModule(module, speed, callback)


### PR DESCRIPTION
This adds the support to dynamically show/hide module headers, based on what is returned by `module.getHeader()`.

Previously, the initialisation included the `<header>` into the DOM **only if the `module.getHeader()` returned something not null, undefined or empty**. This means that subsequent updates couldn't change the header because the DOM did not exist. In some module (e.g. Sonos module: https://github.com/tbouron/MMM-Sonos/blob/master/MMM-Sonos.js#L74) this is problematic because the header display is conditioned by its current state: if there is no data, then nothing should be displayed.

This change does the following:
- the header DOM is always added.
- if the header string is null, undefined or empty, then the `<header>` has a `style="display: none;"`, otherwise, it is displayed as usual.



