### PR TITLE
Added basename config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 *This release is scheduled to be released on 2020-07-01.*
 
-# Added
+### Added
 
-# Updated
+### Updated
 
-# Deleted
+### Deleted
 
 ### Fixed
 - The broken modules due to Socket.io change from last release [#1973](https://github.com/MichMich/MagicMirror/issues/1973)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # Deleted
 
+### Fixed
+- The broken modules due to Socket.io change from last release [#1973](https://github.com/MichMich/MagicMirror/issues/1973)
 
 ## [2.11.0] - 2020-04-01
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -15,6 +15,8 @@ var config = {
 	                      // - "0.0.0.0", "::" to listen on any interface
 	                      // Default, when address config is left out or empty, is "localhost"
 	port: 8080,
+	basename: "/", // The URL pathname where MagicMirror is hosted. If you are using a Reverse proxy
+	               // you must set the sub path here. basename must end with a /
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], // Set [] to allow all IP addresses
 	                                                       // or add a specific IPv4 of 192.168.1.5 :
 	                                                       // ["127.0.0.1", "::ffff:127.0.0.1", "::1", "::ffff:192.168.1.5"],

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -15,8 +15,8 @@ var config = {
 	                      // - "0.0.0.0", "::" to listen on any interface
 	                      // Default, when address config is left out or empty, is "localhost"
 	port: 8080,
-	basename: "/", // The URL pathname where MagicMirror is hosted. If you are using a Reverse proxy
-	               // you must set the sub path here. basename must end with a /
+	basePath: "/", // The URL path where MagicMirror is hosted. If you are using a Reverse proxy
+	               // you must set the sub path here. basePath must end with a /
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"], // Set [] to allow all IP addresses
 	                                                       // or add a specific IPv4 of 192.168.1.5 :
 	                                                       // ["127.0.0.1", "::ffff:127.0.0.1", "::1", "::ffff:192.168.1.5"],

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -15,7 +15,7 @@ if (typeof(mmPort) !== "undefined") {
 var defaults = {
 	address: address,
 	port: port,
-	basename: "/",
+	basePath: "/",
 	kioskmode: false,
 	electronOptions: {},
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -15,6 +15,7 @@ if (typeof(mmPort) !== "undefined") {
 var defaults = {
 	address: address,
 	port: port,
+	basename: "/",
 	kioskmode: false,
 	electronOptions: {},
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -9,7 +9,7 @@ var MMSocket = function(moduleName) {
 
 	// Private Methods
 	self.socket = io("/" + self.moduleName, {
-		path: config.basename + "socket.io"
+		path: config.basePath + "socket.io"
 	});
 	var notificationCallback = function() {};
 

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -9,7 +9,7 @@ var MMSocket = function(moduleName) {
 
 	// Private Methods
 	self.socket = io("/" + self.moduleName, {
-		path: window.location.pathname + "socket.io"
+		path: config.basename + "socket.io"
 	});
 	var notificationCallback = function() {};
 


### PR DESCRIPTION
use basename in socket.io path fix #1973

The use of `window.location.pathname` in the socket.io path (introduced in #1937) broke some modules, because the url was not always the basename of MagicMirror. To resolve this the basename is now a configuration option which can be set in the configuration. The default value is `/` which results in the behavior as before #1937 was added.