### PR TITLE
added config option to hide sunrise/sunset in Current Weather module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _This release is scheduled to be released on 2020-07-01._
 - Added option to config the level of logging
 - Added prettier for an even cleaner codebase
 - Hide Sunrise/Sunset in Weather module
+- Hide Sunrise/Sunset in Current Weather module
 - Added Met Office DataHub (UK) provider
 
 ### Updated

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -23,6 +23,7 @@ Module.register("currentweather", {
 		lang: config.language,
 		decimalSymbol: ".",
 		showHumidity: false,
+		showSun: true,
 		degreeLabel: false,
 		showIndoorTemperature: false,
 		showIndoorHumidity: false,
@@ -155,13 +156,15 @@ Module.register("currentweather", {
 			small.appendChild(humidityIcon);
 		}
 
-		var sunriseSunsetIcon = document.createElement("span");
-		sunriseSunsetIcon.className = "wi dimmed " + this.sunriseSunsetIcon;
-		small.appendChild(sunriseSunsetIcon);
+		if (this.config.showSun) {
+			var sunriseSunsetIcon = document.createElement("span");
+			sunriseSunsetIcon.className = "wi dimmed " + this.sunriseSunsetIcon;
+			small.appendChild(sunriseSunsetIcon);
 
-		var sunriseSunsetTime = document.createElement("span");
-		sunriseSunsetTime.innerHTML = " " + this.sunriseSunsetTime;
-		small.appendChild(sunriseSunsetTime);
+			var sunriseSunsetTime = document.createElement("span");
+			sunriseSunsetTime.innerHTML = " " + this.sunriseSunsetTime;
+			small.appendChild(sunriseSunsetTime);
+		}
 
 		wrapper.appendChild(small);
 	},


### PR DESCRIPTION
Adds configuration option to hide sunrise/sunset in the default Current Weather module.

Configuration option is `showSun` to match the addition to the default Weather module.

Appropriate request also submitted to [MagicMirror-Documentation](https://github.com/MichMich/MagicMirror-Documentation).