### PR TITLE
A space after icon of sunrise and sunset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2021-01-01._
 - Wrong node-ical version installed (package.json) requested version. (#2153)
 - Fix calendar fetcher subsequent timing (#2160)
 - Rename Greek translation to correct ISO 639-1 alpha-2 code (gr > el). (#2155)
+- Add a space after icons of sunrise and sunset (#2169)
 
 ## [2.13.0] - 2020-10-01
 

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -187,10 +187,10 @@ Module.register("clock", {
 				'"><i class="fa fa-sun-o" aria-hidden="true"></i> ' +
 				untilNextEventString +
 				"</span>" +
-				'<span><i class="fa fa-arrow-up" aria-hidden="true"></i>' +
+				'<span><i class="fa fa-arrow-up" aria-hidden="true"></i> ' +
 				formatTime(this.config, sunTimes.sunrise) +
 				"</span>" +
-				'<span><i class="fa fa-arrow-down" aria-hidden="true"></i>' +
+				'<span><i class="fa fa-arrow-down" aria-hidden="true"></i> ' +
 				formatTime(this.config, sunTimes.sunset) +
 				"</span>";
 		}


### PR DESCRIPTION
It's just a "typo" of missing space after an icon in sunrise and sunset. In a moonrise and moonset the space exists and it looks better.