### PR TITLE
Loading the configuration file in the client from the server instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - To start in server only mode, use `npm run server`.
 - Timestamp in log output now also contains the date
 - Turkish translation.
+- Loading the evaluated config file from the server instead of including it in the client (to make it possible to use environment variables in the config file)
 
 ## [2.10.2] - 2020-02-21
 

--- a/index.html
+++ b/index.html
@@ -39,8 +39,6 @@
 	<div class="region fullscreen above"><div class="container"></div></div>
 	<script type="text/javascript" src="/socket.io/socket.io.js"></script>
 	<script type="text/javascript" src="vendor/node_modules/nunjucks/browser/nunjucks.min.js"></script>
-	<script type="text/javascript" src="js/defaults.js"></script>
-	<script type="text/javascript" src="#CONFIG_FILE#"></script>
 	<script type="text/javascript" src="vendor/vendor.js"></script>
 	<script type="text/javascript" src="modules/default/defaultmodules.js"></script>
 	<script type="text/javascript" src="js/logger.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-/* global  Log, Loader, Module, config, defaults */
+/* global  Log, Loader, Module, config */
 /* jshint -W020, esversion: 6 */
 
 /* Magic Mirror
@@ -340,16 +340,14 @@ var MM = (function() {
 	};
 
 	/* loadConfig()
-	 * Loads the core config and combines it with de system defaults.
+	 * Loads the core config file from the server.
 	 */
 	var loadConfig = function() {
-		if (typeof config === "undefined") {
-			config = defaults;
-			Log.error("Config file is missing! Please create a config file.");
-			return;
-		}
-
-		config = Object.assign({}, defaults, config);
+		return fetch ("config/").then((response) => {
+			return response.json();
+		}).then((data) => {
+			config = data;
+		});
 	};
 
 	/* setSelectionMethodsForModules()
@@ -453,9 +451,10 @@ var MM = (function() {
 		 */
 		init: function() {
 			Log.info("Initializing MagicMirror.");
-			loadConfig();
-			Translator.loadCoreTranslations(config.language);
-			Loader.loadModules();
+			loadConfig().then(() => {
+				Translator.loadCoreTranslations(config.language);
+				Loader.loadModules();
+			});
 		},
 
 		/* modulesStarted(moduleObjects)

--- a/js/server.js
+++ b/js/server.js
@@ -71,12 +71,6 @@ var Server = function(config, callback) {
 		var html = fs.readFileSync(path.resolve(global.root_path + "/index.html"), {encoding: "utf8"});
 		html = html.replace("#VERSION#", global.version);
 
-		configFile = "config/config.js";
-		if (typeof(global.configuration_file) !== "undefined") {
-		    configFile = global.configuration_file;
-		}
-		html = html.replace("#CONFIG_FILE#", configFile);
-
 		res.send(html);
 	});
 

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -32,12 +32,12 @@ describe("Clock set to spanish language module", function() {
 
 		it("shows date with correct format", function() {
 			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
 		it("shows time in 24hr format", function() {
 			const timeRegex = /^(?:2[0-3]|[01]\d):[0-5]\d[0-5]\d$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -49,12 +49,12 @@ describe("Clock set to spanish language module", function() {
 
 		it("shows date with correct format", function() {
 			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
 		it("shows time in 12hr format", function() {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -66,7 +66,7 @@ describe("Clock set to spanish language module", function() {
 
 		it("shows 12hr time with upper case AM/PM", function() {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[AP]M$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -78,7 +78,7 @@ describe("Clock set to spanish language module", function() {
 
 		it("shows week with correct format", function() {
 			const weekRegex = /^Semana [0-9]{1,2}$/;
-			return app.client.waitUntilWindowLoaded()
+			return app.client.waitUntilTextExists(".clock", "")
 				.getText(".clock .week").should.eventually.match(weekRegex);
 		});
 	});

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -32,12 +32,12 @@ describe("Clock module", function() {
 
 		it("shows date with correct format", function() {
 			const dateRegex = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (?:January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}, \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
 		it("shows time in 24hr format", function() {
 			const timeRegex = /^(?:2[0-3]|[01]\d):[0-5]\d[0-5]\d$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -49,12 +49,12 @@ describe("Clock module", function() {
 
 		it("shows date with correct format", function() {
 			const dateRegex = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (?:January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}, \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
 		it("shows time in 12hr format", function() {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -66,7 +66,7 @@ describe("Clock module", function() {
 
 		it("shows 12hr time with upper case AM/PM", function() {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[AP]M$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -78,7 +78,7 @@ describe("Clock module", function() {
 
 		it("shows 12hr time without seconds am/pm", function() {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -90,14 +90,14 @@ describe("Clock module", function() {
 
 		it("shows week with correct format", function() {
 			const weekRegex = /^Week [0-9]{1,2}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .week").should.eventually.match(weekRegex);
+			return app.client.waitUntilTextExists(".clock", "").getText(".clock .week").should.eventually.match(weekRegex);
 		});
 
 		it("shows week with correct number of week of year", function() {
 			it("FIXME: if the day is a sunday this not match");
 			//	const currentWeekNumber = require("current-week-number")();
 			//	const weekToShow = "Week " + currentWeekNumber;
-			//	return app.client.waitUntilWindowLoaded()
+			//	return app.client.waitUntilTextExists(".clock", "")
 			//		.getText(".clock .week").should.eventually.equal(weekToShow);
 		});
 	});

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -35,7 +35,7 @@ describe("Compliments module", function() {
 			var hour = new Date().getHours();
 			if (hour >= 3 && hour < 12) {
 				// if morning check
-				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+				return app.client.waitUntilTextExists(".compliments", "").getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Hi", "Good Morning", "Morning test"]);
 				});
 			}
@@ -45,7 +45,7 @@ describe("Compliments module", function() {
 			var hour = new Date().getHours();
 			if (hour >= 12 && hour < 17) {
 				// if morning check
-				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+				return app.client.waitUntilTextExists(".compliments", "").getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Hello", "Good Afternoon", "Afternoon test"]);
 				});
 			}
@@ -55,7 +55,7 @@ describe("Compliments module", function() {
 			var hour = new Date().getHours();
 			if (!(hour >= 3 && hour < 12) && !(hour >= 12 && hour < 17)) {
 				// if evening check
-				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+				return app.client.waitUntilTextExists(".compliments", "").getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Hello There", "Good Evening", "Evening test"]);
 				});
 			}
@@ -70,7 +70,7 @@ describe("Compliments module", function() {
 			});
 
 			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", function() {
-				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+				return app.client.waitUntilTextExists(".compliments", "").getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Anytime here"]);
 				});
 			});
@@ -83,7 +83,7 @@ describe("Compliments module", function() {
 			});
 
 			it("Show anytime compliments", function() {
-				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+				return app.client.waitUntilTextExists(".compliments", "").getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Anytime here"]);
 				});
 			});

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -31,7 +31,7 @@ describe("Test helloworld module", function() {
 		});
 
 		it("Test message helloworld module", function () {
-			return app.client.waitUntilWindowLoaded()
+			return app.client.waitUntilTextExists(".helloworld", "")
 				.getText(".helloworld").should.eventually.equal("Test HelloWorld Module");
 		});
 	});
@@ -43,7 +43,7 @@ describe("Test helloworld module", function() {
 		});
 
 		it("Test message helloworld module", function () {
-			return app.client.waitUntilWindowLoaded()
+			return app.client.waitUntilTextExists(".helloworld", "")
 				.getText(".helloworld").should.eventually.equal("Hello World!");
 		});
 	});

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -26,12 +26,12 @@ describe("Check configuration without modules", function () {
 	});
 
 	it("Show the message MagicMirror title", function () {
-		return app.client.waitUntilWindowLoaded()
+		return app.client.waitUntilTextExists("#module_1_helloworld", "")
 			.getText("#module_1_helloworld .module-content").should.eventually.equal("Magic Mirror2");
 	});
 
 	it("Show the text Michael's website", function () {
-		return app.client.waitUntilWindowLoaded()
+		return app.client.waitUntilTextExists("#module_5_helloworld", "")
 			.getText("#module_5_helloworld .module-content").should.eventually.equal("www.michaelteeuw.nl");
 	});
 });


### PR DESCRIPTION
Resubmit of https://github.com/MichMich/MagicMirror/pull/1940 since I had some merge problems with git. Now with working tests too.

I took a first stab at making it possible to use environment variables in the configuration file ( https://github.com/MichMich/MagicMirror/issues/1756 ).

The biggest problem with this seemed to be that both the client and the server both loads the config file each, where the server has access to the environment variables and the client doesn't. But since the server already exposes the possiblity to get the config file like this:  https://github.com/MichMich/MagicMirror/blob/5bf90ae31d600e3f595ffd242b99515fa7905b1a/js/server.js#L56-L58
I figured fetching that as config instead of just including it would cause it to actually have the servers evaluated config instead (instead of this line):
https://github.com/MichMich/MagicMirror/blob/5bf90ae31d600e3f595ffd242b99515fa7905b1a/index.html#L43

I've tested it by setting configuration values to 
```
{
	module: "helloworld",
	position: "lower_third",
	config: {
		"text": process.env.HELLO_WORLD
	}
}
```
And it seems to work and even apply to the client. Maybe this shouldn't be the recommended way to use environment variables in the configuration file, but this pull request would probably be needed whatever is decided.

Hope its ok to use fetch() since it works with ```npm start``` and all modern browsers seems to have supported it for a few years ( https://caniuse.com/#feat=fetch )
