### PR TITLE
Merging config/.gitignore with .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,10 @@ Temporary Items
 # Ignore changes to the custom css files.
 /css/custom.css
 
+# Ignore users config file but keep the sample.
+/config/*
+!/config/config.js.sample
+
 # Vim
 ## swap
 [._]*.s[a-w][a-z]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ _This release is scheduled to be released on 2021-01-01._
 - Added GitHub workflows for automated testing and changelog enforcement.
 
 ### Updated
-
+- Merging .gitignore in the config-folder with the .gitignore in the root-folder.
 - Weather module - forecast now show TODAY and TOMORROW instead of weekday, to make it easier to understand.
 - Update dependencies to latest versions.
 - Update dependencies eslint, feedme, simple-git and socket.io to latest versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _This release is scheduled to be released on 2021-01-01._
 - Added GitHub workflows for automated testing and changelog enforcement.
 
 ### Updated
+
 - Merging .gitignore in the config-folder with the .gitignore in the root-folder.
 - Weather module - forecast now show TODAY and TOMORROW instead of weekday, to make it easier to understand.
 - Update dependencies to latest versions.

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,2 +1,0 @@
-*
-!config.js.sample


### PR DESCRIPTION
The separate .gitignore in the config-folder has been kind of annoying when trying to have my own git-repository for my configuration files when running the docker-image since the config/.gitignore is created on every startup.

Moved the parts related to config into the roots .gitignore instead.