### PR TITLE
Fixing double conversion of time between UTC and local timezone

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -468,11 +468,6 @@ Module.register("calendar", {
 			for (var e in calendar) {
 				var event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 
-				// correct data for the current timezone
-				var offset = -(new Date().getTimezoneOffset() * 60 * 1000);
-				event.startDate = event.startDate - offset;
-				event.endDate = event.endDate - offset;
-
 				if (event.endDate < now) {
 					continue;
 				}

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -186,10 +186,12 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumNu
 						// kblankenship1989 - to fix issue #1798, converting all dates to locale time first, then converting back to UTC time
 						const pastLocal = pastMoment.subtract(past.getTimezoneOffset(), "minutes").toDate();
 						const futureLocal = futureMoment.subtract(future.getTimezoneOffset(), "minutes").toDate();
-						const datesLocal = rule.between(pastLocal, futureLocal, true, limitFunction);
-						const dates = datesLocal.map(function (dateLocal) {
-							return moment(dateLocal).add(dateLocal.getTimezoneOffset(), "minutes").toDate();
-						});
+						const dates = rule.between(pastLocal, futureLocal, true, limitFunction);
+						if (getTitleFromEvent(event).search("Manageando") > -1) {
+							console.log(startDate);
+							console.log(event);
+							console.log(rule);
+						}
 
 						// The "dates" array contains the set of dates within our desired date range range that are valid
 						// for the recurrence rule. *However*, it's possible for us to have a specific recurrence that

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -187,11 +187,6 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumNu
 						const pastLocal = pastMoment.subtract(past.getTimezoneOffset(), "minutes").toDate();
 						const futureLocal = futureMoment.subtract(future.getTimezoneOffset(), "minutes").toDate();
 						const dates = rule.between(pastLocal, futureLocal, true, limitFunction);
-						if (getTitleFromEvent(event).search("Manageando") > -1) {
-							console.log(startDate);
-							console.log(event);
-							console.log(rule);
-						}
 
 						// The "dates" array contains the set of dates within our desired date range range that are valid
 						// for the recurrence rule. *However*, it's possible for us to have a specific recurrence that


### PR DESCRIPTION
- Does the pull request solve a **related** issue?
Yes

- If so, can you reference the issue?
#2068

- What does the pull request accomplish? Use a list if needed.
Event times appear to be broken in the current release. This fix removes the logic in two places that's converting across UTC and local timezones. I haven't updated the Changelog, but can do it if this seems reasonable.

- More context
I suspect this to be case because we started using 'ical' directly, and some of the changes made in PR 1884 in 'ical' might have been lost. I had submitted a fix to 'ical' to correctly handle timezone parsing (https://github.com/peterbraden/ical.js/pull/111), but it's not accepted as there's a build dependency.
I will try to submit a separate fix outside of 'ical' to correctly handle timezone conversion when the event organizer is in a different timezone.

- If it includes major visual changes please add screenshots.
It worked for my Calendar which has some pretty complex events.
