### PR TITLE
Fix for #2018

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ _This release is scheduled to be released on 2020-07-01._
 
 - The broken modules due to Socket.io change from last release [#1973](https://github.com/MichMich/MagicMirror/issues/1973)
 - Add backward compatibility for old module code in socketclient.js [#1973](https://github.com/MichMich/MagicMirror/issues/1973)
+- Fix the use of "maxNumberOfDays" in the module "weatherforecast" [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
 
 ## [2.11.0] - 2020-04-01
 

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -294,7 +294,7 @@ Module.register("weatherforecast", {
 			return;
 		}
 
-		params += "&cnt=" + (this.config.maxNumberOfDays·<·1·||·this.config.maxNumberOfDays·>·17 ? 7 : this.config.maxNumberOfDays);
+		params += "&cnt=" + (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17 ? 7 : this.config.maxNumberOfDays);
 
 		params += "&units=" + this.config.units;
 		params += "&lang=" + this.config.lang;

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -294,7 +294,7 @@ Module.register("weatherforecast", {
 			return;
 		}
 
-		params += "&cnt=" + (((this.config.maxNumberOfDays < 1) || (this.config.maxNumberOfDays > 17)) ? 7 : this.config.maxNumberOfDays);
+		params += "&cnt=" + (this.config.maxNumberOfDays·<·1·||·this.config.maxNumberOfDays·>·17 ? 7 : this.config.maxNumberOfDays);
 
 		params += "&units=" + this.config.units;
 		params += "&lang=" + this.config.lang;

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -294,6 +294,8 @@ Module.register("weatherforecast", {
 			return;
 		}
 
+		params += "&cnt=" + (((this.config.maxNumberOfDays < 1) || (this.config.maxNumberOfDays > 17)) ? 7 : this.config.maxNumberOfDays);
+
 		params += "&units=" + this.config.units;
 		params += "&lang=" + this.config.lang;
 		params += "&APPID=" + this.config.appid;


### PR DESCRIPTION
Fix the use of "maxNumberOfDays" in the module "weatherforecast" [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
