### PR TITLE
Bug fix to correctly handle the logic for 'maxEntries' Issue #2050

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror²
 
-## [20.11.1] - 2020-06-20
+## [2.12.0] - 2020-06-20
 ### Fixed
 - Bug fix related to 'maxEntries' not displaying Calendar events.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror²
 
+## [20.11.1] - 2020-06-20
+### Fixed
+- Bug fix related to 'maxEntries' not displaying Calendar events.
+
 ## [2.11.0] - 2020-04-01
 
 🚨 READ THIS BEFORE UPDATING 🚨

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -334,7 +334,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumNumbe
 			});
 
 			//console.log(newEvents);
-            events = newEvents;
+			events = newEvents;
 
 			self.broadcastEvents();
 			scheduleTimer();

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -8,7 +8,7 @@
 var ical = require("./vendor/ical.js");
 var moment = require("moment");
 
-var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, includePastEvents) {
+var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumNumberOfDays, auth, includePastEvents) {
 	var self = this;
 
 	var reloadTimer = null;
@@ -226,13 +226,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 							var curEvent = event;
 							var showRecurrence = true;
 
-							// Stop parsing this event's recurrences if we've already found maximumEntries worth of recurrences.
-							// (The logic below would still filter the extras, but the check is simple since we're already tracking the count)
-							if (addedEvents >= maximumEntries) {
-								break;
-							}
-
-							startDate = moment(date);
+						    startDate = moment(date);
 
 							// For each date that we"re checking, it"s possible that there is a recurrence override for that one day.
 							if ((curEvent.recurrences != undefined) && (curEvent.recurrences[dateKey] != undefined))
@@ -266,7 +260,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 								showRecurrence = false;
 							}
 
-							if ((showRecurrence === true) && (addedEvents < maximumEntries)) {
+							if (showRecurrence === true) {
 								addedEvents++;
 								newEvents.push({
 									title: recurrenceTitle,
@@ -340,8 +334,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumEntri
 			});
 
 			//console.log(newEvents);
-
-			events = newEvents.slice(0, maximumEntries);
+            events = newEvents;
 
 			self.broadcastEvents();
 			scheduleTimer();

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -226,7 +226,7 @@ var CalendarFetcher = function(url, reloadInterval, excludedEvents, maximumNumbe
 							var curEvent = event;
 							var showRecurrence = true;
 
-						    startDate = moment(date);
+							startDate = moment(date);
 
 							// For each date that we"re checking, it"s possible that there is a recurrence override for that one day.
 							if ((curEvent.recurrences != undefined) && (curEvent.recurrences[dateKey] != undefined))

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -47,7 +47,7 @@ module.exports = NodeHelper.create({
 		var fetcher;
 		if (typeof self.fetchers[url] === "undefined") {
 			console.log("Create new calendar fetcher for url: " + url + " - Interval: " + fetchInterval);
-			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents);
+			fetcher = new CalendarFetcher(url, fetchInterval, excludedEvents, maximumNumberOfDays, auth, broadcastPastEvents);
 
 			fetcher.onReceive(function(fetcher) {
 				//console.log('Broadcast events.');


### PR DESCRIPTION
* Does the pull request solve a **related** issue? Yes
* If so, can you reference the issue? https://github.com/MichMich/MagicMirror/issues/2050
* What does the pull request accomplish? Use a list if needed.
** Removes the logic of filtering events by `maxEntries` from calendarfetcher.js
** Results in the logic of filtering to solely be done in calendar.js
* If it includes major visual changes please add screenshots.
