### PR TITLE
Use correct object in browser context

### DIFF
--- a/js/module.js
+++ b/js/module.js
@@ -466,8 +466,8 @@ function cmpVersions(a, b) {
 Module.register = function (name, moduleDefinition) {
 
 	if (moduleDefinition.requiresVersion) {
-		Log.log("Check MagicMirror version for module '" + name + "' - Minimum version:  " + moduleDefinition.requiresVersion + " - Current version: " + global.version);
-		if (cmpVersions(global.version, moduleDefinition.requiresVersion) >= 0) {
+		Log.log("Check MagicMirror version for module '" + name + "' - Minimum version:  " + moduleDefinition.requiresVersion + " - Current version: " + window.version);
+		if (cmpVersions(window.version, moduleDefinition.requiresVersion) >= 0) {
 			Log.log("Version is ok!");
 		} else {
 			Log.log("Version is incorrect. Skip module: '" + name + "'");


### PR DESCRIPTION
Fixes #2011 by not using the `global` object but rather the correct `window` object in the browser context of the module initialisation