### PR TITLE
fix: add missing +1 for month

### DIFF
--- a/modules/default/calendar/vendor/ical.js/node-ical.js
+++ b/modules/default/calendar/vendor/ical.js/node-ical.js
@@ -28,7 +28,7 @@ var rrule = require('rrule').RRule
 
 function getLocaleISOString(date) {
 	var year = date.getFullYear().toString(10).padStart(4,'0');
-	var month = (date.getMonth().toString(10) + 1).padStart(2,'0');
+	var month = (date.getMonth() + 1).toString(10).padStart(2,'0');
 	var day = date.getDate().toString(10).padStart(2,'0');
 	var hour = date.getHours().toString(10).padStart(2,'0');
 	var minute = date.getMinutes().toString(10).padStart(2,'0');

--- a/modules/default/calendar/vendor/ical.js/node-ical.js
+++ b/modules/default/calendar/vendor/ical.js/node-ical.js
@@ -28,7 +28,7 @@ var rrule = require('rrule').RRule
 
 function getLocaleISOString(date) {
 	var year = date.getFullYear().toString(10).padStart(4,'0');
-	var month = date.getMonth().toString(10).padStart(2,'0');
+	var month = (date.getMonth().toString(10) + 1).padStart(2,'0');
 	var day = date.getDate().toString(10).padStart(2,'0');
 	var hour = date.getHours().toString(10).padStart(2,'0');
 	var minute = date.getMinutes().toString(10).padStart(2,'0');


### PR DESCRIPTION
This is a fix to a missed `+1` in PR #1884.  Month for date is 0-11, not 1-12 so this fixes that offset for the date string.