### PR TITLE
Cleanup config check script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Updated
-Replaced grunt-based linters with their non-grunt equivalents
+- Cleaned up check_config code
+- Replaced grunt-based linters with their non-grunt equivalents
 
 ### Deleted
 
@@ -114,7 +115,7 @@ Special thanks to @sdetweil for all his great contributions!
 ### Updated
 - Updatenotification module: Display update notification for a limited (configurable) time.
 - Enabled e2e/vendor_spec.js tests.
-- The css/custom.css will be rename after the next release. We've add into `run-start.sh` a instruction by GIT to ignore with `--skip-worktree` and `rm --cached`. [#1540](https://github.com/MichMich/MagicMirror/issues/1540)
+- The css/custom.css will be renamed after the next release. We've added into `run-start.sh` an instruction by GIT to ignore with `--skip-worktree` and `rm --cached`. [#1540](https://github.com/MichMich/MagicMirror/issues/1540)
 - Disable sending of notification CLOCK_SECOND when displaySeconds is false.
 
 ### Fixed
@@ -149,7 +150,7 @@ Special thanks to @sdetweil for all his great contributions!
 
 ### Updated
 - English translation for "Feels" to "Feels like"
-- Fixed the example calender url in `config.js.sample`
+- Fixed the example calendar url in `config.js.sample`
 - Update `ical.js` to solve various calendar issues.
 - Update weather city list url [#1676](https://github.com/MichMich/MagicMirror/issues/1676)
 - Only update clock once per minute when seconds aren't shown
@@ -254,7 +255,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 - Documentation for the existing `scale` option in the Weather Forecast module.
 
 ### Fixed
-- Allow to parse recurring calendar events where the start date is before 1900
+- Allow parsing recurring calendar events where the start date is before 1900
 - Fixed Polish translation for Single Update Info
 - Ignore entries with unparseable details in the calendar module
 - Bug showing FullDayEvents one day too long in calendar fixed
@@ -363,7 +364,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 - Add system notification `MODULE_DOM_CREATED` for notifying each module when their Dom has been fully loaded.
 - Add types for module.
 - Implement Danger.js to notify contributors when CHANGELOG.md is missing in PR.
-- Allow to scroll in full page article view of default newsfeed module with gesture events from [MMM-Gestures](https://github.com/thobach/MMM-Gestures)
+- Allow scrolling in full page article view of default newsfeed module with gesture events from [MMM-Gestures](https://github.com/thobach/MMM-Gestures)
 - Changed 'compliments.js' - update DOM if remote compliments are loaded instead of waiting one updateInterval to show custom compliments
 - Automated unit tests utils, deprecated, translator, cloneObject(lockstrings)
 - Automated integration tests translations
@@ -404,7 +405,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 **Note:** This update uses new dependencies. Please update using the following command: `git pull && npm install`
 
 ### Changed
-- Calender week is now handled with a variable translation in order to move number language specific.
+- Calendar week is now handled with a variable translation in order to move number language specific.
 - Reverted the Electron dependency back to 1.4.15 since newer version don't seem to work on the Raspberry Pi very well.
 
 ### Added
@@ -570,7 +571,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 - Remove white flash on boot up.
 - Added `update` in Raspberry Pi installation script.
 - Fix an issue where the analog clock looked scrambled. ([#611](https://github.com/MichMich/MagicMirror/issues/611))
-- If units is set to imperial, the showRainAmount option of weatherforecast will show the correct unit.
+- If units are set to imperial, the showRainAmount option of weatherforecast will show the correct unit.
 - Module currentWeather: check if temperature received from api is defined.
 - Fix an issue with module hidden status changing to `true` although lock string prevented showing it.
 - Fix newsfeed module bug (removeStartTags)
@@ -594,7 +595,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 - Module API: Method to overwrite the module's header. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules#getheader) for more information.
 - Module API: Option to define the minimum MagicMirror version to run a module. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules#requiresversion) for more information.
 - Calendar module now broadcasts the event list to all other modules using the notification system. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/calendar) for more information.
-- Possibility to use the the calendar feed as the source for the weather (currentweather & weatherforecast) location data. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/weatherforecast) for more information.
+- Possibility to use the calendar feed as the source for the weather (currentweather & weatherforecast) location data. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/weatherforecast) for more information.
 - Added option to show rain amount in the weatherforecast default module
 - Add module `updatenotification` to get an update whenever a new version is available. [See documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules/default/updatenotification) for more information.
 - Add the ability to set timezone on the date display in the Clock Module
@@ -602,7 +603,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 - Possibility to use currentweather for the compliments
 - Added option `disabled` for modules.
 - Added option `address` to set bind address.
-- Added option `onlyTemp` for currentweather module to show show only current temperature and weather icon.
+- Added option `onlyTemp` for currentweather module to show only current temperature and weather icon.
 - Added option `remoteFile` to compliments module to load compliment array from filesystem.
 - Added option `zoom` to scale the whole mirror display with a given factor.
 - Added option `roundTemp` for currentweather and weatherforecast modules to display temperatures rounded to nearest integer.

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -11,11 +11,13 @@
 
 const Linter = require("eslint").Linter;
 const linter = new Linter();
-const config = require(__dirname + "/../../.eslintrc.json");
 
-var path = require("path");
-var fs = require("fs");
-var Utils = require(__dirname + "/../../js/utils.js");
+const path = require("path");
+const fs = require("fs");
+
+const rootPath = path.resolve(__dirname + "/../");
+const config = require(rootPath + "/.eslintrc.json");
+const Utils = require(rootPath + "/js/utils.js");
 
 /* getConfigFile()
  * Return string with path of configuration file
@@ -23,8 +25,7 @@ var Utils = require(__dirname + "/../../js/utils.js");
  */
 function getConfigFile() {
 	// FIXME: This function should be in core. Do you want refactor me ;) ?, be good!
-	rootPath = path.resolve(__dirname + "/../../");
-	var configFileName = path.resolve(rootPath + "/config/config.js");
+	let configFileName = path.resolve(rootPath + "/config/config.js");
 	if (process.env.MM_CONFIG_FILE) {
 		configFileName = path.resolve(process.env.MM_CONFIG_FILE);
 	}
@@ -32,7 +33,7 @@ function getConfigFile() {
 }
 
 function checkConfigFile() {
-	var configFileName = getConfigFile();
+	const configFileName = getConfigFile();
 	// Check if file is present
 	if (fs.existsSync(configFileName) === false) {
 		console.error(Utils.colors.error("File not found: "), configFileName);
@@ -49,7 +50,7 @@ function checkConfigFile() {
 	// Validate syntax of the configuration file.
 	// In case the there errors show messages and
 	// return
-	console.info(Utils.colors.info("Checking file... ", configFileName));
+	console.info(Utils.colors.info("Checking file... "), configFileName);
 	// I'm not sure if all ever is utf-8
 	fs.readFile(configFileName, "utf-8", function (err, data) {
 		if (err) { throw err; }
@@ -58,15 +59,11 @@ function checkConfigFile() {
 			console.log("Your configuration file doesn't contain syntax errors :)");
 			return true;
 		} else {
-			errors = messages;
-			for (var idx in errors) {
-				error = errors[idx];
+			messages.forEach(error => {
 				console.log("Line", error.line, "col", error.column, error.message);
-			}
+			});
 		}
 	});
 }
 
-if (process.env.NODE_ENV !== "test") {
-	checkConfigFile();
-}
+checkConfigFile();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:lint": "npm run test:js && npm run test:style",
     "test:js": "eslint *.js js/**/*.js modules/default/**/*.js clientonly/*.js serveronly/*.js translations/*.js vendor/*.js tests/**/*.js config/* --config .eslintrc.json",
     "test:style": "stylelint css/main.css modules/default/**/*.css --config .stylelintrc.json",
-    "config:check": "node tests/configs/check_config.js",
+    "config:check": "node js/check_config.js",
     "lint": "npm run lint:js && npm run lint:json && npm run lint:markdown && npm run lint:style && npm run lint:yaml",
     "lint:js": "eslint *.js js/**/*.js modules/default/**/*.js clientonly/*.js serveronly/*.js translations/*.js vendor/*.js tests/**/*.js config/* --config .eslintrc.json --fix",
     "lint:json": "jsonlint -q package.json .eslintrc.json .markdownlintrc.json .stylelintrc.json modules/default/*/translations/*.json translations/*.json vendor/package.json",


### PR DESCRIPTION
The check_config file is not really a test and will never run when we execute them on travis. 
Therefore I propose to move it into the normal js folder.

In the process I also cleaned up some code in there, used more const/let instead of var and simplified the code a little
