### PR TITLE
Backward browser compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _This release is scheduled to be released on 2020-10-01._
 
 ### Fixed
 
+- Fix backward compatibility issues for Safari < 11. [#1985](https://github.com/MichMich/MagicMirror/issues/1985)
 - Fix the use of "maxNumberOfDays" in the module "weatherforecast depending on the endpoint (forecast/daily or forecast)". [#2018](https://github.com/MichMich/MagicMirror/issues/2018)
 - Fix calendar display. Account for current timezone. [#2068](https://github.com/MichMich/MagicMirror/issues/2068)
 - Fix logLevel being set before loading config.

--- a/js/logger.js
+++ b/js/logger.js
@@ -19,7 +19,7 @@
 		root.Log = factory(root.config);
 	}
 })(this, function (config) {
-	let logLevel = {
+	const logLevel = {
 		info: Function.prototype.bind.call(console.info, console),
 		log: Function.prototype.bind.call(console.log, console),
 		error: Function.prototype.bind.call(console.error, console),

--- a/js/main.js
+++ b/js/main.js
@@ -42,7 +42,7 @@ var MM = (function () {
 			dom.appendChild(moduleHeader);
 
 			if (typeof module.getHeader() === "undefined" || module.getHeader() !== "") {
-				moduleHeader.style = "display: none;";
+				moduleHeader.style.display = "none;";
 			}
 
 			var moduleContent = document.createElement("div");
@@ -216,7 +216,11 @@ var MM = (function () {
 		contentWrapper[0].appendChild(newContent);
 
 		headerWrapper[0].innerHTML = newHeader;
-		headerWrapper[0].style = headerWrapper.length > 0 && newHeader ? undefined : "display: none;";
+		if (headerWrapper.length > 0 && newHeader) {
+			delete headerWrapper[0].style;
+		} else {
+			headerWrapper[0].style.display = "none";
+		}
 	};
 
 	/* hideModule(module, speed, callback)


### PR DESCRIPTION
This PR solves #1985. The "undefined" header is not shown on Safari < 11 anymore. Furthermore, the new logger implementation is now also working on older browsers i.e. Safari < 11. The issue here was that with an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) some browsers do not allow declaration of variables with `let` or `var`, but only with `const`. I think this makes sense as IIFE is used for immutable functions.

Only tested with Safari < 11 on iPad from 2012.