### PR TITLE
Fixes getting only full day forecasts

### DIFF
--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -297,8 +297,8 @@ Module.register("weatherforecast", {
 		let numberOfDays;
 		if (this.config.forecastEndpoint === "forecast") {
 			numberOfDays = this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 5 ? 5 : this.config.maxNumberOfDays;
-			// don't get forecasts for the 6th day, as it would not represent the whole day
-			numberOfDays = numberOfDays * 8 - (Math.floor(new Date().getHours() / 3) % 8);
+			// don't get forecasts for the next day, as it would not represent the whole day
+			numberOfDays = numberOfDays * 8 - (Math.round(new Date().getHours() / 3) % 8);
 		} else {
 			numberOfDays = this.config.maxNumberOfDays < 1 || this.config.maxNumberOfDays > 17 ? 7 : this.config.maxNumberOfDays;
 		}


### PR DESCRIPTION
Finally I had time to examine the API well enough.
It seems that the correct function to use here is the round function.
Now the forecast requested from the API will always fetch full days only.

Fixes #2018 
Corrects the PR #2066 