### PR TITLE
weatherforecast OpenWeather onecall api support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 _This release is scheduled to be released on 2020-10-01._
 
 ### Added
+- Added support in weatherforecast for OpenWeather onecall API
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 _This release is scheduled to be released on 2020-10-01._
 
 ### Added
+
 - Added support in weatherforecast for OpenWeather onecall API
 
 ### Updated


### PR DESCRIPTION
Relating to [Issue 2076](https://github.com/MichMich/MagicMirror/issues/2076), adds support to weatherforecast for OpenWeather onecall API.