### PR TITLE
Added start:dev command to npm scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _This release is scheduled to be released on 2021-04-01._
 
 - Added GitHub workflows for automated testing and changelog enforcement.
 - Add CodeCov badge to Readme.
+- Added `start:dev` command to the npm scripts for starting electron with devTools open
 
 ### Updated
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"main": "js/electron.js",
 	"scripts": {
 		"start": "DISPLAY=\"${DISPLAY:=:0}\" ./node_modules/.bin/electron js/electron.js",
+		"start:dev": "DISPLAY=\"${DISPLAY:=:0}\" ./node_modules/.bin/electron js/electron.js dev",
 		"server": "node ./serveronly",
 		"install": "echo \"Installing vendor files ...\n\" && cd vendor && npm install --loglevel=error",
 		"install-fonts": "echo \"Installing fonts ...\n\" && cd fonts && npm install --loglevel=error",


### PR DESCRIPTION
I noticed there was the option to start electron with the dev command line argument. So I figured it would make sense to add an entry for that in the package.json scripts section for this.