### PR TITLE
Permit substituting a falsy value in translator variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ _This release is scheduled to be released on 2021-01-01._
 - update node-ical version again, 0.12.5, change RRULE fix (#2371, #2379)
 - Added missing function call in module.show()
 - remove undefined objects from modules array (#2382)
+- Translator variables can have falsy values (e.g. empty string)
 
 ## [2.13.0] - 2020-10-01
 

--- a/js/translator.js
+++ b/js/translator.js
@@ -68,7 +68,7 @@ var Translator = (function () {
 					template = variables.fallback;
 				}
 				return template.replace(new RegExp("{([^}]+)}", "g"), function (_unused, varName) {
-					return variables[varName] || "{" + varName + "}";
+					return varName in variables ? variables[varName] : "{" + varName + "}";
 				});
 			}
 


### PR DESCRIPTION
Fixes #2389; this no longer evaluates the provided value, merely the presence of the key.  That means values which are falsy to JS (empty string, undefined, number 0, etc.) now get substituted where before they didn't.

For some possible values, it's possible that's not what you wanted -- but leaving {VARNAME} in place probably wasn't either, so 🤷‍♂️.  It fails differently now.  For empty strings, zeros, etc. this fixes a bug.