### PR TITLE
Updated raspberry.sh installer script to save apt-get log output to a file 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Improve handling for armv6l devices, where electron support has gone away, add optional serveronly config option.
 - Improved run-start.sh to handle for serveronly mode, by choice, or when electron not available.
 - Only check for xwindows running if not on macOS.
+- Updated raspberry.sh installer script to save apt-get log output to a file that can be tailed
 
 ### Fixed
 - Fixed issue in weatherforecast module where predicted amount of rain was not using the decimal symbol specified in config.js.
@@ -30,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue in calendar module where the debug script didn't work correctly with authentication
 - Fixed issue that some full day events were not correctly recognized as such
 - Display full day events lasting multiple days as happening today instead of some days ago if they are still ongoing
+- Fixed an issue where the raspberry.sh installer script can get stuck when there are packages that need to be upgraded
 
 ## [2.9.0] - 2019-10-01
 

--- a/installers/raspberry.sh
+++ b/installers/raspberry.sh
@@ -99,14 +99,16 @@ function verlt() { [ "$1" = "$2" ] && return 1 || verlte $1 $2 ;}
 # Update before first apt-get
 if [ $mac != 'Darwin' ]; then
 	echo -e "\e[96mUpdating packages ...\e[90m" | tee -a $logfile
+	aptget_logfile=$logdir/apt-get.log
+	echo "apt-get log being saved to $aptget_logfile"
 	upgrade=$false
-	update=$(sudo apt-get update 2>&1)
+	update=$(sudo apt-get update > $aptget_logfile 2>&1)
 	echo $update >> $logfile
 	update_rc=$?
 	if [ $update_rc -ne 0 ]; then
 	 echo -e "\e[91mUpdate failed, retrying installation ...\e[90m" | tee -a $logfile
 	 if [ $(echo $update | grep "apt-secure" | wc -l) -eq 1 ]; then
-			update=$(sudo apt-get update --allow-releaseinfo-change 2>&1)
+			update=$(sudo apt-get update --allow-releaseinfo-change > $aptget_logfile 2>&1)
 			update_rc=$?
 			echo $update >> $logfile
 			if [ $update_rc -ne 0 ]; then
@@ -122,7 +124,7 @@ if [ $mac != 'Darwin' ]; then
 		upgrade=$true
 	fi
 	if [ $upgrade -eq $true ]; then
-	   upgrade_result=$(sudo apt-get upgrade 2>&1)
+	   upgrade_result=$(sudo apt-get upgrade --assume-yes > $aptget_logfile 2>&1)
 		 upgrade_rc=$?
 		 echo apt upgrade result ="rc=$upgrade_rc $upgrade_result" >> $logfile
 	fi


### PR DESCRIPTION
- Updated raspberry.sh installer script to save apt-get log output to a file that can be tailed
- Fixed an issue where the raspberry.sh installer script can get stuck when there are packages that need to be upgraded

