### PR TITLE
use relative path for socket.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix regression in currentweather module causing 'undefined' to show up when config.hideTemp is false
 - Fix FEELS translation for Croatian
 - Fixed weather tests [#1840](https://github.com/MichMich/MagicMirror/issues/1840)
+- Fixed Socket.io can't be used with Reverse Proxy in serveronly mode [#1934](https://github.com/MichMich/MagicMirror/issues/1934)
 
 ### Updated
 - Remove documentation from core repository and link to new dedicated docs site: [docs.magicmirror.builders](https://docs.magicmirror.builders).

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 		<div class="region bottom right"><div class="container"></div></div>
 	</div>
 	<div class="region fullscreen above"><div class="container"></div></div>
-	<script type="text/javascript" src="/socket.io/socket.io.js"></script>
+	<script type="text/javascript" src="socket.io/socket.io.js"></script>
 	<script type="text/javascript" src="vendor/node_modules/nunjucks/browser/nunjucks.min.js"></script>
 	<script type="text/javascript" src="js/defaults.js"></script>
 	<script type="text/javascript" src="#CONFIG_FILE#"></script>

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -8,7 +8,9 @@ var MMSocket = function(moduleName) {
 	self.moduleName = moduleName;
 
 	// Private Methods
-	self.socket = io("/" + self.moduleName);
+	self.socket = io("/" + self.moduleName, {
+		path: window.location.pathname + "/socket.io"
+	});
 	var notificationCallback = function() {};
 
 	var onevent = self.socket.onevent;

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -9,7 +9,7 @@ var MMSocket = function(moduleName) {
 
 	// Private Methods
 	self.socket = io("/" + self.moduleName, {
-		path: window.location.pathname + "/socket.io"
+		path: window.location.pathname + "socket.io"
 	});
 	var notificationCallback = function() {};
 


### PR DESCRIPTION
This Pull Request fix #1934

* It changes the javascript include path of the `/socket.io/socket.io.js` to a relative one, like all the other scripts
* It appends the path of the current window to the path of the socket.io endpoint
