### PR TITLE
fixed minor typo (apiKey vs. appid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _This release is scheduled to be released on 2020-10-01._
 
 ### Updated
 
+- Change incorrect weather.js default properties.
+
 ### Deleted
 
 ### Fixed

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -15,7 +15,6 @@ Module.register("weather", {
 
 		location: false,
 		locationID: false,
-		apiKey: "",
 		units: config.units,
 
 		tempUnits: config.units,
@@ -43,6 +42,8 @@ Module.register("weather", {
 		initialLoadDelay: 0, // 0 seconds delay
 		retryDelay: 2500,
 
+		apiKey: "",
+		apiSecret: "",
 		apiVersion: "2.5",
 		apiBase: "https://api.openweathermap.org/data/",
 		weatherEndpoint: "/weather",

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -15,7 +15,7 @@ Module.register("weather", {
 
 		location: false,
 		locationID: false,
-		appid: "",
+		apiKey: "",
 		units: config.units,
 
 		tempUnits: config.units,


### PR DESCRIPTION
Not much of note. I was initially getting nothing from the module and got confused by the typo since I thought the config file needed an `appid` key instead of an `apiKey` key, which is used everywhere else in the module.