### PR TITLE
Fixes the un-hide problem with currentwether and weatherforcast modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _This release is scheduled to be released on 2021-01-01._
 
 ### Fixed
 
+- Fixed the "un-hide on update" problem with "currentwather" and "watherforcast" modules.
 - JSON Parse translation files with comments crashing UI. (#2149)
 - Calendar parsing where RRULE bug returns wrong date, add Windows timezone name support. (#2145, #2151)
 - Wrong node-ical version installed (package.json) requested version. (#2153)

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -495,11 +495,12 @@ Module.register("currentweather", {
 
 		this.sunriseSunsetTime = timeString;
 		this.sunriseSunsetIcon = sunrise < now && sunset > now ? "wi-sunset" : "wi-sunrise";
-
-		this.show(this.config.animationSpeed, { lockString: this.identifier });
-		this.loaded = true;
-		this.updateDom(this.config.animationSpeed);
-		this.sendNotification("CURRENTWEATHER_DATA", { data: data });
+		if (!this.hidden) {
+			this.show(this.config.animationSpeed, { lockString: this.identifier });
+			this.loaded = true;
+			this.updateDom(this.config.animationSpeed);
+			this.sendNotification("CURRENTWEATHER_DATA", { data: data });
+		}
 	},
 
 	/* scheduleUpdate()

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -408,9 +408,11 @@ Module.register("weatherforecast", {
 		}
 
 		//Log.log(this.forecast);
-		this.show(this.config.animationSpeed, { lockString: this.identifier });
-		this.loaded = true;
-		this.updateDom(this.config.animationSpeed);
+		if (!this.hidden) {
+			this.show(this.config.animationSpeed, { lockString: this.identifier });
+			this.loaded = true;
+			this.updateDom(this.config.animationSpeed);
+		}
 	},
 
 	/* scheduleUpdate()


### PR DESCRIPTION
- Does the pull request solve a **related** issue?
I don't really know if there is an "issue" created. I just read three different threads in the forum regarding the "automatic un-hide". And I have myself had the same problem.

- What does the pull request accomplish? Use a list if needed.
Gets rid of the problem that you never can hide the "currentweather" and "weatherforcast" for more then the time it updates.

- If it includes major visual changes please add screenshots.
No visual changes. Just piece of mind. :)
