### PR TITLE
Refactoring newsfeed-module to use templates instead of dom-generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Cleaned up old code on server side.
 - Convert `-0` to `0` when displaying temperature.
 - Code cleanup for FEELS like and added {DEGREE} placeholder for FEELSLIKE for each language
+- Converted newsfeed module to use templates.
 
 ### Removed
 

--- a/modules/default/newsfeed/fullarticle.njk
+++ b/modules/default/newsfeed/fullarticle.njk
@@ -1,0 +1,3 @@
+<div>
+    <iframe class="newsfeed-fullarticle" src="{{ url }}"></iframe>
+</div>

--- a/modules/default/newsfeed/newsfeed.css
+++ b/modules/default/newsfeed/newsfeed.css
@@ -1,0 +1,14 @@
+iframe.newsfeed-fullarticle {
+  width: 100vw;
+  /* very large height value to allow scrolling */
+  height: 3000px;
+  top: 0;
+  left: 0;
+  border: none;
+  z-index: 1;
+}
+
+.region.bottom.bar.newsfeed-fullarticle {
+  bottom: inherit;
+  top: -90px;
+}

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -108,7 +108,7 @@ Module.register("newsfeed", {
 				url: this.getActiveItemURL()
 			};
 		}
-		if (this.newsItems.length == 0) {
+		if (this.newsItems.length === 0) {
 			return {
 				loaded: false
 			};
@@ -185,7 +185,7 @@ Module.register("newsfeed", {
 			}, this);
 		}
 
-		for (var item of newsItems) {
+		newsItems.forEach((item) => {
 			//Remove selected tags from the beginning of rss feed items (title or description)
 			if (this.config.removeStartTags === "title" || this.config.removeStartTags === "both") {
 				for (let f = 0; f < this.config.startTags.length; f++) {
@@ -222,7 +222,8 @@ Module.register("newsfeed", {
 					}
 				}
 			}
-		}
+		});
+
 		// get updated news items and broadcast them
 		var updatedItems = [];
 		newsItems.forEach((value) => {

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -118,44 +118,6 @@ Module.register("newsfeed", {
 				wrapper.appendChild(sourceAndTimestamp);
 			}
 
-			//Remove selected tags from the beginning of rss feed items (title or description)
-
-			if (this.config.removeStartTags === "title" || this.config.removeStartTags === "both") {
-				for (let f = 0; f < this.config.startTags.length; f++) {
-					if (this.newsItems[this.activeItem].title.slice(0, this.config.startTags[f].length) === this.config.startTags[f]) {
-						this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].title.slice(this.config.startTags[f].length, this.newsItems[this.activeItem].title.length);
-					}
-				}
-			}
-
-			if (this.config.removeStartTags === "description" || this.config.removeStartTags === "both") {
-				if (this.isShowingDescription) {
-					for (let f = 0; f < this.config.startTags.length; f++) {
-						if (this.newsItems[this.activeItem].description.slice(0, this.config.startTags[f].length) === this.config.startTags[f]) {
-							this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(this.config.startTags[f].length, this.newsItems[this.activeItem].description.length);
-						}
-					}
-				}
-			}
-
-			//Remove selected tags from the end of rss feed items (title or description)
-
-			if (this.config.removeEndTags) {
-				for (let f = 0; f < this.config.endTags.length; f++) {
-					if (this.newsItems[this.activeItem].title.slice(-this.config.endTags[f].length) === this.config.endTags[f]) {
-						this.newsItems[this.activeItem].title = this.newsItems[this.activeItem].title.slice(0, -this.config.endTags[f].length);
-					}
-				}
-
-				if (this.isShowingDescription) {
-					for (let f = 0; f < this.config.endTags.length; f++) {
-						if (this.newsItems[this.activeItem].description.slice(-this.config.endTags[f].length) === this.config.endTags[f]) {
-							this.newsItems[this.activeItem].description = this.newsItems[this.activeItem].description.slice(0, -this.config.endTags[f].length);
-						}
-					}
-				}
-			}
-
 			if (!this.config.showFullArticle) {
 				const title = document.createElement("div");
 				title.className = "newsfeed-title bright medium light" + (!this.config.wrapTitle ? " no-wrap" : "");
@@ -257,6 +219,44 @@ Module.register("newsfeed", {
 			}, this);
 		}
 
+		for (var item of newsItems) {
+			//Remove selected tags from the beginning of rss feed items (title or description)
+			if (this.config.removeStartTags === "title" || this.config.removeStartTags === "both") {
+				for (let f = 0; f < this.config.startTags.length; f++) {
+					if (item.title.slice(0, this.config.startTags[f].length) === this.config.startTags[f]) {
+						item.title = item.title.slice(this.config.startTags[f].length, item.title.length);
+					}
+				}
+			}
+
+			if (this.config.removeStartTags === "description" || this.config.removeStartTags === "both") {
+				if (this.isShowingDescription) {
+					for (let f = 0; f < this.config.startTags.length; f++) {
+						if (item.description.slice(0, this.config.startTags[f].length) === this.config.startTags[f]) {
+							item.description = item.description.slice(this.config.startTags[f].length, item.description.length);
+						}
+					}
+				}
+			}
+
+			//Remove selected tags from the end of rss feed items (title or description)
+
+			if (this.config.removeEndTags) {
+				for (let f = 0; f < this.config.endTags.length; f++) {
+					if (item.title.slice(-this.config.endTags[f].length) === this.config.endTags[f]) {
+						item.title = item.title.slice(0, -this.config.endTags[f].length);
+					}
+				}
+
+				if (this.isShowingDescription) {
+					for (let f = 0; f < this.config.endTags.length; f++) {
+						if (item.description.slice(-this.config.endTags[f].length) === this.config.endTags[f]) {
+							item.description = item.description.slice(0, -this.config.endTags[f].length);
+						}
+					}
+				}
+			}
+		}
 		// get updated news items and broadcast them
 		var updatedItems = [];
 		newsItems.forEach((value) => {

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -44,6 +44,11 @@ Module.register("newsfeed", {
 		return ["moment.js"];
 	},
 
+	//Define required styles.
+	getStyles: function () {
+		return ["newsfeed.css"];
+	},
+
 	// Define required translations.
 	getTranslations: function () {
 		// The translations for the default modules are defined in the core translation files.
@@ -135,16 +140,8 @@ Module.register("newsfeed", {
 
 			if (this.config.showFullArticle) {
 				const fullArticle = document.createElement("iframe");
-				fullArticle.className = "";
-				fullArticle.style.width = "100vw";
-				// very large height value to allow scrolling
-				fullArticle.height = "3000";
-				fullArticle.style.height = "3000";
-				fullArticle.style.top = "0";
-				fullArticle.style.left = "0";
-				fullArticle.style.border = "none";
+				fullArticle.className = "newsfeed-fullarticle";
 				fullArticle.src = this.getActiveItemURL();
-				fullArticle.style.zIndex = 1;
 				wrapper.appendChild(fullArticle);
 			}
 
@@ -335,8 +332,7 @@ Module.register("newsfeed", {
 		this.config.showFullArticle = false;
 		this.scrollPosition = 0;
 		// reset bottom bar alignment
-		document.getElementsByClassName("region bottom bar")[0].style.bottom = "0";
-		document.getElementsByClassName("region bottom bar")[0].style.top = "inherit";
+		document.getElementsByClassName("region bottom bar")[0].classList.remove("newsfeed-fullarticle");
 		if (!this.timer) {
 			this.scheduleUpdateInterval();
 		}
@@ -406,8 +402,7 @@ Module.register("newsfeed", {
 		this.config.showFullArticle = !this.isShowingDescription;
 		// make bottom bar align to top to allow scrolling
 		if (this.config.showFullArticle === true) {
-			document.getElementsByClassName("region bottom bar")[0].style.bottom = "inherit";
-			document.getElementsByClassName("region bottom bar")[0].style.top = "-90px";
+			document.getElementsByClassName("region bottom bar")[0].classList.add("newsfeed-fullarticle");
 		}
 		clearInterval(this.timer);
 		this.timer = null;

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -80,6 +80,9 @@ Module.register("newsfeed", {
 			this.generateFeed(payload);
 
 			if (!this.loaded) {
+				if (this.config.hideLoading) {
+					this.show();
+				}
 				this.scheduleUpdateInterval();
 			}
 
@@ -144,17 +147,9 @@ Module.register("newsfeed", {
 				fullArticle.src = this.getActiveItemURL();
 				wrapper.appendChild(fullArticle);
 			}
-
-			if (this.config.hideLoading) {
-				this.show();
-			}
 		} else {
-			if (this.config.hideLoading) {
-				this.hide();
-			} else {
-				wrapper.innerHTML = this.translate("LOADING");
-				wrapper.className = "small dimmed";
-			}
+			wrapper.innerHTML = this.translate("LOADING");
+			wrapper.className = "small dimmed";
 		}
 
 		return wrapper;
@@ -340,7 +335,9 @@ Module.register("newsfeed", {
 
 	notificationReceived: function (notification, payload, sender) {
 		const before = this.activeItem;
-		if (notification === "ARTICLE_NEXT") {
+		if (notification === "MODULE_DOM_CREATED" && this.config.hideLoading) {
+			this.hide();
+		} else if (notification === "ARTICLE_NEXT") {
 			this.activeItem++;
 			if (this.activeItem >= this.newsItems.length) {
 				this.activeItem = 0;

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -90,69 +90,43 @@ Module.register("newsfeed", {
 		}
 	},
 
-	// Override dom generator.
-	getDom: function () {
-		const wrapper = document.createElement("div");
-
+	//Override fetching of template name
+	getTemplate: function () {
 		if (this.config.feedUrl) {
-			wrapper.className = "small bright";
-			wrapper.innerHTML = this.translate("MODULE_CONFIG_CHANGED", { MODULE_NAME: "Newsfeed" });
-			return wrapper;
+			return "oldconfig.njk";
+		} else if (this.config.showFullArticle) {
+			return "fullarticle.njk";
+		}
+		return "newsfeed.njk";
+	},
+
+	//Override template data and return whats used for the current template
+	getTemplateData: function () {
+		// this.config.showFullArticle is a run-time configuration, triggered by optional notifications
+		if (this.config.showFullArticle) {
+			return {
+				url: this.getActiveItemURL()
+			};
+		}
+		if (this.newsItems.length == 0) {
+			return {
+				loaded: false
+			};
 		}
 
 		if (this.activeItem >= this.newsItems.length) {
 			this.activeItem = 0;
 		}
+		const item = this.newsItems[this.activeItem];
 
-		if (this.newsItems.length > 0) {
-			// this.config.showFullArticle is a run-time configuration, triggered by optional notifications
-			if (!this.config.showFullArticle && (this.config.showSourceTitle || this.config.showPublishDate)) {
-				const sourceAndTimestamp = document.createElement("div");
-				sourceAndTimestamp.className = "newsfeed-source light small dimmed";
-
-				if (this.config.showSourceTitle && this.newsItems[this.activeItem].sourceTitle !== "") {
-					sourceAndTimestamp.innerHTML = this.newsItems[this.activeItem].sourceTitle;
-				}
-				if (this.config.showSourceTitle && this.newsItems[this.activeItem].sourceTitle !== "" && this.config.showPublishDate) {
-					sourceAndTimestamp.innerHTML += ", ";
-				}
-				if (this.config.showPublishDate) {
-					sourceAndTimestamp.innerHTML += moment(new Date(this.newsItems[this.activeItem].pubdate)).fromNow();
-				}
-				if ((this.config.showSourceTitle && this.newsItems[this.activeItem].sourceTitle !== "") || this.config.showPublishDate) {
-					sourceAndTimestamp.innerHTML += ":";
-				}
-
-				wrapper.appendChild(sourceAndTimestamp);
-			}
-
-			if (!this.config.showFullArticle) {
-				const title = document.createElement("div");
-				title.className = "newsfeed-title bright medium light" + (!this.config.wrapTitle ? " no-wrap" : "");
-				title.innerHTML = this.newsItems[this.activeItem].title;
-				wrapper.appendChild(title);
-			}
-
-			if (this.isShowingDescription) {
-				const description = document.createElement("div");
-				description.className = "newsfeed-desc small light" + (!this.config.wrapDescription ? " no-wrap" : "");
-				const txtDesc = this.newsItems[this.activeItem].description;
-				description.innerHTML = this.config.truncDescription ? (txtDesc.length > this.config.lengthDescription ? txtDesc.substring(0, this.config.lengthDescription) + "..." : txtDesc) : txtDesc;
-				wrapper.appendChild(description);
-			}
-
-			if (this.config.showFullArticle) {
-				const fullArticle = document.createElement("iframe");
-				fullArticle.className = "newsfeed-fullarticle";
-				fullArticle.src = this.getActiveItemURL();
-				wrapper.appendChild(fullArticle);
-			}
-		} else {
-			wrapper.innerHTML = this.translate("LOADING");
-			wrapper.className = "small dimmed";
-		}
-
-		return wrapper;
+		return {
+			loaded: true,
+			config: this.config,
+			sourceTitle: item.sourceTitle,
+			publishDate: moment(new Date(item.pubdate)).fromNow(),
+			title: item.title,
+			description: item.description
+		};
 	},
 
 	getActiveItemURL: function () {

--- a/modules/default/newsfeed/newsfeed.njk
+++ b/modules/default/newsfeed/newsfeed.njk
@@ -1,0 +1,28 @@
+{% if loaded %}
+    <div>
+        {% if (config.showSourceTitle and sourceTitle) or config.showPublishDate %}
+            <div class="newsfeed-source light small dimmed">
+                {% if sourceTitle and config.showSourceTitle %}
+                    {{ sourceTitle }}{% if config.showPublishDate %}, {% else %}: {% endif %}
+                {% endif %}
+                {% if config.showPublishDate %}
+                    {{ publishDate }}: 
+                {% endif %}
+            </div>
+        {% endif %}
+        <div class="newsfeed-title bright medium light{{ ' no-wrap' if config.wrapTitle }}">
+            {{ title }}
+        </div>
+        <div class="newsfeed-desc small light{{ ' no-wrap' if config.wrapDescription }}">
+            {% if config.truncDescription %}
+                {{ description | truncate(config.lengthDescription) }}
+            {% else %}
+                {{ description }}
+            {% endif %}
+        </div>
+    </div>
+{% else %}
+    <div class="small dimmed">
+        {{ "LOADING" | translate | safe }}
+    </div>
+{% endif %}

--- a/modules/default/newsfeed/oldconfig.njk
+++ b/modules/default/newsfeed/oldconfig.njk
@@ -1,0 +1,3 @@
+<div class="small bright">
+    {{ "MODULE_CONFIG_CHANGED" | translate({MODULE_NAME: "Newsfeed"}) | safe }}
+</div>


### PR DESCRIPTION
Made the newsfeed-module use templates and css-files instead:
- Moved code that didn't really have anything to do with rendering to other places (hiding module while loading, stripping of tags)
- Moved style-attributes for "full article"-notification to use classes instead in a css-file
- Separated the rendering to 3 different templates (one for migrating old configs, one for full article and one for the normal viewing)

The only thing that differs slightly is that the description isn't rendered behind when full article is displayed, but since that is placed above everything else the user wouldn't see that anyway (and the title was hidden so I guess that the description being shown was a bug).