### PR TITLE
fix socket.io cors errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _This release is scheduled to be released on 2021-04-01._
 ### Fixed
 
 - Added default log levels to stop calendar log spamming.
+- Fix socket.io cors errors, see [breaking change since socket.io v3](https://socket.io/docs/v3/handling-cors/)
 
 ## [2.14.0] - 2021-01-01
 

--- a/js/server.js
+++ b/js/server.js
@@ -27,7 +27,9 @@ function Server(config, callback) {
 	} else {
 		server = require("http").Server(app);
 	}
-	const io = require("socket.io")(server);
+	const io = require("socket.io")(server, {
+		cors: {}
+	});
 
 	Log.log(`Starting server on port ${port} ... `);
 


### PR DESCRIPTION
Testing [mmpm](https://github.com/Bee-Mar/mmpm) with current mm version I found cors errors in the dev console. May this affects also other modules.

We moved to socket.io v3 with latest release and there where (breaking) changes from v2, see
- https://socket.io/docs/v3/handling-cors/
- https://socket.io/docs/v3/migrating-from-2-x-to-3-0/index.html

Fixed this on mm side with adding `cors: {}` section which uses the default params described [here](https://github.com/expressjs/cors#configuration-options).

The client side must use socket.io-client v3 to get this working.