### PR TITLE
New options "limitDays" and "customEvents"

### DIFF
--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -11,6 +11,7 @@ Module.register("calendar", {
 	defaults: {
 		maximumEntries: 10, // Total Maximum Entries
 		maximumNumberOfDays: 365,
+		limitDays: 0, // Limit the number of days shown, 0 = no limit
 		displaySymbol: true,
 		defaultSymbol: "calendar", // Fontawesome Symbol see https://fontawesome.com/cheatsheet?from=io
 		showLocation: false,
@@ -37,6 +38,7 @@ Module.register("calendar", {
 		hideOngoing: false,
 		colored: false,
 		coloredSymbolOnly: false,
+		customEvents: [], // Array of {keyword: "", symbol: "", color: ""} where Keyword is a regexp and symbol/color are to be applied for matched
 		tableClass: "small",
 		calendars: [
 			{
@@ -153,6 +155,12 @@ Module.register("calendar", {
 
 	// Override dom generator.
 	getDom: function () {
+		// Define second, minute, hour, and day constants
+		const oneSecond = 1000; // 1,000 milliseconds
+		const oneMinute = oneSecond * 60;
+		const oneHour = oneMinute * 60;
+		const oneDay = oneHour * 24;
+
 		var events = this.createEventList();
 		var wrapper = document.createElement("table");
 		wrapper.className = this.config.tableClass;
@@ -218,6 +226,19 @@ Module.register("calendar", {
 				symbolWrapper.className = "symbol align-right " + symbolClass;
 
 				var symbols = this.symbolsForEvent(event);
+				// If symbols are displayed and custom symbol is set, replace event symbol
+				if (this.config.displaySymbol && this.config.customEvents.length > 0) {
+					for (var ev in this.config.customEvents) {
+						if (typeof this.config.customEvents[ev].symbol !== "undefined" && this.config.customEvents[ev].symbol !== "") {
+							var needle = new RegExp(this.config.customEvents[ev].keyword, "gi");
+							if (needle.test(event.title)) {
+								symbols[0] = this.config.customEvents[ev].symbol;
+								break;
+							}
+						}
+					}
+				}
+
 				for (var i = 0; i < symbols.length; i++) {
 					var symbol = document.createElement("span");
 					symbol.className = "fa fa-fw fa-" + symbols[i];
@@ -245,6 +266,23 @@ Module.register("calendar", {
 						yearDiff = thisYear - event.firstYear;
 
 					repeatingCountTitle = ", " + yearDiff + ". " + repeatingCountTitle;
+				}
+			}
+
+			// Color events if custom color is specified
+			if (this.config.customEvents.length > 0) {
+				for (var ev in this.config.customEvents) {
+					if (typeof this.config.customEvents[ev].color !== "undefined" && this.config.customEvents[ev].color !== "") {
+						var needle = new RegExp(this.config.customEvents[ev].keyword, "gi");
+						if (needle.test(event.title)) {
+							eventWrapper.style.cssText = "color:" + this.config.customEvents[ev].color;
+							titleWrapper.style.cssText = "color:" + this.config.customEvents[ev].color;
+							if (this.config.displaySymbol) {
+								symbolWrapper.style.cssText = "color:" + this.config.customEvents[ev].color;
+							}
+							break;
+						}
+					}
 				}
 			}
 
@@ -280,82 +318,56 @@ Module.register("calendar", {
 
 				eventWrapper.appendChild(titleWrapper);
 				var now = new Date();
-				// Define second, minute, hour, and day variables
-				var oneSecond = 1000; // 1,000 milliseconds
-				var oneMinute = oneSecond * 60;
-				var oneHour = oneMinute * 60;
-				var oneDay = oneHour * 24;
-				if (event.fullDayEvent) {
-					//subtract one second so that fullDayEvents end at 23:59:59, and not at 0:00:00 one the next day
-					event.endDate -= oneSecond;
-					if (event.today) {
-						timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
-					} else if (event.startDate - now < oneDay && event.startDate - now > 0) {
-						timeWrapper.innerHTML = this.capFirst(this.translate("TOMORROW"));
-					} else if (event.startDate - now < 2 * oneDay && event.startDate - now > 0) {
-						if (this.translate("DAYAFTERTOMORROW") !== "DAYAFTERTOMORROW") {
-							timeWrapper.innerHTML = this.capFirst(this.translate("DAYAFTERTOMORROW"));
-						} else {
+
+				if (this.config.timeFormat === "absolute") {
+					// Use dateFormat
+					timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
+					// Add end time if showEnd
+					if (this.config.showEnd) {
+						timeWrapper.innerHTML += "-";
+						timeWrapper.innerHTML += this.capFirst(moment(event.endDate, "x").format(this.config.dateEndFormat));
+					}
+					// For full day events we use the fullDayEventDateFormat
+					if (event.fullDayEvent) {
+						//subtract one second so that fullDayEvents end at 23:59:59, and not at 0:00:00 one the next day
+						event.endDate -= oneSecond;
+						timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.fullDayEventDateFormat));
+					}
+					if (this.config.getRelative > 0 && event.startDate < now) {
+						// Ongoing and getRelative is set
+						timeWrapper.innerHTML = this.capFirst(
+							this.translate("RUNNING", {
+								fallback: this.translate("RUNNING") + " {timeUntilEnd}",
+								timeUntilEnd: moment(event.endDate, "x").fromNow(true)
+							})
+						);
+					} else if (this.config.urgency > 0 && event.startDate - now < this.config.urgency * oneDay) {
+						// Within urgency days
+						timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
+					}
+					if (event.fullDayEvent && this.config.nextDaysRelative) {
+						// Full days events within the next two days
+						if (event.today) {
+							timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
+						} else if (event.startDate - now < oneDay && event.startDate - now > 0) {
+							timeWrapper.innerHTML = this.capFirst(this.translate("TOMORROW"));
+						} else if (event.startDate - now < 2 * oneDay && event.startDate - now > 0) {
+							if (this.translate("DAYAFTERTOMORROW") !== "DAYAFTERTOMORROW") {
+								timeWrapper.innerHTML = this.capFirst(this.translate("DAYAFTERTOMORROW"));
+							}
+						}
+					}
+				} else {
+					// Show relative times
+					if (event.startDate >= now) {
+						// Use relative  time
+						timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar());
+						if (event.startDate - now < this.config.getRelative * oneHour) {
+							// If event is within getRelative  hours, display 'in xxx' time format or moment.fromNow()
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
 						}
 					} else {
-						/* Check to see if the user displays absolute or relative dates with their events
-						 * Also check to see if an event is happening within an 'urgency' time frameElement
-						 * For example, if the user set an .urgency of 7 days, those events that fall within that
-						 * time frame will be displayed with 'in xxx' time format or moment.fromNow()
-						 *
-						 * Note: this needs to be put in its own function, as the whole thing repeats again verbatim
-						 */
-						if (this.config.timeFormat === "absolute") {
-							if (this.config.urgency > 1 && event.startDate - now < this.config.urgency * oneDay) {
-								// This event falls within the config.urgency period that the user has set
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").from(moment().format("YYYYMMDD")));
-							} else {
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.fullDayEventDateFormat));
-							}
-						} else {
-							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").from(moment().format("YYYYMMDD")));
-						}
-					}
-					if (this.config.showEnd) {
-						timeWrapper.innerHTML += "-";
-						timeWrapper.innerHTML += this.capFirst(moment(event.endDate, "x").format(this.config.fullDayEventDateFormat));
-					}
-				} else {
-					if (event.startDate >= new Date()) {
-						if (event.startDate - now < 2 * oneDay) {
-							// This event is within the next 48 hours (2 days)
-							if (event.startDate - now < this.config.getRelative * oneHour) {
-								// If event is within 6 hour, display 'in xxx' time format or moment.fromNow()
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
-							} else {
-								if (this.config.timeFormat === "absolute" && !this.config.nextDaysRelative) {
-									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
-								} else {
-									// Otherwise just say 'Today/Tomorrow at such-n-such time'
-									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar());
-								}
-							}
-						} else {
-							/* Check to see if the user displays absolute or relative dates with their events
-							 * Also check to see if an event is happening within an 'urgency' time frameElement
-							 * For example, if the user set an .urgency of 7 days, those events that fall within that
-							 * time frame will be displayed with 'in xxx' time format or moment.fromNow()
-							 *
-							 * Note: this needs to be put in its own function, as the whole thing repeats again verbatim
-							 */
-							if (this.config.timeFormat === "absolute") {
-								if (this.config.urgency > 1 && event.startDate - now < this.config.urgency * oneDay) {
-									// This event falls within the config.urgency period that the user has set
-									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
-								} else {
-									timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").format(this.config.dateFormat));
-								}
-							} else {
-								timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
-							}
-						}
-					} else {
+						// Ongoing event
 						timeWrapper.innerHTML = this.capFirst(
 							this.translate("RUNNING", {
 								fallback: this.translate("RUNNING") + " {timeUntilEnd}",
@@ -363,12 +375,7 @@ Module.register("calendar", {
 							})
 						);
 					}
-					if (this.config.showEnd) {
-						timeWrapper.innerHTML += "-";
-						timeWrapper.innerHTML += this.capFirst(moment(event.endDate, "x").format(this.config.dateEndFormat));
-					}
 				}
-				//timeWrapper.innerHTML += ' - '+ moment(event.startDate,'x').format('lll');
 				timeWrapper.className = "time light " + this.timeClassForUrl(event.url);
 				eventWrapper.appendChild(timeWrapper);
 			}
@@ -521,6 +528,35 @@ Module.register("calendar", {
 		events.sort(function (a, b) {
 			return a.startDate - b.startDate;
 		});
+
+		// Limit the number of days displayed
+		// If limitDays is set > 0, limit display to that number of days
+		if (this.config.limitDays > 0) {
+			var newEvents = [];
+			var lastDate = today.clone().subtract(1, "days").format("YYYYMMDD");
+			var days = 0;
+			var eventDate;
+			for (var ev of events) {
+				eventDate = moment(ev.startDate, "x").format("YYYYMMDD");
+				// if date of event is later than lastdate
+				// check if we already are showing max unique days
+				if (eventDate > lastDate) {
+					// if the only entry in the first day is a full day event that day is not counted as unique
+					if (newEvents.length === 1 && days === 1 && newEvents[0].fullDayEvent) {
+						days--;
+					}
+					days++;
+					if (days > this.config.limitDays) {
+						continue;
+					} else {
+						lastDate = eventDate;
+					}
+				}
+				newEvents.push(ev);
+			}
+			events = newEvents;
+		}
+
 		return events.slice(0, this.config.maximumEntries);
 	},
 
@@ -565,7 +601,7 @@ Module.register("calendar", {
 	 * @returns {string[]} The symbols
 	 */
 	symbolsForEvent: function (event) {
-		let symbols = this.getCalendarPropertyAsArray(event.url, "symbol", this.config.defaultSymbol);
+		var symbols = this.getCalendarPropertyAsArray(event.url, "symbol", this.config.defaultSymbol);
 
 		if (event.recurringEvent === true && this.hasCalendarProperty(event.url, "recurringSymbol")) {
 			symbols = this.mergeUnique(this.getCalendarPropertyAsArray(event.url, "recurringSymbol", this.config.defaultSymbol), symbols);
@@ -666,7 +702,7 @@ Module.register("calendar", {
 	},
 
 	getCalendarPropertyAsArray: function (url, property, defaultValue) {
-		let p = this.getCalendarProperty(url, property, defaultValue);
+		var p = this.getCalendarProperty(url, property, defaultValue);
 		if (!(p instanceof Array)) p = [p];
 		return p;
 	},


### PR DESCRIPTION
New calendar config options "limitDays" and "customEvents"
limitDays will limit the discrete number of days displayed.
customEvents changes color and/or symbol for events based on keyword

Example config:
limitDays: 1,  // Only show one discrete day of events
customEvents: [{keyword: "birthday", color: "Gold", symbol: "birthday-cake"}] // keyword is a regexp, color is the color to use and symbol is the font awesome symbol to use
Case is ignored when event tiles are searched for keyword.

> Please send your pull requests the develop branch.
> Don't forget to add the change to CHANGELOG.md.

**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.
Thanks!

- Does the pull request solve a **related** issue?
- If so, can you reference the issue?
- What does the pull request accomplish? Use a list if needed.
- If it includes major visual changes please add screenshots.
