### PR TITLE
Add Chuvash translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _This release is scheduled to be released on 2021-01-01._
 ### Added
 
 - Added new log level "debug" to the logger.
+- Chuvash translation
 
 ### Updated
 

--- a/translations/cv.json
+++ b/translations/cv.json
@@ -25,7 +25,7 @@
 	"WNW": "АҪА",
 	"NW": "ҪА",
 	"NNW": "ҪҪА",
-	"FEELS": "Туйӑнать",
+	"FEELS": "Туйӑннӑ",
 
 	"UPDATE_NOTIFICATION": "MagicMirror² валли ҫӗнетӳ пур.",
 	"UPDATE_NOTIFICATION_MODULE": "{MODULE_NAME} модуль валли ҫӗнетӳ пур.",

--- a/translations/cv.json
+++ b/translations/cv.json
@@ -1,0 +1,34 @@
+{
+	"LOADING": "Тиенет &hellip;",
+
+	"TODAY": "Паян",
+	"TOMORROW": "Ыран",
+	"DAYAFTERTOMORROW": "Виҫмине",
+	"RUNNING": "Хальхи",
+	"EMPTY": "Пулас ӗҫ ҫук",
+
+	"WEEK": "{weekNumber} эрне",
+
+	"N": "Ҫ",
+	"NNE": "ҪҪТ",
+	"NE": "ҪТ",
+	"ENE": "ТҪТ",
+	"E": "Т",
+	"ESE": "ТКТ",
+	"SE": "КТ",
+	"SSE": "ККТ",
+	"S": "К",
+	"SSW": "ККА",
+	"SW": "КА",
+	"WSW": "АКА",
+	"W": "А",
+	"WNW": "АҪА",
+	"NW": "ҪА",
+	"NNW": "ҪҪА",
+	"FEELS": "Туйӑнать",
+
+	"UPDATE_NOTIFICATION": "MagicMirror² валли ҫӗнетӳ пур.",
+	"UPDATE_NOTIFICATION_MODULE": "{MODULE_NAME} модуль валли ҫӗнетӳ пур.",
+	"UPDATE_INFO_SINGLE": "Ҫак инсталляци {BRANCH_NAME} commit турат {COMMIT_COUNT} коммитпа кая уйрӑлса тӑрать.",
+	"UPDATE_INFO_MULTIPLE": "Ҫак инсталляци {BRANCH_NAME} commit турат {COMMIT_COUNT} коммитпа кая уйрӑлса тӑрать."
+}

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -14,6 +14,7 @@ var translations = {
 	fy: "translations/fy.json", // Frysk
 	es: "translations/es.json", // Spanish
 	ca: "translations/ca.json", // Catalan
+	cv: "translations/cv.json", // Chuvash
 	nb: "translations/nb.json", // Norsk bokmål
 	nn: "translations/nn.json", // Norsk nynorsk
 	pt: "translations/pt.json", // Português


### PR DESCRIPTION
This change adds the Chuvash translation:
- translations/cv.json (cv is the iso code for Chuvash language)
- translations/translations.json (since it is needed to registered to be loadable)
- a note in the CHANGELOG.

