### PR TITLE
 Adjusts maxNumberOfDays depending on the endpoint 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _This release is scheduled to be released on 2020-10-01._
 ### Deleted
 
 ### Fixed
+- Fix the use of "maxNumberOfDays" in the module "weatherforecast depending on the endpoint (forecast/daily or forecast)". [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
 
 ## [2.12.0] - 2020-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ _This release is scheduled to be released on 2020-10-01._
 ### Deleted
 
 ### Fixed
+
 - Fix the use of "maxNumberOfDays" in the module "weatherforecast depending on the endpoint (forecast/daily or forecast)". [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
 
 ## [2.12.0] - 2020-07-01

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -294,7 +294,15 @@ Module.register("weatherforecast", {
 			return;
 		}
 
-		params += "&cnt=" + (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17 ? 7 : this.config.maxNumberOfDays);
+		let numberOfDays;
+		if (this.config.forecastEndpoint === "forecast") {
+			numberOfDays = (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 5 ? 5 : this.config.maxNumberOfDays);
+			// don't get forecasts for the 6th day, as it would not represent the whole day
+			numberOfDays = numberOfDays * 8 - Math.ceil(new Date().getHours() / 3) % 8;
+		} else {
+			numberOfDays = (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17) ? 7 : this.config.maxNumberOfDays;
+		}
+		params += "&cnt=" + numberOfDays;
 
 		params += "&units=" + this.config.units;
 		params += "&lang=" + this.config.lang;

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -296,11 +296,11 @@ Module.register("weatherforecast", {
 
 		let numberOfDays;
 		if (this.config.forecastEndpoint === "forecast") {
-			numberOfDays = (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 5 ? 5 : this.config.maxNumberOfDays);
+			numberOfDays = this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 5 ? 5 : this.config.maxNumberOfDays;
 			// don't get forecasts for the 6th day, as it would not represent the whole day
-			numberOfDays = numberOfDays * 8 - Math.ceil(new Date().getHours() / 3) % 8;
+			numberOfDays = numberOfDays * 8 - (Math.floor(new Date().getHours() / 3) % 8);
 		} else {
-			numberOfDays = (this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17) ? 7 : this.config.maxNumberOfDays;
+			numberOfDays = this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17 ? 7 : this.config.maxNumberOfDays;
 		}
 		params += "&cnt=" + numberOfDays;
 


### PR DESCRIPTION
Fixes #2018 

Now the `cnt` is set depending on the endpoint
- for 'forecast/daily' the `maxNumberOfDays` is used directly
- for 'forcast' `maxNumberOfDay` is adjusted. The maximum here is 5 days

The documentation for this module need to be adjusted as well:
https://docs.magicmirror.builders/modules/weatherforecast.html#configuration-options

If a free API token is used this description fits the maxNumberOfDays config:
Possible values: 1 - 5
Default value: 5 (5 days) 

Else the config description remains the same