### PR TITLE
Added --dry-run to fetch call within updatednotification module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _This release is scheduled to be released on 2020-10-01._
 
 ### Added
 
+- `--dry-run` option adde in fetch call within updatenotification node_helper. This is to prevent
+  MagicMirror from consuming any fetch result. Causes conflict with MMPM when attempting to check
+  for updates to MagicMirror and/or MagicMirror modules.
 - Test coverage with Istanbul, run it with `npm run test:coverage`.
 - Add lithuanian language.
 - Added support in weatherforecast for OpenWeather onecall API.

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -72,7 +72,7 @@ module.exports = NodeHelper.create({
 	performFetch: function () {
 		var self = this;
 		simpleGits.forEach((sg) => {
-			sg.git.fetch().status((err, data) => {
+			sg.git.fetch(["--dry-run"]).status((err, data) => {
 				data.module = sg.module;
 				if (!err) {
 					sg.git.log({ "-1": null }, (err, data2) => {


### PR DESCRIPTION
The `updatenotification` module uses a standard `git fetch`, which consumes any updates available for a given repository, and the MagicMirror repository itself. This causes [MMPM](https://github.com/bee-mar/mmpm) to report modules as up to date when scanning module directories and the MagicMirror repository.

This is remedied by adding the `--dry-run` option to the fetch call, which still leaves repository data available to be fetched when scanning directories.
