### PR TITLE
Add date compliments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Run tests on long term support and latest stable version of nodejs
 - Added the ability to configure a list of modules that shouldn't be update checked.
 - Run linters on git commits
+- Added date functionality to compliments: display birthday wishes or celebrate an anniversary
 
 ### Fixed
 - Force declaration of public ip address in config file (ISSUE #1852)

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -162,19 +162,19 @@ Module.register("compliments", {
 		// get the current time of day compliments list
 		var compliments = this.complimentArray();
 		// variable for index to next message to display
-		let index=0;
+		let index = 0;
 		// are we randomizing
 		if(this.config.random){
 			// yes
 			index = this.randomIndex(compliments);
 		}
 		else{
-			// no, sequetial
-			// if doing sequential,  don't fall off the end
+			// no, sequential
+			// if doing sequential, don't fall off the end
 			index = (this.lastIndexUsed >= (compliments.length-1))?0: ++this.lastIndexUsed;
 		}
 
-		return compliments[index];
+		return compliments[index] || "";
 	},
 
 	// Override dom generator.
@@ -184,9 +184,9 @@ Module.register("compliments", {
 		// get the compliment text
 		var complimentText = this.randomCompliment();
 		// split it into parts on newline text
-		var parts= complimentText.split("\n");
+		var parts = complimentText.split("\n");
 		// create a span to hold it all
-		var compliment=document.createElement("span");
+		var compliment = document.createElement("span");
 		// process all the parts of the compliment text
 		for (part of parts){
 			// create a text element for each part

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -29,11 +29,14 @@ Module.register("compliments", {
 				"You look nice!",
 				"Hi, sexy!"
 			],
-			1403 : [
-				"Happy birthday, Albert Einstein!"
+			"....-01-01": [
+				"Happy new year!"
 			],
-			1012: [
-				"Happy birthday, Ada Lovelace!"
+			"....-..-14": [
+				"Have a great 14th day of the month!"
+			],
+			"2020-12-10": [
+				"Happy 205th Birthday, Ada Lovelace!"
 			]
 		},
 		updateInterval: 30000,
@@ -108,7 +111,7 @@ Module.register("compliments", {
 	 */
 	complimentArray: function() {
 		var hour = moment().hour();
-		var date = moment().format("DDMM");
+		var date = moment().format("YYYY-MM-DD");
 		var compliments;
 
 		if (hour >= this.config.morningStartTime && hour < this.config.morningEndTime && this.config.compliments.hasOwnProperty("morning")) {
@@ -129,8 +132,10 @@ Module.register("compliments", {
 
 		compliments.push.apply(compliments, this.config.compliments.anytime);
 
-		if (date in this.config.compliments) {
-			compliments.push.apply(compliments, this.config.compliments[date]);
+		for (entry in this.config.compliments) {
+			if (new RegExp(entry).test(date)) {
+				compliments.push.apply(compliments, this.config.compliments[entry]);
+			}
 		}
 
 		return compliments;

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -31,12 +31,6 @@ Module.register("compliments", {
 			],
 			"....-01-01": [
 				"Happy new year!"
-			],
-			"....-..-14": [
-				"Have a great 14th day of the month!"
-			],
-			"2020-12-10": [
-				"Happy 205th Birthday, Ada Lovelace!"
 			]
 		},
 		updateInterval: 30000,

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -28,7 +28,10 @@ Module.register("compliments", {
 				"Wow, you look hot!",
 				"You look nice!",
 				"Hi, sexy!"
-			]
+			],
+			date: [
+				["12-10", "Happy birthday, Ada Lovelace!"]
+			],
 		},
 		updateInterval: 30000,
 		remoteFile: null,
@@ -102,6 +105,8 @@ Module.register("compliments", {
 	 */
 	complimentArray: function() {
 		var hour = moment().hour();
+		var year = moment().year();
+		var today = moment(new Date());
 		var compliments;
 
 		if (hour >= this.config.morningStartTime && hour < this.config.morningEndTime && this.config.compliments.hasOwnProperty("morning")) {
@@ -121,6 +126,12 @@ Module.register("compliments", {
 		}
 
 		compliments.push.apply(compliments, this.config.compliments.anytime);
+
+		this.config.compliments.date.forEach(d => {
+			if (today.isSame(year + "-" + d[0], "month"))  {
+				compliments.push(d[1]);
+			}
+		});
 
 		return compliments;
 	},

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -29,10 +29,12 @@ Module.register("compliments", {
 				"You look nice!",
 				"Hi, sexy!"
 			],
-			date: [
-				["03-14", "Happy birthday, Albert Einstein!"],
-				["12-10", "Happy birthday, Ada Lovelace!"]
+			1403 : [
+				"Happy birthday, Albert Einstein!"
 			],
+			1012: [
+				"Happy birthday, Ada Lovelace!"
+			]
 		},
 		updateInterval: 30000,
 		remoteFile: null,
@@ -106,8 +108,7 @@ Module.register("compliments", {
 	 */
 	complimentArray: function() {
 		var hour = moment().hour();
-		var year = moment().year();
-		var today = moment(new Date());
+		var date = moment().format("DDMM");
 		var compliments;
 
 		if (hour >= this.config.morningStartTime && hour < this.config.morningEndTime && this.config.compliments.hasOwnProperty("morning")) {
@@ -128,11 +129,9 @@ Module.register("compliments", {
 
 		compliments.push.apply(compliments, this.config.compliments.anytime);
 
-		this.config.compliments.date.forEach(d => {
-			if (today.isSame(year + "-" + d[0], "month"))  {
-				compliments.push(d[1]);
-			}
-		});
+		if (date in this.config.compliments) {
+			compliments.push.apply(compliments, this.config.compliments[date]);
+		}
 
 		return compliments;
 	},

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -30,6 +30,7 @@ Module.register("compliments", {
 				"Hi, sexy!"
 			],
 			date: [
+				["03-14", "Happy birthday, Albert Einstein!"],
 				["12-10", "Happy birthday, Ada Lovelace!"]
 			],
 		},

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -27,8 +27,8 @@ let config = {
 					morning: [],
 					afternoon: [],
 					evening: [],
-					1012: [
-						"Happy birthday, Ada Lovelace!"
+					"....-01-01": [
+						"Happy new year!"
 					]
 				}
 			}

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -1,0 +1,40 @@
+/* Magic Mirror Test config compliments with date type
+ *
+ * By Rejas
+ *
+ * MIT Licensed.
+ */
+
+let config = {
+	port: 8080,
+	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
+
+	language: "en",
+	timeFormat: 12,
+	units: "metric",
+	electronOptions: {
+		webPreferences: {
+			nodeIntegration: true,
+		},
+	},
+
+	modules: [
+		{
+			module: "compliments",
+			position: "middle_center",
+			config: {
+				compliments: {
+					morning: [],
+					afternoon: [],
+					evening: [],
+					1012: [
+						"Happy birthday, Ada Lovelace!"
+					]
+				}
+			}
+		}
+	]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {module.exports = config;}

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -1,5 +1,6 @@
 const helpers = require("../global-setup");
 const expect = require("chai").expect;
+const moment = require("moment");
 
 const describe = global.describe;
 const it = global.it;
@@ -86,6 +87,42 @@ describe("Compliments module", function() {
 				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Anytime here"]);
 				});
+			});
+		});
+	});
+
+	describe("Feature date in compliments module", function() {
+		describe("Set date and empty compliments for anytime, morning, evening and afternoon", function() {
+			let RealDate;
+
+			before(function() {
+				// Set config sample for use in test
+				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_date.js";
+
+				RealDate = Date;
+				let customTimeMs = moment("2015-10-12T06:00:00.000Z").valueOf();
+
+				function MockDate() {
+					return new RealDate(customTimeMs);
+				}
+
+				MockDate.now = function () {
+					return new MockDate().valueOf();
+				};
+
+				MockDate.prototype = RealDate.prototype;
+
+				Date = MockDate;
+			});
+
+			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", function() {
+				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
+					expect(text).to.be.oneOf(["Happy birthday, Ada Lovelace!"]);
+				});
+			});
+
+			after(function() {
+				Date = RealDate;
 			});
 		});
 	});

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -96,12 +96,12 @@ describe("Compliments module", function() {
 			before(function() {
 				// Set config sample for use in test
 				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_date.js";
-				MockDate.set("2000-12-10");
+				MockDate.set("2000-01-01");
 			});
 
-			it("Show happy birthday compliment on special date", function() {
+			it("Show happy new year compliment on new years day", function() {
 				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
-					expect(text).to.be.oneOf(["Happy birthday, Ada Lovelace!"]);
+					expect(text).to.be.oneOf(["Happy new year!"]);
 				});
 			});
 

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -1,6 +1,6 @@
 const helpers = require("../global-setup");
 const expect = require("chai").expect;
-const moment = require("moment");
+const MockDate = require("./mocks/date.js");
 
 const describe = global.describe;
 const it = global.it;
@@ -93,36 +93,20 @@ describe("Compliments module", function() {
 
 	describe("Feature date in compliments module", function() {
 		describe("Set date and empty compliments for anytime, morning, evening and afternoon", function() {
-			let RealDate;
-
 			before(function() {
 				// Set config sample for use in test
 				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_date.js";
-
-				RealDate = Date;
-				let customTimeMs = moment("2015-10-12T06:00:00.000Z").valueOf();
-
-				function MockDate() {
-					return new RealDate(customTimeMs);
-				}
-
-				MockDate.now = function () {
-					return new MockDate().valueOf();
-				};
-
-				MockDate.prototype = RealDate.prototype;
-
-				Date = MockDate;
+				MockDate.set("2000-12-10");
 			});
 
-			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", function() {
+			it("Show happy birthday compliment on special date", function() {
 				return app.client.waitUntilWindowLoaded().getText(".compliments").then(function(text) {
 					expect(text).to.be.oneOf(["Happy birthday, Ada Lovelace!"]);
 				});
 			});
 
 			after(function() {
-				Date = RealDate;
+				MockDate.reset();
 			});
 		});
 	});

--- a/tests/e2e/modules/mocks/date.js
+++ b/tests/e2e/modules/mocks/date.js
@@ -6,88 +6,88 @@
 */
 
 (function(name, definition) {
-    if (typeof module !== 'undefined') module.exports = definition();
-    else if (typeof define === 'function' && typeof define.amd === 'object') define(definition);
-    else this[name] = definition();
-}('MockDate', function() {
-    "use strict";
+	if (typeof module !== "undefined") {module.exports = definition();}
+	else if (typeof define === "function" && typeof define.amd === "object") {define(definition);}
+	else {this[name] = definition();}
+}("MockDate", function() {
+	"use strict";
 
-    var _Date = Date
-        , _getTimezoneOffset = Date.prototype.getTimezoneOffset
-        , now   = null
+	var _Date = Date
+		, _getTimezoneOffset = Date.prototype.getTimezoneOffset
+		, now = null
     ;
 
-    function MockDate(y, m, d, h, M, s, ms) {
-        var date;
+	function MockDate(y, m, d, h, M, s, ms) {
+		var date;
 
-        switch (arguments.length) {
+		switch (arguments.length) {
 
-            case 0:
-                if (now !== null) {
-                    date = new _Date(now);
-                } else {
-                    date = new _Date();
-                }
-                break;
+		case 0:
+			if (now !== null) {
+				date = new _Date(now);
+			} else {
+				date = new _Date();
+			}
+			break;
 
-            case 1:
-                date = new _Date(y);
-                break;
+		case 1:
+			date = new _Date(y);
+			break;
 
-            default:
-                d = typeof d === 'undefined' ? 1 : d;
-                h = h || 0;
-                M = M || 0;
-                s = s || 0;
-                ms = ms || 0;
-                date = new _Date(y, m, d, h, M, s, ms);
-                break;
-        }
+		default:
+			d = typeof d === "undefined" ? 1 : d;
+			h = h || 0;
+			M = M || 0;
+			s = s || 0;
+			ms = ms || 0;
+			date = new _Date(y, m, d, h, M, s, ms);
+			break;
+		}
 
-        return date;
-    }
+		return date;
+	}
 
-    MockDate.UTC = _Date.UTC;
+	MockDate.UTC = _Date.UTC;
 
-    MockDate.now = function() {
-        return new MockDate().valueOf();
-    };
+	MockDate.now = function() {
+		return new MockDate().valueOf();
+	};
 
-    MockDate.parse = function(dateString) {
-        return _Date.parse(dateString);
-    };
+	MockDate.parse = function(dateString) {
+		return _Date.parse(dateString);
+	};
 
-    MockDate.toString = function() {
-        return _Date.toString();
-    };
+	MockDate.toString = function() {
+		return _Date.toString();
+	};
 
-    MockDate.prototype = _Date.prototype;
+	MockDate.prototype = _Date.prototype;
 
-    function set(date, timezoneOffset) {
-        var dateObj = new Date(date)
-        if (isNaN(dateObj.getTime())) {
-            throw new TypeError('mockdate: The time set is an invalid date: ' + date)
-        }
+	function set(date, timezoneOffset) {
+		var dateObj = new Date(date);
+		if (isNaN(dateObj.getTime())) {
+			throw new TypeError("mockdate: The time set is an invalid date: " + date);
+		}
 
-        if (typeof timezoneOffset === 'number') {
-            MockDate.prototype.getTimezoneOffset = function() {
-                return timezoneOffset;
-            }
-        }
+		if (typeof timezoneOffset === "number") {
+			MockDate.prototype.getTimezoneOffset = function() {
+				return timezoneOffset;
+			};
+		}
 
-        Date = MockDate;
+		Date = MockDate;
 
-        now = dateObj.valueOf();
-    }
+		now = dateObj.valueOf();
+	}
 
-    function reset() {
-        Date = _Date;
-        Date.prototype.getTimezoneOffset = _getTimezoneOffset
-    }
+	function reset() {
+		Date = _Date;
+		Date.prototype.getTimezoneOffset = _getTimezoneOffset;
+	}
 
-    return {
-        set: set,
-        reset: reset
-    };
+	return {
+		set: set,
+		reset: reset
+	};
 
 }));

--- a/tests/e2e/modules/mocks/date.js
+++ b/tests/e2e/modules/mocks/date.js
@@ -1,0 +1,86 @@
+(function(name, definition) {
+    if (typeof module !== 'undefined') module.exports = definition();
+    else if (typeof define === 'function' && typeof define.amd === 'object') define(definition);
+    else this[name] = definition();
+}('MockDate', function() {
+    "use strict";
+
+    var _Date = Date
+        , _getTimezoneOffset = Date.prototype.getTimezoneOffset
+        , now   = null
+    ;
+
+    function MockDate(y, m, d, h, M, s, ms) {
+        var date;
+
+        switch (arguments.length) {
+
+            case 0:
+                if (now !== null) {
+                    date = new _Date(now);
+                } else {
+                    date = new _Date();
+                }
+                break;
+
+            case 1:
+                date = new _Date(y);
+                break;
+
+            default:
+                d = typeof d === 'undefined' ? 1 : d;
+                h = h || 0;
+                M = M || 0;
+                s = s || 0;
+                ms = ms || 0;
+                date = new _Date(y, m, d, h, M, s, ms);
+                break;
+        }
+
+        return date;
+    }
+
+    MockDate.UTC = _Date.UTC;
+
+    MockDate.now = function() {
+        return new MockDate().valueOf();
+    };
+
+    MockDate.parse = function(dateString) {
+        return _Date.parse(dateString);
+    };
+
+    MockDate.toString = function() {
+        return _Date.toString();
+    };
+
+    MockDate.prototype = _Date.prototype;
+
+    function set(date, timezoneOffset) {
+        var dateObj = new Date(date)
+        if (isNaN(dateObj.getTime())) {
+            throw new TypeError('mockdate: The time set is an invalid date: ' + date)
+        }
+
+        if (typeof timezoneOffset === 'number') {
+            MockDate.prototype.getTimezoneOffset = function() {
+                return timezoneOffset;
+            }
+        }
+
+        Date = MockDate;
+
+        now = dateObj.valueOf();
+    }
+
+    function reset() {
+        Date = _Date;
+        Date.prototype.getTimezoneOffset = _getTimezoneOffset
+    }
+
+    return {
+        set: set,
+        reset: reset
+    };
+
+}));

--- a/tests/e2e/modules/mocks/date.js
+++ b/tests/e2e/modules/mocks/date.js
@@ -1,3 +1,10 @@
+/**
+ * MockDate
+ *
+ * By Bob Lauer (https://github.com/boblauer/MockDate
+ * MIT Licensed.
+*/
+
 (function(name, definition) {
     if (typeof module !== 'undefined') module.exports = definition();
     else if (typeof define === 'function' && typeof define.amd === 'object') define(definition);


### PR DESCRIPTION
This adds another type of compliment to the module: date specifics.

So know you can add a compliment on a special day, like for a anniversary or birthday.

Default compliment for this are:

```
			date: [
				["03-14", "Happy birthday, Albert Einstein!"],
				["12-10", "Happy birthday, Ada Lovelace!"]
			],
```

As you can see the format is ["month-day", "text"]. A little too late for using it on my girlfriends birthday, but that day will come again :-D