### PR TITLE
Add github action for uploading codecov results

### DIFF
--- a/.github/workflows/codecov-test-suites.yml
+++ b/.github/workflows/codecov-test-suites.yml
@@ -1,4 +1,6 @@
-name: Run Test Suites
+# This workflow runs the automated test and uploads the coverage results to codecov.io
+
+name: "Run Codecov Tests"
 
 on: [push]
 
@@ -12,4 +14,4 @@ jobs:
           export DISPLAY=:99
           npm install
           npm run test:coverage
-          bash <(curl -s https://codecov.io/bash) # Upload to Codecov
+          bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/codecov-test-suites.yml
+++ b/.github/workflows/codecov-test-suites.yml
@@ -2,7 +2,11 @@
 
 name: "Run Codecov Tests"
 
-on: [push]
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
 
 jobs:
   run-and-upload-coverage-report:

--- a/.github/workflows/codecov-test-suites.yml
+++ b/.github/workflows/codecov-test-suites.yml
@@ -5,13 +5,16 @@ name: "Run Codecov Tests"
 on: [push]
 
 jobs:
-  test:
+  run-and-upload-coverage-report:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: |
           Xvfb :99 -screen 0 1024x768x16 &
           export DISPLAY=:99
-          npm install
+          npm ci
           npm run test:coverage
-          bash <(curl -s https://codecov.io/bash)
+      - uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage/lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/codecov-test-suites.yml
+++ b/.github/workflows/codecov-test-suites.yml
@@ -1,0 +1,15 @@
+name: Run Test Suites
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          Xvfb :99 -screen 0 1024x768x16 &
+          export DISPLAY=:99
+          npm install
+          npm run test:coverage
+          bash <(curl -s https://codecov.io/bash) # Upload to Codecov

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,10 +1,11 @@
 name: "Enforce Changelog"
+
 on:
   pull_request:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  # Enforces the update of a changelog file on every pull request 
+  # Enforces the update of a changelog file on every pull request
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/enforce-changelog.yml
+++ b/.github/workflows/enforce-changelog.yml
@@ -1,3 +1,5 @@
+# This workflow enforces the update of a changelog file on every pull request
+
 name: "Enforce Changelog"
 
 on:
@@ -5,7 +7,6 @@ on:
       types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 jobs:
-  # Enforces the update of a changelog file on every pull request
   check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/node-ci.js.yml
+++ b/.github/workflows/node-ci.js.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Automated Tests
+name: "Run Automated Tests"
 
 on:
   push:
@@ -11,13 +11,10 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2021-04-01._
 
 ### Added
 
+- Added GitHub workflows for automated testing and changelog enforcement.
+
 ### Updated
 
 - Updated markdown files.
@@ -44,7 +46,6 @@ Special thanks to the following contributors: @Alvinger, @AndyPoms, @ashishtank,
 - Calendar: new options "limitDays" and "coloredEvents".
 - Added new option "limitDays" - limit the number of discreet days displayed.
 - Added new option "customEvents" - use custom symbol/color based on keyword in event title.
-- Added GitHub workflows for automated testing and changelog enforcement.
 
 ### Updated
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "/home/runner/work/rejas/MagicMirror/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,0 @@
-fixes:
-  - "/home/runner/work/rejas/MagicMirror/::"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"install-fonts": "echo \"Installing fonts ...\n\" && cd fonts && npm install --loglevel=error",
 		"postinstall": "npm run install-fonts && echo \"MagicMirror installation finished successfully! \n\"",
 		"test": "NODE_ENV=test mocha tests --recursive",
-		"test:coverage": "NODE_ENV=test nyc mocha tests --recursive --timeout=3000",
+		"test:coverage": "NODE_ENV=test nyc --reporter=lcov --reporter=text mocha tests --recursive --timeout=3000",
 		"test:e2e": "NODE_ENV=test mocha tests/e2e --recursive",
 		"test:unit": "NODE_ENV=test mocha tests/unit --recursive",
 		"test:prettier": "prettier --check **/*.{js,css,json,md,yml}",


### PR DESCRIPTION
I added codecov testing coverage a while ago. This PR would now add a github action that uploads the results to codecov io

It is only a draft since:

a) I dont know if @MichMich wants it :-) PLus he would need to register the MM repo with codecov.io

b) I dont know on what occasion we should upload the results? Every push? Or only on merges?

c) Other comments?