### PR TITLE
prevent empty path components for module main scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Added default log levels to stop calendar log spamming.
 - Fix socket.io cors errors, see [breaking change since socket.io v3](https://socket.io/docs/v3/handling-cors/)
 - Fix Issue with weather forecast icons due to fixed day start and end time (#2221)
+- Fix empty directory for each module's main javascript file in the inspector
 
 ## [2.14.0] - 2021-01-01
 

--- a/js/loader.js
+++ b/js/loader.js
@@ -114,7 +114,7 @@ var Loader = (function () {
 	 * @param {Function} callback Function called when done.
 	 */
 	var loadModule = function (module, callback) {
-		var url = module.path + "/" + module.file;
+		var url = module.path + module.file;
 
 		var afterLoad = function () {
 			var moduleObject = Module.create(module.name);


### PR DESCRIPTION
The `module.path` component has by definition in line 97 a trailing slash.
Hence adding another is unneeded, but results in an additional folder in the inspector.