### PR TITLE
Log date timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed `run-start.sh` script and update start commands:
   - To start using electron, use `npm run start`.
   - To start in server only mode, use `npm run server`.
+- Timestamp in log output now also contains the date
 
 ## [2.10.1] - 2020-01-10
 

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ var path = require("path");
 require("module-alias/register");
 
 // add timestamps in front of log messages
-require("console-stamp")(console, "HH:MM:ss.l");
+require("console-stamp")(console, "yyyy-mm-dd HH:MM:ss.l");
 
 // Get version number.
 global.version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;


### PR DESCRIPTION
Since it's pretty hard to find actual debug output for a certain day, I changed the log timestamp format so that it now also logs the full date.