### PR TITLE
Fix the vendor_spec test:

### DIFF
--- a/tests/e2e/vendor_spec.js
+++ b/tests/e2e/vendor_spec.js
@@ -15,6 +15,7 @@ describe("Vendors", function () {
 	var app = null;
 
 	before(function () {
+		process.env.MM_CONFIG_FILE = "tests/configs/env.js";
 		return helpers.startApplication({
 			args: ["js/electron.js"]
 		}).then(function (startedApp) { app = startedApp; });
@@ -25,10 +26,6 @@ describe("Vendors", function () {
 	});
 
 	describe("Get list vendors", function () {
-
-		before(function () {
-			process.env.MM_CONFIG_FILE = "tests/configs/env.js";
-		});
 
 		var vendors = require(__dirname + "/../../vendor/vendor.js");
 		Object.keys(vendors).forEach(vendor => {


### PR DESCRIPTION
This change set after startApplication the configuration to run this
test.

The previous statement when e2e are running using --recursive the
MM_CONFIG_FILE was setting by the test running before this one.

This PR fix the #1842