### PR TITLE
Display still ongoing multiple day events as happening today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix handling of config.js for serverOnly mode commented out.
 - Fixed issue in calendar module where the debug script didn't work correctly with authentication
 - Fixed issue that some full day events were not correctly recognized as such
+- Display full day events lasting multiple days as happening today instead of some days ago if they are still ongoing
 
 ## [2.9.0] - 2019-10-01
 

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -306,6 +306,11 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 							continue;
 						}
 
+						// adjust start date so multiple day events will be displayed as happening today even though they started some days ago already
+						if (fullDayEvent && startDate <= today) {
+							startDate = moment(today);
+						}
+
 						// Every thing is good. Add it to the list.
 
 						newEvents.push({


### PR DESCRIPTION
Full day events spanning over multiple days such as school holidays are currently displayed as: 8 days ago.
This PR changes this so these events will be shown as 'today', if they are still ongoing.
