### PR TITLE
Add missing translations for fi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 *This release is scheduled to be released on 2020-04-01.*
 
 ### Added
+
+- Finnish translation for "PRECIP", "UPDATE_INFO_MULTIPLE" and "UPDATE_INFO_SINGLE".
+
 ### Updated
 ### Fixed
 

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -28,6 +28,9 @@
 	
 	"UPDATE_NOTIFICATION": "MagicMirror² päivitys saatavilla.",
 	"UPDATE_NOTIFICATION_MODULE": "Päivitys saatavilla moduulille {MODULE_NAME}.",
+	"UPDATE_INFO_SINGLE": "Nykyasennus on {COMMIT_COUNT} muutoksen jäljessä {BRANCH_NAME} haaraan nähden.",
+	"UPDATE_INFO_MULTIPLE": "Nykyasennus on {COMMIT_COUNT} muutosta jäljessä {BRANCH_NAME} haaraan nähden.",
 	
-	"FEELS": "Tuntuu kuin"
+	"FEELS": "Tuntuu kuin",
+	"PRECIP": "Sateen todennäköisyys"
 }


### PR DESCRIPTION
For #1843. Couldn't find an acronym for PRECIP ("Probability of rain/snow"). Hope it's not too long for the UI.