### PR TITLE
backward compatibility to socket v2 clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix empty directory for each module's main javascript file in the inspector
 - Fix Issue with weather forecast icons unit tests with different timezones (#2221)
 - Fix issue with unencoded characters in translated strings when using nunjuck template (`Loading &hellip;` as an example)
+- Fix socket.io backward compatibility with socket v2 clients
 
 ## [2.14.0] - 2021-01-01
 

--- a/js/server.js
+++ b/js/server.js
@@ -28,7 +28,11 @@ function Server(config, callback) {
 		server = require("http").Server(app);
 	}
 	const io = require("socket.io")(server, {
-		cors: {}
+		cors: {
+			origin: /.*$/,
+			credentials: true
+		},
+		allowEIO3: true
 	});
 
 	Log.log(`Starting server on port ${port} ... `);


### PR DESCRIPTION
After migration to socket v3 with latest release v2.14.0 clients using socket-client v2 are not able to connect, see also https://socket.io/docs/v3/migrating-from-2-x-to-3-0/#How-to-upgrade-an-existing-production-deployment.

With newest [socket version v3.1.0](https://github.com/socketio/socket.io/releases/tag/3.1.0) a new parameter `allowEIO3` was introduced for backward compatibility. Additionally some cors parameters needed adjusted to work with socket-client v2.

Tested this using [mmpm](https://github.com/Bee-Mar/mmpm) as test-client with both socket-client versions.

Related to https://github.com/Bee-Mar/mmpm/issues/60