### PR TITLE
Added error to callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Converted newsfeed module to use templates.
 - Update documentation and help screen about invalid config files.
 - Moving weather provider specific code and configuration into each provider and making hourly part of the interface.
+- Callback for `module.show` also gets triggered if lock strings are active but then contains an error `callback(error)`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Added `start:dev` command to the npm scripts for starting electron with devTools open.
 - Added logging when using deprecated modules weatherforecast or currentweather.
 - Portuguese translations for "MODULE_CONFIG_CHANGED" and PRECIP.
+- `module.show` has now the option for a callback on error.
 
 ### Updated
 
@@ -29,7 +30,6 @@ _This release is scheduled to be released on 2021-04-01._
 - Moving weather provider specific code and configuration into each provider and making hourly part of the interface.
 - Bump electron to v11.
 - Dont update the DOM when a module is not displayed.
-- Callback for `module.show` also gets triggered if lock strings are active but then contains an error `callback(error)`.
 
 ### Removed
 

--- a/js/main.js
+++ b/js/main.js
@@ -295,6 +295,7 @@ var MM = (function () {
 		// Otherwise cancel show action.
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
+			callback("Active lock strings");
 			return;
 		}
 
@@ -321,13 +322,13 @@ var MM = (function () {
 			clearTimeout(module.showHideTimer);
 			module.showHideTimer = setTimeout(function () {
 				if (typeof callback === "function") {
-					callback();
+					callback(null);
 				}
 			}, speed);
 		} else {
 			// invoke callback
 			if (typeof callback === "function") {
-				callback();
+				callback(null);
 			}
 		}
 	};

--- a/js/main.js
+++ b/js/main.js
@@ -295,7 +295,7 @@ var MM = (function () {
 		// Otherwise cancel show action.
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
-			callback("ERR_ACTIVE_LOCK_STRINGS");
+			callback(new Error("ERR_ACTIVE_LOCK_STRINGS"));
 			return;
 		}
 

--- a/js/main.js
+++ b/js/main.js
@@ -279,8 +279,9 @@ var MM = (function () {
 	 * @param {number} speed The speed of the show animation.
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
+	 * @param {Function} errorCallback Called when the module failed to show.
 	 */
-	var showModule = function (module, speed, callback, options) {
+	var showModule = function (module, speed, callback, errorCallback, options) {
 		options = options || {};
 
 		// remove lockString if set in options.
@@ -295,7 +296,9 @@ var MM = (function () {
 		// Otherwise cancel show action.
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
-			callback(new Error("ERR_ACTIVE_LOCK_STRINGS"));
+			if (typeof errorCallback === "function") {
+				errorCallback(new Error("ERR_ACTIVE_LOCK_STRINGS"));
+			}
 			return;
 		}
 
@@ -322,13 +325,13 @@ var MM = (function () {
 			clearTimeout(module.showHideTimer);
 			module.showHideTimer = setTimeout(function () {
 				if (typeof callback === "function") {
-					callback(null);
+					callback();
 				}
 			}, speed);
 		} else {
 			// invoke callback
 			if (typeof callback === "function") {
-				callback(null);
+				callback();
 			}
 		}
 	};
@@ -587,10 +590,11 @@ var MM = (function () {
 		 * @param {number} speed The speed of the show animation.
 		 * @param {Function} callback Called when the animation is done.
 		 * @param {object} [options] Optional settings for the show method.
+		 * @param {Function} errorCallback Called when the module failed to show.
 		 */
-		showModule: function (module, speed, callback, options) {
+		showModule: function (module, speed, callback, errorCallback, options) {
 			// do not change module.hidden yet, only if we really show it later
-			showModule(module, speed, callback, options);
+			showModule(module, speed, callback, errorCallback, options);
 		}
 	};
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -279,9 +279,8 @@ var MM = (function () {
 	 * @param {number} speed The speed of the show animation.
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
-	 * @param {Function} errorCallback Called when the module failed to show.
 	 */
-	var showModule = function (module, speed, callback, errorCallback, options) {
+	var showModule = function (module, speed, callback, options) {
 		options = options || {};
 
 		// remove lockString if set in options.
@@ -296,8 +295,8 @@ var MM = (function () {
 		// Otherwise cancel show action.
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
-			if (typeof errorCallback === "function") {
-				errorCallback(new Error("ERR_ACTIVE_LOCK_STRINGS"));
+			if (typeof options.onError === "function") {
+				options.onError(new Error("ERR_ACTIVE_LOCK_STRINGS"));
 			}
 			return;
 		}
@@ -590,11 +589,10 @@ var MM = (function () {
 		 * @param {number} speed The speed of the show animation.
 		 * @param {Function} callback Called when the animation is done.
 		 * @param {object} [options] Optional settings for the show method.
-		 * @param {Function} errorCallback Called when the module failed to show.
 		 */
-		showModule: function (module, speed, callback, errorCallback, options) {
+		showModule: function (module, speed, callback, options) {
 			// do not change module.hidden yet, only if we really show it later
-			showModule(module, speed, callback, errorCallback, options);
+			showModule(module, speed, callback, options);
 		}
 	};
 })();

--- a/js/main.js
+++ b/js/main.js
@@ -296,7 +296,7 @@ var MM = (function () {
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
 			if (typeof options.onError === "function") {
-				options.onError(new Error("ERR_ACTIVE_LOCK_STRINGS"));
+				options.onError(new Error("LOCK_STRING_ACTIVE"));
 			}
 			return;
 		}

--- a/js/main.js
+++ b/js/main.js
@@ -295,7 +295,7 @@ var MM = (function () {
 		// Otherwise cancel show action.
 		if (module.lockStrings.length !== 0 && options.force !== true) {
 			Log.log("Will not show " + module.name + ". LockStrings active: " + module.lockStrings.join(","));
-			callback("Active lock strings");
+			callback("ERR_ACTIVE_LOCK_STRINGS");
 			return;
 		}
 

--- a/js/module.js
+++ b/js/module.js
@@ -432,9 +432,11 @@ var Module = Class.extend({
 		MM.showModule(
 			this,
 			speed,
-			function () {
-				self.resume();
-				callback();
+			function (error) {
+				if (!error) {
+					self.resume();
+				}
+				callback(error);
 			},
 			options
 		);

--- a/js/module.js
+++ b/js/module.js
@@ -416,8 +416,9 @@ var Module = Class.extend({
 	 * @param {number} speed The speed of the show animation.
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
+	 * @param {Function} errorCallback Called when the module failed to show.
 	 */
-	show: function (speed, callback, options) {
+	show: function (speed, callback, options, errorCallback) {
 		if (typeof callback === "object") {
 			options = callback;
 			callback = function () {};
@@ -425,17 +426,16 @@ var Module = Class.extend({
 
 		callback = callback || function () {};
 		options = options || {};
+		errorCallback = errorCallback || function () {};
 
-		var self = this;
 		MM.showModule(
 			this,
 			speed,
-			function (error) {
-				if (!error) {
-					self.resume();
-				}
-				callback(error);
+			() => {
+				this.resume();
+				callback();
 			},
+			errorCallback,
 			options
 		);
 	}

--- a/js/module.js
+++ b/js/module.js
@@ -416,9 +416,8 @@ var Module = Class.extend({
 	 * @param {number} speed The speed of the show animation.
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
-	 * @param {Function} errorCallback Called when the module failed to show.
 	 */
-	show: function (speed, callback, options, errorCallback) {
+	show: function (speed, callback, options) {
 		if (typeof callback === "object") {
 			options = callback;
 			callback = function () {};
@@ -426,7 +425,6 @@ var Module = Class.extend({
 
 		callback = callback || function () {};
 		options = options || {};
-		errorCallback = errorCallback || function () {};
 
 		MM.showModule(
 			this,
@@ -435,7 +433,6 @@ var Module = Class.extend({
 				this.resume();
 				callback();
 			},
-			errorCallback,
 			options
 		);
 	}


### PR DESCRIPTION
- Does the pull request solve a **related** issue?

After adding `lockStrings` in a merge request of a module we were running into issues because the callback wasn't triggered in case lock strings were active. Which means you only get notified on success. The way nodejs and any popular libraries that still uses callbacks implement them are like callback(error) or callback(error, data). This way the caller gets always notified and can handle based on the error argument.

@skuethe with this, we can avoid manually checking for active lock strings again.

- If so, can you reference the issue?

https://github.com/fewieden/MMM-Modal/pull/7#issuecomment-768625722

- What does the pull request accomplish?

* callback for show function always gets called.
* If lockStrings are still active the callback contains an error
