### PR TITLE
Fix log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _This release is scheduled to be released on 2020-10-01._
 
 - Fix the use of "maxNumberOfDays" in the module "weatherforecast depending on the endpoint (forecast/daily or forecast)". [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
 - Fix calendar display. Account for current timezone. [#2068](https://github.com/MichMich/MagicMirror/issues/2068)
+- Fix logLevel being set before loading config
 
 ## [2.12.0] - 2020-07-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -202,6 +202,8 @@ var App = function () {
 		loadConfig(function (c) {
 			config = c;
 
+			Log.setLogLevel(config.logLevel);
+
 			var modules = [];
 
 			for (var m in config.modules) {

--- a/js/logger.js
+++ b/js/logger.js
@@ -32,13 +32,15 @@
 		timeStamp: Function.prototype.bind.call(console.timeStamp, console)
 	};
 
-	if (config && config.logLevel) {
-		Object.keys(logLevel).forEach(function (key, index) {
-			if (!config.logLevel.includes(key.toLocaleUpperCase())) {
-				logLevel[key] = function () {};
-			}
-		});
-	}
+	logLevel.setLogLevel = function (newLevel) {
+		if (newLevel) {
+			Object.keys(logLevel).forEach(function (key, index) {
+				if (!newLevel.includes(key.toLocaleUpperCase())) {
+					logLevel[key] = function () {};
+				}
+			});
+		}
+	};
 
 	return logLevel;
 });

--- a/js/main.js
+++ b/js/main.js
@@ -477,6 +477,9 @@ var MM = (function () {
 		init: function () {
 			Log.info("Initializing MagicMirror.");
 			loadConfig();
+
+			Log.setLogLevel(config.logLevel);
+
 			Translator.loadCoreTranslations(config.language);
 			Loader.loadModules();
 		},


### PR DESCRIPTION
The logLevel config entry had no effect since the config was loaded after the logLevel was initialized. This PR changes the order, now the logLevel is set after the config is loaded