### PR TITLE
Fix config check after merge of prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Special thanks to the following contributors: @AndreKoepke, @andrezibaia, @bryan
 - Throw error when check_config fails. [#1928](https://github.com/MichMich/MagicMirror/issues/1928)
 - Bug fix related to 'maxEntries' not displaying Calendar events. [#2050](https://github.com/MichMich/MagicMirror/issues/2050)
 - Updated ical library to latest version. [#1926](https://github.com/MichMich/MagicMirror/issues/1926)
+- Fix config check after merge of prettier [#2109](https://github.com/MichMich/MagicMirror/issues/2109)
 
 ## [2.11.0] - 2020-04-01
 

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -55,14 +55,13 @@ function checkConfigFile() {
 		}
 		const messages = linter.verify(data);
 		if (messages.length === 0) {
-			Log.log("Your configuration file doesn't contain syntax errors :)");
-			return true;
+			Log.info(Utils.colors.pass("Your configuration file doesn't contain syntax errors :)"));
 		} else {
+			Log.error(Utils.colors.error("Your configuration file contains syntax errors :("));
 			// In case the there errors show messages and return
 			messages.forEach((error) => {
-				Log.log("Line", error.line, "col", error.column, error.message);
+				Log.error("Line", error.line, "col", error.column, error.message);
 			});
-			throw new Error("Wrong syntax in config file!");
 		}
 	});
 }

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -12,7 +12,6 @@ const path = require("path");
 const fs = require("fs");
 
 const rootPath = path.resolve(__dirname + "/../");
-const config = require(rootPath + "/.eslintrc.json");
 const Log = require(rootPath + "/js/logger.js");
 const Utils = require(rootPath + "/js/utils.js");
 
@@ -54,7 +53,7 @@ function checkConfigFile() {
 		if (err) {
 			throw err;
 		}
-		const messages = linter.verify(data, config);
+		const messages = linter.verify(data);
 		if (messages.length === 0) {
 			Log.log("Your configuration file doesn't contain syntax errors :)");
 			return true;

--- a/js/utils.js
+++ b/js/utils.js
@@ -10,7 +10,8 @@ var Utils = {
 	colors: {
 		warn: colors.yellow,
 		error: colors.red,
-		info: colors.blue
+		info: colors.blue,
+		pass: colors.green
 	}
 };
 


### PR DESCRIPTION
The verifying of the config file doesnt need the eslint config file to run. SO remove it and jsut check the syntax and not the format. Fixes #2109 