### PR TITLE
deprecate module currentweather and weatherforecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Added CodeCov badge to Readme.
 - Added CURRENTWEATHER_TYPE notification to currentweather and weather module, use it in compliments module.
 - Added `start:dev` command to the npm scripts for starting electron with devTools open.
+- Added logging when using deprecated modules weatherforecast or currentweather.
 
 ### Updated
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -66,22 +66,27 @@ var config = {
 			position: "lower_third"
 		},
 		{
-			module: "currentweather",
+			module: "weather",
 			position: "top_right",
 			config: {
+				weatherProvider: "openweathermap",
+				type: "current",
 				location: "New York",
 				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
-				appid: "YOUR_OPENWEATHER_API_KEY"
+				apiKey: "YOUR_OPENWEATHER_API_KEY"
 			}
 		},
 		{
-			module: "weatherforecast",
+			module: "weather",
 			position: "top_right",
 			header: "Weather Forecast",
 			config: {
+				weatherProvider: "openweathermap",
+				type: "forecast",
+				weatherEndpoint: "/forecast",
 				location: "New York",
 				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
-				appid: "YOUR_OPENWEATHER_API_KEY"
+				apiKey: "YOUR_OPENWEATHER_API_KEY"
 			}
 		},
 		{

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -83,7 +83,6 @@ var config = {
 			config: {
 				weatherProvider: "openweathermap",
 				type: "forecast",
-				weatherEndpoint: "/forecast",
 				location: "New York",
 				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
 				apiKey: "YOUR_OPENWEATHER_API_KEY"

--- a/modules/default/currentweather/README.md
+++ b/modules/default/currentweather/README.md
@@ -1,5 +1,7 @@
 # Module: Current Weather
 
+> :warning: **This module is deprecated in favor of the [weather](https://docs.magicmirror.builders/modules/weather.html) module.**
+
 The `currentweather` module is one of the default modules of the MagicMirror.
 This module displays the current weather, including the windspeed, the sunset or sunrise time, the temperature and an icon to display the current conditions.
 

--- a/modules/default/currentweather/currentweather.js
+++ b/modules/default/currentweather/currentweather.js
@@ -3,6 +3,8 @@
  *
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
+ *
+ * This module is deprecated. Any additional feature will no longer be merged.
  */
 Module.register("currentweather", {
 	// Default module config.

--- a/modules/default/currentweather/node_helper.js
+++ b/modules/default/currentweather/node_helper.js
@@ -1,0 +1,9 @@
+const NodeHelper = require("node_helper");
+const Log = require("../../../js/logger");
+
+module.exports = NodeHelper.create({
+	// Override start method.
+	start: function () {
+		Log.warn(`The module '${this.name}' is deprecated in favor of the 'weather'-module, please refer to the documentation for a migration path`);
+	}
+});

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -18,7 +18,7 @@ WeatherProvider.register("openweathermap", {
 	defaults: {
 		apiVersion: "2.5",
 		apiBase: "https://api.openweathermap.org/data/",
-		weatherEndpoint: "/weather",
+		weatherEndpoint: "",
 		locationID: false,
 		location: false,
 		lat: 0,
@@ -96,8 +96,21 @@ WeatherProvider.register("openweathermap", {
 	 */
 	setConfig(config) {
 		this.config = config;
-		if (this.config.type === "hourly") {
-			this.config.weatherEndpoint = "/onecall";
+		if (!this.config.weatherEndpoint) {
+			switch (this.config.type) {
+				case "hourly":
+					this.config.weatherEndpoint = "/onecall";
+					break;
+				case "daily":
+				case "forecast":
+					this.config.weatherEndpoint = "/forecast";
+					break;
+				case "current":
+					this.config.weatherEndpoint = "/weather";
+					break;
+				default:
+					Log.error("weatherEndpoint not configured and could not resolve it based on type");
+			}
 		}
 	},
 

--- a/modules/default/weatherforecast/README.md
+++ b/modules/default/weatherforecast/README.md
@@ -1,5 +1,7 @@
 # Module: Weather Forecast
 
+> :warning: **This module is deprecated in favor of the [weather](https://docs.magicmirror.builders/modules/weather.html) module.**
+
 The `weatherforecast` module is one of the default modules of the MagicMirror.
 This module displays the weather forecast for the coming week, including an an icon to display the current conditions, the minimum temperature and the maximum temperature.
 

--- a/modules/default/weatherforecast/node_helper.js
+++ b/modules/default/weatherforecast/node_helper.js
@@ -1,0 +1,9 @@
+const NodeHelper = require("node_helper");
+const Log = require("../../../js/logger");
+
+module.exports = NodeHelper.create({
+	// Override start method.
+	start: function () {
+		Log.warn(`The module '${this.name}' is deprecated in favor of the 'weather'-module, please refer to the documentation for a migration path`);
+	}
+});

--- a/modules/default/weatherforecast/weatherforecast.js
+++ b/modules/default/weatherforecast/weatherforecast.js
@@ -3,6 +3,8 @@
  *
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
+ *
+ * This module is deprecated. Any additional feature will no longer be merged.
  */
 Module.register("weatherforecast", {
 	// Default module config.


### PR DESCRIPTION
- Adding logging when using deprecated weather-modules (had to add a NodeHelper for each)
- Updating sample config file to use the new weather module
- Added comment in code about not accepting new features
- Added warning in the old weather modules readme