### PR TITLE
Add different GitHub repos to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,7 @@ If you are facing an issue or found a bug while trying to install MagicMirror vi
 ---
 
 ## I found a bug in MagicMirror
-Please make sure to only submit reproducible issues. You can safely remove everything above dividing line. 
+Please make sure to only submit reproducible issues. You can safely remove everything above the dividing line. 
 When submitting a new issue, please supply the following information:
 
 **Platform**: Place your platform here... give us your web browser/Electron version *and* your hardware (Raspberry Pi 2/3, Windows, Mac, Linux, System V UNIX).

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,21 @@
-Please only submit reproducible issues. 
-
+## I'm not sure if this is a bug
 If you're not sure if it's a real bug or if it's just you, please open a topic on the forum: [https://forum.magicmirror.builders/category/15/bug-hunt](https://forum.magicmirror.builders/category/15/bug-hunt)
+
+## I'm having troubles installing or configuring MagicMirror
 Problems installing or configuring your MagicMirror? Check out: [https://forum.magicmirror.builders/category/10/troubleshooting](https://forum.magicmirror.builders/category/10/troubleshooting)
 
+## I found a bug in the official MagicMirror Docker image
+If you are facing an issue or found a bug while running MagicMirror inside a Docker container please create an issue in the GitHub repository of the official MagicMirror Docker image:
+[https://github.com/bastilimbach/docker-MagicMirror](https://github.com/bastilimbach/docker-MagicMirror)
+
+## I found a bug in the official MagicMirror installer
+If you are facing an issue or found a bug while trying to install MagicMirror via the official installer please report it in the respective GitHub repository:
+[https://github.com/sdetweil/MagicMirror_scripts](https://github.com/sdetweil/MagicMirror_scripts)
+
+---
+
+## I found a bug in MagicMirror
+Please make sure to only submit reproducible issues. You can safely remove everything above dividing line. 
 When submitting a new issue, please supply the following information:
 
 **Platform**: Place your platform here... give us your web browser/Electron version *and* your hardware (Raspberry Pi 2/3, Windows, Mac, Linux, System V UNIX).


### PR DESCRIPTION
This commit adds the official docker image repo as well as the installation scripts repo to the issue template to avoid the creation of issue which don't belong to the MagicMirror core.

I send this PR to the master branch as this has nothing to do with the actual product. If you want I can also change it back to point to the development branch.
