### PR TITLE
1840 fix weather tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
 dist: trusty
 language: node_js
 node_js:
- - "10"
+  - 10
+  - lts/*
+  - node
 before_install:
   - npm i -g npm
 before_script:
- - yarn danger ci
- - npm install grunt-cli -g
- - "export DISPLAY=:99.0"
- - "export ELECTRON_DISABLE_SANDBOX=1"
- - "sh -e /etc/init.d/xvfb start"
- - sleep 5
+  - yarn danger ci
+  - npm install grunt-cli -g
+  - "export DISPLAY=:99.0"
+  - "export ELECTRON_DISABLE_SANDBOX=1"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 5
 script:
-- npm run test:e2e
-- npm run test:unit
-- grunt
+  - npm run test:e2e
+  - npm run test:unit
+  - grunt
 after_script:
- - npm list
+  - npm list
 cache:
- directories:
-  - node_modules
+  directories:
+    - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `clock` module now optionally displays sun and moon data, including rise/set times, remaining daylight, and percent of moon illumination.
 - Added Hebrew translation.
 - Add HTTPS support and update config.js.sample
-
+- Run tests on long term support and latest stable version of nodejs
 
 ### Fixed
 - Force declaration of public ip adress in config file (ISSUE #1852)
 - Fixes `run-start.sh`: If running in docker-container, don't check the environment, just start electron (ISSUE #1859)
 - Fix calendar time offset for recurring events crossing Daylight Savings Time (ISSUE #1798)
 - Fix regression in currentweather module causing 'undefined' to show up when config.hideTemp is false
+- Fixed weather tests [#1840](https://github.com/MichMich/MagicMirror/issues/1840)
 
 ### Updated
 - Remove documentation from core repository and link to new dedicated docs site: [docs.magicmirror.builders](https://docs.magicmirror.builders).

--- a/tests/e2e/modules/weather_spec.js
+++ b/tests/e2e/modules/weather_spec.js
@@ -8,14 +8,7 @@ const helpers = require("../global-setup");
 
 const {generateWeather, generateWeatherForecast} = require("./mocks");
 
-const wait = () => new Promise(res => setTimeout(res, 3000));
-
-// See issue: https://github.com/MichMich/MagicMirror/issues/1840
-// Skipping the weather tests for now since these seem to give issues.
-// Please send a PR if you know how to fix these. Thanks!
- 		
-
-describe.skip("Weather module", function() {
+describe("Weather module", function() {
 
 	let app;
 
@@ -49,7 +42,7 @@ describe.skip("Weather module", function() {
 
 			it("should render wind speed and wind direction", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
 			});
@@ -59,7 +52,7 @@ describe.skip("Weather module", function() {
 				const sunset = moment().startOf("day").unix();
 
 				const weather = generateWeather({sys: {sunrise, sunset}});
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather .normal.medium span.wi.dimmed.wi-sunrise", 10000);
 
@@ -71,7 +64,7 @@ describe.skip("Weather module", function() {
 				const sunset = moment().endOf("day").unix();
 
 				const weather = generateWeather({sys: {sunrise, sunset}});
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather .normal.medium span.wi.dimmed.wi-sunset", 10000);
 
@@ -80,7 +73,7 @@ describe.skip("Weather module", function() {
 
 			it("should render temperature with icon", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather .large.light span.wi.weathericon.wi-snow", 10000);
 
@@ -89,7 +82,7 @@ describe.skip("Weather module", function() {
 
 			it("should render feels like temperature", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				return app.client.waitUntilTextExists(".weather .normal.medium span.dimmed", "Feels like -5.6°", 10000);
 			});
@@ -102,14 +95,14 @@ describe.skip("Weather module", function() {
 
 			it("should render useBeaufort = false", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "12", 10000);
 			});
 
 			it("should render showWindDirectionAsArrow = true", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather .normal.medium sup i.fa-long-arrow-up", 10000);
 				const element = await app.client.getHTML(".weather .normal.medium sup i.fa-long-arrow-up");
@@ -119,7 +112,7 @@ describe.skip("Weather module", function() {
 
 			it("should render showHumidity = true", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(3)", "93", 10000);
 				return app.client.waitForExist(".weather .normal.medium sup i.wi-humidity", 10000);
@@ -127,7 +120,7 @@ describe.skip("Weather module", function() {
 
 			it("should render degreeLabel = true", async function() {
 				const weather = generateWeather();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitUntilTextExists(".weather .large.light span.bright", "1°C", 10000);
 
@@ -151,7 +144,7 @@ describe.skip("Weather module", function() {
 						speed: 11.8 * 2.23694
 					},
 				});
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
 				await app.client.waitUntilTextExists(".weather .large.light span.bright", "34,7°", 10000);
@@ -169,7 +162,7 @@ describe.skip("Weather module", function() {
 						speed: 11.8 * 2.23694
 					},
 				});
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(3)", "93,7", 10000);
 				await app.client.waitUntilTextExists(".weather .large.light span.bright", "34,7°", 10000);
@@ -192,7 +185,7 @@ describe.skip("Weather module", function() {
 
 			it("should render days", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				const days = ["Fri", "Sat", "Sun", "Mon", "Tue"];
 
@@ -203,7 +196,7 @@ describe.skip("Weather module", function() {
 
 			it("should render icons", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				const icons = ["day-cloudy", "rain", "day-sunny", "day-sunny", "day-sunny"];
 
@@ -214,7 +207,7 @@ describe.skip("Weather module", function() {
 
 			it("should render max temperatures", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				const temperatures = ["24.4°", "21.0°", "22.9°", "23.4°", "20.6°"];
 
@@ -225,7 +218,7 @@ describe.skip("Weather module", function() {
 
 			it("should render min temperatures", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				const temperatures = ["15.3°", "13.6°", "13.8°", "13.9°", "10.9°"];
 
@@ -236,7 +229,7 @@ describe.skip("Weather module", function() {
 
 			it("should render fading of rows", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				const opacities = [1, 1, 0.8, 0.5333333333333333, 0.2666666666666667];
 
@@ -256,14 +249,14 @@ describe.skip("Weather module", function() {
 
 			it("should render custom table class", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather table.myTableClass", 10000);
 			});
 
 			it("should render colored rows", async function() {
 				const weather = generateWeatherForecast();
-				await setup([weather, template]);
+				await setup({template, data: weather});
 
 				await app.client.waitForExist(".weather table.myTableClass", 10000);
 

--- a/tests/node_modules/webdriverajaxstub/index.js
+++ b/tests/node_modules/webdriverajaxstub/index.js
@@ -3,7 +3,7 @@ function plugin (wdInstance, requests) {
 		throw new Error("You can't use WebdriverAjaxStub with this version of WebdriverIO");
 	}
 
-	function stub(requests, done) {
+	function stub({template, data}, done) {
 		window.XMLHttpRequest = function () {
 			this.open = function (method, url) {
 				this.method = method;
@@ -13,7 +13,7 @@ function plugin (wdInstance, requests) {
 			this.send = function () {
 				this.status = 200;
 				this.readyState = 4;
-				const response = requests.shift() || [];
+				const response = this.url.includes('.njk') ? template : data;
 				this.response = response;
 				this.responseText = response;
 				this.onreadystatechange();


### PR DESCRIPTION
https://github.com/MichMich/MagicMirror/issues/1840

Fix timing issue in weather tests => returning response by url instead of index

By debugging the tests locally I noticed, that the tests were failing randomly. By taking a closer look I spotted that the failing tests rendered the weather data as JSON in the spectron window. Increasing the timeouts helped me to detect in the network console that the weather data was retunred for the request to the nunjuck template. It seemed that in some random cases there was a timing issue, which requested first the template and then the weather.

The following change is resolving the timing issue, as it is returning the data based on the url, rather than relying on a specific order of requests.