### PR TITLE
bump electron to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -249,20 +249,27 @@
 			}
 		},
 		"@electron/get": {
-			"version": "1.12.2",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.2.tgz",
-			"integrity": "sha512-vAuHUbfvBQpYTJ5wB7uVIDq5c/Ry0fiTBMs7lnEYAo/qXXppIVcWdfBr57u6eRnKdVso7KSiH6p/LbQAG6Izrg==",
-			"optional": true,
+			"version": "1.12.3",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.3.tgz",
+			"integrity": "sha512-NFwSnVZQK7dhOYF1NQCt+HGqgL1aNdj0LUSx75uCqnZJqyiWCVdAMFV4b4/kC8HjUJAnsvdSEmjEt4G2qNQ9+Q==",
 			"requires": {
 				"debug": "^4.1.1",
 				"env-paths": "^2.2.0",
+				"filenamify": "^4.1.0",
 				"fs-extra": "^8.1.0",
 				"global-agent": "^2.0.2",
 				"global-tunnel-ng": "^2.7.1",
 				"got": "^9.6.0",
 				"progress": "^2.0.3",
-				"sanitize-filename": "^1.6.2",
+				"semver": "^6.2.0",
 				"sumchecker": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"@eslint/eslintrc": {
@@ -373,8 +380,7 @@
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
-			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-			"optional": true
+			"integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
 		},
 		"@stylelint/postcss-css-in-js": {
 			"version": "0.37.2",
@@ -399,9 +405,20 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
 			"integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-			"optional": true,
 			"requires": {
 				"defer-to-connect": "^1.0.1"
+			}
+		},
+		"@types/cacheable-request": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+			"integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+			"dev": true,
+			"requires": {
+				"@types/http-cache-semantics": "*",
+				"@types/keyv": "*",
+				"@types/node": "*",
+				"@types/responselike": "*"
 			}
 		},
 		"@types/component-emitter": {
@@ -418,6 +435,21 @@
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.9.tgz",
 			"integrity": "sha512-zurD1ibz21BRlAOIKP8yhrxlqKx6L9VCwkB5kMiP6nZAhoF5MvC7qS1qPA7nRcr1GJolfkQC7/EAL4hdYejLtg=="
+		},
+		"@types/http-cache-semantics": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+			"integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+			"dev": true
+		},
+		"@types/keyv": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+			"integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
 		},
 		"@types/mdast": {
 			"version": "3.0.3",
@@ -441,9 +473,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.19.4",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.4.tgz",
-			"integrity": "sha512-o3oj1bETk8kBwzz1WlO6JWL/AfAA3Vm6J1B3C9CsdxHYp7XgPiH7OEXPUbZTndHlRaIElrANkQfe6ZmfJb3H2w=="
+			"version": "12.19.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+			"integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -457,17 +489,51 @@
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
+		"@types/puppeteer": {
+			"version": "5.4.2",
+			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.2.tgz",
+			"integrity": "sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
+		"@types/puppeteer-core": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@types/puppeteer-core/-/puppeteer-core-5.4.0.tgz",
+			"integrity": "sha512-yqRPuv4EFcSkTyin6Yy17pN6Qz2vwVwTCJIDYMXbE3j8vTPhv0nCQlZOl5xfi0WHUkqvQsjAR8hAfjeMCoetwg==",
+			"dev": true,
+			"requires": {
+				"@types/puppeteer": "*"
+			}
+		},
+		"@types/responselike": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/unist": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
 			"dev": true
 		},
-		"@types/webdriverio": {
-			"version": "4.13.3",
-			"resolved": "https://registry.npmjs.org/@types/webdriverio/-/webdriverio-4.13.3.tgz",
-			"integrity": "sha512-AfSQM1xTO9Ax+u9uSQPDuw69DQ0qA2RMoKHn86jCgWNcwKVUjGMSP4sfSl3JOfcZN8X/gWvn7znVPp2/g9zcJA==",
+		"@types/which": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
+			"integrity": "sha512-8oDqyLC7eD4HM307boe2QWKyuzdzWBj56xI/imSl2cpL+U3tCMaTAkMJ4ee5JBZ/FsOJlvRGeIShiZDAl1qERA==",
+			"dev": true
+		},
+		"@types/yauzl": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"@types/node": "*"
 			}
@@ -477,6 +543,104 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
+		},
+		"@wdio/config": {
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/@wdio/config/-/config-6.12.1.tgz",
+			"integrity": "sha512-V5hTIW5FNlZ1W33smHF4Rd5BKjGW2KeYhyXDQfXHjqLCeRiirZ9fABCo9plaVQDnwWSUMWYaAaIAifV82/oJCQ==",
+			"dev": true,
+			"requires": {
+				"@wdio/logger": "6.10.10",
+				"deepmerge": "^4.0.0",
+				"glob": "^7.1.2"
+			}
+		},
+		"@wdio/logger": {
+			"version": "6.10.10",
+			"resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-6.10.10.tgz",
+			"integrity": "sha512-2nh0hJz9HeZE0VIEMI+oPgjr/Q37ohrR9iqsl7f7GW5ik+PnKYCT9Eab5mR1GNMG60askwbskgGC1S9ygtvrSw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"loglevel": "^1.6.0",
+				"loglevel-plugin-prefix": "^0.8.4",
+				"strip-ansi": "^6.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"@wdio/protocols": {
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-6.12.0.tgz",
+			"integrity": "sha512-UhTBZxClCsM3VjaiDp4DoSCnsa7D1QNmI2kqEBfIpyNkT3GcZhJb7L+nL0fTkzCwi7+/uLastb3/aOwH99gt0A==",
+			"dev": true
+		},
+		"@wdio/repl": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-6.11.0.tgz",
+			"integrity": "sha512-FxrFKiTkFyELNGGVEH1uijyvNY7lUpmff6x+FGskFGZB4uSRs0rxkOMaEjxnxw7QP1zgQKr2xC7GyO03gIGRGg==",
+			"dev": true,
+			"requires": {
+				"@wdio/utils": "6.11.0"
+			}
+		},
+		"@wdio/utils": {
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-6.11.0.tgz",
+			"integrity": "sha512-vf0sOQzd28WbI26d6/ORrQ4XKWTzSlWLm9W/K/eJO0NASKPEzR+E+Q2kaa+MJ4FKXUpjbt+Lxfo+C26TzBk7tg==",
+			"dev": true,
+			"requires": {
+				"@wdio/logger": "6.10.10"
+			}
 		},
 		"abab": {
 			"version": "2.0.5",
@@ -519,6 +683,12 @@
 			"integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
 			"dev": true
 		},
+		"agent-base": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+			"integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+			"dev": true
+		},
 		"aggregate-error": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -553,16 +723,10 @@
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
 			"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA=="
 		},
-		"ansi-escapes": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-			"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-			"dev": true
-		},
 		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -593,44 +757,49 @@
 			}
 		},
 		"archiver": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
-			"integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-5.2.0.tgz",
+			"integrity": "sha512-QEAKlgQuAtUxKeZB9w5/ggKXh21bZS+dzzuQ0RPBC20qtDCbTyzqmisoeJP46MP39fg4B4IcyvR+yeyEBdblsQ==",
 			"dev": true,
 			"requires": {
-				"archiver-utils": "^1.3.0",
-				"async": "^2.0.0",
+				"archiver-utils": "^2.1.0",
+				"async": "^3.2.0",
 				"buffer-crc32": "^0.2.1",
-				"glob": "^7.0.0",
-				"lodash": "^4.8.0",
-				"readable-stream": "^2.0.0",
-				"tar-stream": "^1.5.0",
-				"zip-stream": "^1.2.0"
+				"readable-stream": "^3.6.0",
+				"readdir-glob": "^1.0.0",
+				"tar-stream": "^2.1.4",
+				"zip-stream": "^4.0.4"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"archiver-utils": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-			"integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.0",
-				"graceful-fs": "^4.1.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.0",
 				"lazystream": "^1.0.0",
-				"lodash": "^4.8.0",
-				"normalize-path": "^2.0.0",
+				"lodash.defaults": "^4.2.0",
+				"lodash.difference": "^4.5.0",
+				"lodash.flatten": "^4.4.0",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.union": "^4.6.0",
+				"normalize-path": "^3.0.0",
 				"readable-stream": "^2.0.0"
-			},
-			"dependencies": {
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-					"dev": true,
-					"requires": {
-						"remove-trailing-separator": "^1.0.1"
-					}
-				}
 			}
 		},
 		"archy": {
@@ -658,12 +827,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
 			"integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-			"dev": true
-		},
-		"array-find-index": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
 			"dev": true
 		},
 		"array-flatten": {
@@ -708,18 +871,21 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
 		},
 		"async": {
-			"version": "2.6.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.14"
-			}
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+			"dev": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.2",
@@ -752,30 +918,6 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
-		"babel-runtime": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-			"dev": true,
-			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.11",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-					"dev": true
-				},
-				"regenerator-runtime": {
-					"version": "0.11.1",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-					"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-					"dev": true
-				}
-			}
-		},
 		"bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -793,9 +935,9 @@
 			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
 		},
 		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
 			"dev": true
 		},
 		"base64id": {
@@ -827,13 +969,27 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-			"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+			"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"body-parser": {
@@ -926,48 +1082,32 @@
 				"ieee754": "^1.1.13"
 			}
 		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"dev": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"dev": true
-		},
 		"buffer-crc32": {
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"dev": true
-		},
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"optional": true
 		},
 		"bytes": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
 			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
 		},
+		"cacheable-lookup": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+			"dev": true
+		},
 		"cacheable-request": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
 			"integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-			"optional": true,
 			"requires": {
 				"clone-response": "^1.0.2",
 				"get-stream": "^5.1.0",
@@ -982,7 +1122,6 @@
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
 					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"optional": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -990,8 +1129,7 @@
 				"lowercase-keys": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-					"optional": true
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
 				}
 			}
 		},
@@ -1011,22 +1149,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-		},
-		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-			"dev": true
-		},
-		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"dev": true,
-			"requires": {
-				"camelcase": "^2.0.0",
-				"map-obj": "^1.0.0"
-			}
 		},
 		"caniuse-lite": {
 			"version": "1.0.30001161",
@@ -1090,12 +1212,6 @@
 			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
 			"dev": true
 		},
-		"chardet": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-			"dev": true
-		},
 		"check-error": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -1153,6 +1269,26 @@
 				}
 			}
 		},
+		"chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
+		},
+		"chrome-launcher": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+			"integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*",
+				"escape-string-regexp": "^1.0.5",
+				"is-wsl": "^2.2.0",
+				"lighthouse-logger": "^1.0.0",
+				"mkdirp": "^0.5.3",
+				"rimraf": "^3.0.2"
+			}
+		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -1168,21 +1304,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-			"dev": true
-		},
-		"cli-cursor": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-			"dev": true,
-			"requires": {
-				"restore-cursor": "^2.0.0"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
 		"cliui": {
@@ -1226,16 +1347,9 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
 			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"optional": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
 		},
 		"color-convert": {
 			"version": "1.9.3",
@@ -1293,24 +1407,26 @@
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"compress-commons": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
-			"integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+			"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "^0.2.1",
-				"crc32-stream": "^2.0.0",
-				"normalize-path": "^2.0.0",
-				"readable-stream": "^2.0.0"
+				"buffer-crc32": "^0.2.13",
+				"crc32-stream": "^4.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^3.6.0"
 			},
 			"dependencies": {
-				"normalize-path": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				}
 			}
@@ -1324,6 +1440,7 @@
 			"version": "1.6.2",
 			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+			"optional": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"inherits": "^2.0.3",
@@ -1383,9 +1500,9 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"core-js": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-			"integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
+			"integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
 			"optional": true
 		},
 		"core-util-is": {
@@ -1435,23 +1552,37 @@
 				}
 			}
 		},
-		"crc": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-			"integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+		"crc-32": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+			"integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
 			"dev": true,
 			"requires": {
-				"buffer": "^5.1.0"
+				"exit-on-epipe": "~1.0.1",
+				"printj": "~1.1.0"
 			}
 		},
 		"crc32-stream": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
-			"integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+			"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
 			"dev": true,
 			"requires": {
-				"crc": "^3.4.4",
-				"readable-stream": "^2.0.0"
+				"crc-32": "^1.2.0",
+				"readable-stream": "^3.4.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"cross-spawn": {
@@ -1464,34 +1595,11 @@
 				"which": "^2.0.1"
 			}
 		},
-		"css": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-			"dev": true,
-			"requires": {
-				"inherits": "^2.0.3",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.5.2",
-				"urix": "^0.1.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"css-parse": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/css-parse/-/css-parse-2.0.0.tgz",
-			"integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-			"dev": true,
-			"requires": {
-				"css": "^2.0.0"
-			}
+		"css-shorthand-properties": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz",
+			"integrity": "sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==",
+			"dev": true
 		},
 		"css-value": {
 			"version": "0.0.1",
@@ -1526,15 +1634,6 @@
 					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 					"dev": true
 				}
-			}
-		},
-		"currently-unhandled": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true,
-			"requires": {
-				"array-find-index": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -1619,17 +1718,10 @@
 			"integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
 			"dev": true
 		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
-		},
 		"decompress-response": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
 			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"optional": true,
 			"requires": {
 				"mimic-response": "^1.0.0"
 			}
@@ -1643,21 +1735,15 @@
 				"type-detect": "^4.0.0"
 			}
 		},
-		"deep-extend": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
-		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"deepmerge": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
-			"integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+			"integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
 			"dev": true
 		},
 		"default-require-extensions": {
@@ -1680,8 +1766,7 @@
 		"defer-to-connect": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-			"optional": true
+			"integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
 		},
 		"define-properties": {
 			"version": "1.1.3",
@@ -1717,6 +1802,29 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
 			"integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg=",
+			"dev": true
+		},
+		"devtools": {
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/devtools/-/devtools-6.12.1.tgz",
+			"integrity": "sha512-JyG46suEiZmld7/UVeogkCWM0zYGt+2ML/TI+SkEp+bTv9cs46cDb0pKF3glYZJA7wVVL2gC07Ic0iCxyJEnCQ==",
+			"dev": true,
+			"requires": {
+				"@wdio/config": "6.12.1",
+				"@wdio/logger": "6.10.10",
+				"@wdio/protocols": "6.12.0",
+				"@wdio/utils": "6.11.0",
+				"chrome-launcher": "^0.13.1",
+				"edge-paths": "^2.1.0",
+				"puppeteer-core": "^5.1.0",
+				"ua-parser-js": "^0.7.21",
+				"uuid": "^8.0.0"
+			}
+		},
+		"devtools-protocol": {
+			"version": "0.0.818844",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
+			"integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
 			"dev": true
 		},
 		"diff": {
@@ -1819,8 +1927,7 @@
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-			"optional": true
+			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -1831,21 +1938,25 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"edge-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/edge-paths/-/edge-paths-2.2.1.tgz",
+			"integrity": "sha512-AI5fC7dfDmCdKo3m5y7PkYE8m6bMqR6pvVpgtrZkkhcJXFLelUgkjrhk3kXXx8Kbw2cRaTT4LkOR7hqf39KJdw==",
+			"dev": true,
+			"requires": {
+				"@types/which": "^1.3.2",
+				"which": "^2.0.2"
+			}
+		},
 		"ee-first": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
-		"ejs": {
-			"version": "2.5.9",
-			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-			"integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
-			"dev": true
-		},
 		"electron": {
-			"version": "8.5.3",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-8.5.3.tgz",
-			"integrity": "sha512-cDozmnx6GUNpe9E/pkxeNZq78szgyM2LixlJ+Sov+SzYjXwzTdBfiWuELLkw047ucWvaDFCv5QuYGMmyjJPk7g==",
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-11.2.1.tgz",
+			"integrity": "sha512-Im1y29Bnil+Nzs+FCTq01J1OtLbs+2ZGLLllaqX/9n5GgpdtDmZhS/++JHBsYZ+4+0n7asO+JKQgJD+CqPClzg==",
 			"optional": true,
 			"requires": {
 				"@electron/get": "^1.0.1",
@@ -1854,88 +1965,34 @@
 			}
 		},
 		"electron-chromedriver": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-8.0.0.tgz",
-			"integrity": "sha512-d0210ExhkGOwYLXFZHQR6LISZ8UbMqXWLwjTe8Cdh44XlO4z4+6DWQfM0p7aB2Qak/An6tN732Yl98wN1ylZww==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/electron-chromedriver/-/electron-chromedriver-11.0.0.tgz",
+			"integrity": "sha512-ayMJPBbB4puU0SqYbcD9XvF3/7GWIhqKE1n5lG2/GQPRnrZkNoPIilsrS0rQcD50Xhl69KowatDqLhUznZWtbA==",
 			"dev": true,
 			"requires": {
-				"electron-download": "^4.1.1",
-				"extract-zip": "^1.6.7"
-			}
-		},
-		"electron-download": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
-			"integrity": "sha512-FjEWG9Jb/ppK/2zToP+U5dds114fM1ZOJqMAR4aXXL5CvyPE9fiqBK/9YcwC9poIFQTEJk/EM/zyRwziziRZrg==",
-			"dev": true,
-			"requires": {
-				"debug": "^3.0.0",
-				"env-paths": "^1.0.0",
-				"fs-extra": "^4.0.1",
-				"minimist": "^1.2.0",
-				"nugget": "^2.0.1",
-				"path-exists": "^3.0.0",
-				"rc": "^1.2.1",
-				"semver": "^5.4.1",
-				"sumchecker": "^2.0.2"
+				"@electron/get": "^1.12.2",
+				"extract-zip": "^2.0.0"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
 					}
 				},
-				"env-paths": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-1.0.0.tgz",
-					"integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=",
-					"dev": true
-				},
-				"fs-extra": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-					"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"sumchecker": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-2.0.2.tgz",
-					"integrity": "sha1-D0LBDl0F2l1C7qPlbDOZo31sWz4=",
-					"dev": true,
-					"requires": {
-						"debug": "^2.2.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"dev": true,
-							"requires": {
-								"ms": "2.0.0"
-							}
-						},
-						"ms": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-							"dev": true
-						}
+						"pump": "^3.0.0"
 					}
 				}
 			}
@@ -2024,8 +2081,7 @@
 		"env-paths": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-			"optional": true
+			"integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -2383,6 +2439,12 @@
 				"clone-regexp": "^2.1.0"
 			}
 		},
+		"exit-on-epipe": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+			"integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+			"dev": true
+		},
 		"express": {
 			"version": "4.17.1",
 			"resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2460,32 +2522,11 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
-		"external-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-			"integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-			"dev": true,
-			"requires": {
-				"chardet": "^0.4.0",
-				"iconv-lite": "^0.4.17",
-				"tmp": "^0.0.33"
-			},
-			"dependencies": {
-				"iconv-lite": {
-					"version": "0.4.24",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-					"dev": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				}
-			}
-		},
 		"extract-zip": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
 			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+			"optional": true,
 			"requires": {
 				"concat-stream": "^1.6.2",
 				"debug": "^2.6.9",
@@ -2497,6 +2538,7 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"optional": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -2504,7 +2546,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"optional": true
 				}
 			}
 		},
@@ -2625,21 +2668,27 @@
 				"sax": "^1.2.4"
 			}
 		},
-		"figures": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-			"dev": true,
-			"requires": {
-				"escape-string-regexp": "^1.0.5"
-			}
-		},
 		"file-entry-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
 			"integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
 			"requires": {
 				"flat-cache": "^3.0.4"
+			}
+		},
+		"filename-reserved-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+		},
+		"filenamify": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.2.0.tgz",
+			"integrity": "sha512-pkgE+4p7N1n7QieOopmn3TqJaefjdWXwEkj2XLZJLKfOgcQKkn11ahvGNgTD8mLggexLiDFQxeTs14xVU22XPA==",
+			"requires": {
+				"filename-reserved-regex": "^2.0.0",
+				"strip-outer": "^1.0.1",
+				"trim-repeated": "^1.0.0"
 			}
 		},
 		"finalhandler": {
@@ -2680,16 +2729,6 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
-			}
-		},
-		"find-up": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-			"dev": true,
-			"requires": {
-				"path-exists": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"find-versions": {
@@ -2772,7 +2811,6 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
 			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"optional": true,
 			"requires": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
@@ -2802,15 +2840,6 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
 		},
-		"gaze": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-			"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-			"dev": true,
-			"requires": {
-				"globule": "^1.0.0"
-			}
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2835,17 +2864,16 @@
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
 		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+		"get-port": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+			"integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
 			"dev": true
 		},
 		"get-stream": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-			"optional": true,
 			"requires": {
 				"pump": "^3.0.0"
 			}
@@ -2895,10 +2923,13 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"optional": true
+					"version": "7.3.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+					"optional": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
 				}
 			}
 		},
@@ -2997,17 +3028,6 @@
 			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
 		},
-		"globule": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
-			"integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
-			"dev": true,
-			"requires": {
-				"glob": "~7.1.1",
-				"lodash": "~4.17.10",
-				"minimatch": "~3.0.2"
-			}
-		},
 		"gonzales-pe": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
@@ -3021,7 +3041,6 @@
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
 			"integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-			"optional": true,
 			"requires": {
 				"@sindresorhus/is": "^0.14.0",
 				"@szmarczak/http-timer": "^1.1.2",
@@ -3122,12 +3141,6 @@
 			"resolved": "https://registry.npmjs.org/helmet/-/helmet-4.3.1.tgz",
 			"integrity": "sha512-WsafDyKsIexB0+pUNkq3rL1rB5GVAghR68TP8ssM9DPEMzfBiluEQlVzJ/FEj6Vq2Ag3CNuxf7aYMjXrN0X49Q=="
 		},
-		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-			"dev": true
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -3179,8 +3192,7 @@
 		"http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
-			"optional": true
+			"integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
 		},
 		"http-errors": {
 			"version": "1.7.2",
@@ -3209,6 +3221,34 @@
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
+			}
+		},
+		"http2-wrapper": {
+			"version": "1.0.0-beta.5.2",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
+			"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+			"dev": true,
+			"requires": {
+				"quick-lru": "^5.1.1",
+				"resolve-alpn": "^1.0.0"
+			},
+			"dependencies": {
+				"quick-lru": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+					"dev": true
+				}
+			}
+		},
+		"https-proxy-agent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+			"integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "5",
+				"debug": "4"
 			}
 		},
 		"human-signals": {
@@ -3395,15 +3435,6 @@
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
 		},
-		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true,
-			"requires": {
-				"repeating": "^2.0.0"
-			}
-		},
 		"indexes-of": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -3428,84 +3459,6 @@
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
 			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
-		},
-		"inquirer": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-			"integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-			"dev": true,
-			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.0",
-				"cli-cursor": "^2.1.0",
-				"cli-width": "^2.0.0",
-				"external-editor": "^2.0.4",
-				"figures": "^2.0.0",
-				"lodash": "^4.3.0",
-				"mute-stream": "0.0.7",
-				"run-async": "^2.2.0",
-				"rx-lite": "^4.0.8",
-				"rx-lite-aggregates": "^4.0.8",
-				"string-width": "^2.1.0",
-				"strip-ansi": "^4.0.0",
-				"through": "^2.3.6"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"string-width": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-					"dev": true,
-					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -3574,16 +3527,16 @@
 			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
 			"dev": true
 		},
+		"is-docker": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+			"integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
+			"dev": true
+		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-		},
-		"is-finite": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-			"integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
-			"dev": true
 		},
 		"is-fullwidth-code-point": {
 			"version": "2.0.0",
@@ -3628,17 +3581,20 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-			"dev": true
-		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
 			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
 			"dev": true
+		},
+		"is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"dev": true,
+			"requires": {
+				"is-docker": "^2.0.0"
+			}
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -3886,8 +3842,7 @@
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
-			"optional": true
+			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
 		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
@@ -3947,7 +3902,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
 			"integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-			"optional": true,
 			"requires": {
 				"json-buffer": "3.0.0"
 			}
@@ -3982,24 +3936,38 @@
 				"type-check": "~0.4.0"
 			}
 		},
+		"lighthouse-logger": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+			"integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.8",
+				"marky": "^1.2.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
 			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
 			"dev": true
-		},
-		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
-			}
 		},
 		"locate-path": {
 			"version": "5.0.0",
@@ -4015,16 +3983,70 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+			"dev": true
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+			"dev": true
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
 			"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
 			"dev": true
 		},
+		"lodash.isobject": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+			"integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+			"dev": true
+		},
+		"lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+			"dev": true
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
+		"lodash.union": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+			"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+			"dev": true
+		},
+		"lodash.zip": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+			"integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
 			"dev": true
 		},
 		"log-symbols": {
@@ -4087,27 +4109,28 @@
 				}
 			}
 		},
+		"loglevel": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+			"integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
+			"dev": true
+		},
+		"loglevel-plugin-prefix": {
+			"version": "0.8.4",
+			"resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+			"integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
+			"dev": true
+		},
 		"longest-streak": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
 			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
 			"dev": true
 		},
-		"loud-rejection": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true,
-			"requires": {
-				"currently-unhandled": "^0.4.1",
-				"signal-exit": "^3.0.0"
-			}
-		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-			"optional": true
+			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
 		},
 		"lru-cache": {
 			"version": "6.0.0",
@@ -4144,6 +4167,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
 			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+			"dev": true
+		},
+		"marky": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+			"integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
 			"dev": true
 		},
 		"matcher": {
@@ -4214,24 +4243,6 @@
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
 			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
 		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"dev": true,
-			"requires": {
-				"camelcase-keys": "^2.0.0",
-				"decamelize": "^1.1.2",
-				"loud-rejection": "^1.0.0",
-				"map-obj": "^1.0.1",
-				"minimist": "^1.1.3",
-				"normalize-package-data": "^2.3.4",
-				"object-assign": "^4.0.1",
-				"read-pkg-up": "^1.0.1",
-				"redent": "^1.0.0",
-				"trim-newlines": "^1.0.0"
-			}
-		},
 		"merge-descriptors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -4291,8 +4302,7 @@
 		"mimic-response": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"optional": true
+			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
 		},
 		"min-indent": {
 			"version": "1.0.1",
@@ -4345,6 +4355,12 @@
 			"requires": {
 				"minimist": "^1.2.5"
 			}
+		},
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true
 		},
 		"mocha": {
 			"version": "8.2.1",
@@ -4505,12 +4521,6 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"mute-stream": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
-		},
 		"nanoid": {
 			"version": "3.1.12",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
@@ -4526,6 +4536,12 @@
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+			"dev": true
 		},
 		"node-ical": {
 			"version": "0.12.7",
@@ -4553,18 +4569,6 @@
 			"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
 			"dev": true
 		},
-		"normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4586,8 +4590,7 @@
 		"normalize-url": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
-			"optional": true
+			"integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
 		},
 		"npm-conf": {
 			"version": "1.1.3",
@@ -4607,54 +4610,10 @@
 				}
 			}
 		},
-		"npm-install-package": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/npm-install-package/-/npm-install-package-2.1.0.tgz",
-			"integrity": "sha1-1+/jz816sAYUuJbqUxGdyaslkSU=",
-			"dev": true
-		},
-		"nugget": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-			"integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-			"dev": true,
-			"requires": {
-				"debug": "^2.1.3",
-				"minimist": "^1.1.0",
-				"pretty-bytes": "^1.0.2",
-				"progress-stream": "^1.1.0",
-				"request": "^2.45.0",
-				"single-line-log": "^1.1.2",
-				"throttleit": "0.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
 			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
 		"nwsapi": {
@@ -4897,24 +4856,6 @@
 			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
 			"dev": true
 		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"dev": true,
-			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-					"dev": true
-				}
-			}
-		},
 		"optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -4928,17 +4869,10 @@
 				"word-wrap": "^1.2.3"
 			}
 		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
-		},
 		"p-cancelable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-			"optional": true
+			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 		},
 		"p-limit": {
 			"version": "2.3.0",
@@ -5007,15 +4941,6 @@
 				"is-hexadecimal": "^1.0.0"
 			}
 		},
-		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true,
-			"requires": {
-				"error-ex": "^1.2.0"
-			}
-		},
 		"parse5": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
@@ -5026,15 +4951,6 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-		},
-		"path-exists": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"dev": true,
-			"requires": {
-				"pinkie-promise": "^2.0.0"
-			}
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -5057,17 +4973,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
 			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
 		},
-		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true,
-			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
-			}
-		},
 		"pathval": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -5089,27 +4994,6 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
-		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-			"dev": true
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-			"dev": true
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true,
-			"requires": {
-				"pinkie": "^2.0.0"
-			}
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
@@ -5296,8 +5180,7 @@
 		"prepend-http": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-			"optional": true
+			"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
 		},
 		"prettier": {
 			"version": "2.2.1",
@@ -5312,16 +5195,6 @@
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.2"
-			}
-		},
-		"pretty-bytes": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-			"integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1",
-				"meow": "^3.1.0"
 			}
 		},
 		"pretty-quick": {
@@ -5452,6 +5325,12 @@
 				}
 			}
 		},
+		"printj": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+			"integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+			"dev": true
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5471,16 +5350,6 @@
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
-		"progress-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-			"integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-			"dev": true,
-			"requires": {
-				"speedometer": "~0.1.2",
-				"through2": "~0.2.3"
-			}
-		},
 		"proto-list": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -5495,6 +5364,12 @@
 				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.9.1"
 			}
+		},
+		"proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true
 		},
 		"psl": {
 			"version": "1.8.0",
@@ -5515,22 +5390,53 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-			"dev": true
+		"puppeteer-core": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+			"integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"devtools-protocol": "0.0.818844",
+				"extract-zip": "^2.0.0",
+				"https-proxy-agent": "^4.0.0",
+				"node-fetch": "^2.6.1",
+				"pkg-dir": "^4.2.0",
+				"progress": "^2.0.1",
+				"proxy-from-env": "^1.0.0",
+				"rimraf": "^3.0.2",
+				"tar-fs": "^2.0.0",
+				"unbzip2-stream": "^1.3.3",
+				"ws": "^7.2.3"
+			},
+			"dependencies": {
+				"extract-zip": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+					"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+					"dev": true,
+					"requires": {
+						"@types/yauzl": "^2.9.1",
+						"debug": "^4.1.1",
+						"get-stream": "^5.1.0",
+						"yauzl": "^2.10.0"
+					}
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
 		},
 		"qs": {
 			"version": "6.7.0",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
 			"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
-		},
-		"querystring": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
 		},
 		"quick-lru": {
 			"version": "4.0.1",
@@ -5589,47 +5495,6 @@
 				}
 			}
 		},
-		"rc": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
-			"requires": {
-				"deep-extend": "^0.6.0",
-				"ini": "~1.3.0",
-				"minimist": "^1.2.0",
-				"strip-json-comments": "~2.0.1"
-			},
-			"dependencies": {
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-					"dev": true
-				}
-			}
-		},
-		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true,
-			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
-			}
-		},
-		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true,
-			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
-			}
-		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -5644,6 +5509,15 @@
 				"util-deprecate": "~1.0.1"
 			}
 		},
+		"readdir-glob": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.1.tgz",
+			"integrity": "sha512-91/k1EzZwDx6HbERR+zucygRFfiPl2zkIYZtv3Jjr6Mn7SkKcVct8aVO+sSRiGMc6fLf72du3d92/uY63YPdEA==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.4"
+			}
+		},
 		"readdirp": {
 			"version": "3.5.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -5651,16 +5525,6 @@
 			"dev": true,
 			"requires": {
 				"picomatch": "^2.2.1"
-			}
-		},
-		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true,
-			"requires": {
-				"indent-string": "^2.1.0",
-				"strip-indent": "^1.0.1"
 			}
 		},
 		"regexpp": {
@@ -5712,26 +5576,11 @@
 				"mdast-util-to-markdown": "^0.5.0"
 			}
 		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
-		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
 			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
 			"dev": true
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true,
-			"requires": {
-				"is-finite": "^1.0.0"
-			}
 		},
 		"replace-ext": {
 			"version": "1.0.0",
@@ -5825,50 +5674,39 @@
 				"path-parse": "^1.0.6"
 			}
 		},
+		"resolve-alpn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.0.0.tgz",
+			"integrity": "sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==",
+			"dev": true
+		},
 		"resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 		},
-		"resolve-url": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
-		},
 		"responselike": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
 			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"optional": true,
 			"requires": {
 				"lowercase-keys": "^1.0.0"
 			}
 		},
-		"restore-cursor": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+		"resq": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resq/-/resq-1.10.0.tgz",
+			"integrity": "sha512-hCUd0xMalqtPDz4jXIqs0M5Wnv/LZXN8h7unFOo4/nvExT9dDPbhwd3udRxLlp0HgBnHcV009UlduE9NZi7A6w==",
 			"dev": true,
 			"requires": {
-				"onetime": "^2.0.0",
-				"signal-exit": "^3.0.2"
+				"fast-deep-equal": "^2.0.1"
 			},
 			"dependencies": {
-				"mimic-fn": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-					"dev": true
-				},
-				"onetime": {
+				"fast-deep-equal": {
 					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-					"dev": true,
-					"requires": {
-						"mimic-fn": "^1.0.0"
-					}
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+					"dev": true
 				}
 			}
 		},
@@ -5879,9 +5717,9 @@
 			"dev": true
 		},
 		"rgb2hex": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.10.tgz",
-			"integrity": "sha512-vKz+kzolWbL3rke/xeTE2+6vHmZnNxGyDnaVW4OckntAIcc7DcZzWkQSfxMDwqHS8vhgySnIFyBUH7lIk6PxvQ==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.3.tgz",
+			"integrity": "sha512-clEe0m1xv+Tva1B/TOepuIcvLAxP0U+sCDfgt1SX1HmI2Ahr5/Cd/nzJM1e78NKVtWdoo0s33YehpFA8UfIShQ==",
 			"dev": true
 		},
 		"rimraf": {
@@ -5920,32 +5758,11 @@
 			"resolved": "https://registry.npmjs.org/rrule-alt/-/rrule-alt-2.2.8.tgz",
 			"integrity": "sha1-oxC23Gy8yKEA5Vgj+T9ia9QbFoA="
 		},
-		"run-async": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-			"integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-			"dev": true
-		},
 		"run-parallel": {
 			"version": "1.1.10",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
 			"integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
 			"dev": true
-		},
-		"rx-lite": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-			"dev": true
-		},
-		"rx-lite-aggregates": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-			"dev": true,
-			"requires": {
-				"rx-lite": "*"
-			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -5956,15 +5773,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"sanitize-filename": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-			"integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
-			"optional": true,
-			"requires": {
-				"truncate-utf8-bytes": "^1.0.0"
-			}
 		},
 		"sax": {
 			"version": "1.2.4",
@@ -6118,37 +5926,6 @@
 				}
 			}
 		},
-		"single-line-log": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-			"integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-			"dev": true,
-			"requires": {
-				"string-width": "^1.0.1"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				}
-			}
-		},
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6255,25 +6032,6 @@
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 			"dev": true
 		},
-		"source-map-resolve": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-			"dev": true,
-			"requires": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
-			}
-		},
-		"source-map-url": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
-		},
 		"spawn-wrap": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -6338,24 +6096,17 @@
 			"dev": true
 		},
 		"spectron": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/spectron/-/spectron-10.0.1.tgz",
-			"integrity": "sha512-eMAOr7ovYf+e6+DhkoxVWAMRfZvLJMjtZKwWYkL56fv3Ij6rxhYLjOxybKj0phgMYZ7o2cX5zu2NoyiUM756CA==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/spectron/-/spectron-13.0.0.tgz",
+			"integrity": "sha512-7RPa6Fp8gqL4V0DubobnqIRFHIijkpjg6MFHcJlxoerWyvLJd+cQvOh756XpB1Z/U3DyA9jPcS+HE2PvYRP5+A==",
 			"dev": true,
 			"requires": {
-				"@types/webdriverio": "^4.8.0",
 				"dev-null": "^0.1.1",
-				"electron-chromedriver": "^8.0.0",
-				"request": "^2.87.0",
-				"split": "^1.0.0",
-				"webdriverio": "^4.13.0"
+				"electron-chromedriver": "^11.0.0",
+				"request": "^2.88.2",
+				"split": "^1.0.1",
+				"webdriverio": "^6.9.1"
 			}
-		},
-		"speedometer": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-			"integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
-			"dev": true
 		},
 		"split": {
 			"version": "1.0.1",
@@ -6435,21 +6186,12 @@
 			}
 		},
 		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
-			}
-		},
-		"strip-bom": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true,
-			"requires": {
-				"is-utf8": "^0.2.0"
+				"ansi-regex": "^5.0.0"
 			}
 		},
 		"strip-final-newline": {
@@ -6458,19 +6200,18 @@
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"dev": true
 		},
-		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true,
-			"requires": {
-				"get-stdin": "^4.0.1"
-			}
-		},
 		"strip-json-comments": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+		},
+		"strip-outer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"style-search": {
 			"version": "0.1.0",
@@ -6993,7 +6734,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
 			"integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-			"optional": true,
 			"requires": {
 				"debug": "^4.1.0"
 			}
@@ -7080,19 +6820,42 @@
 				}
 			}
 		},
-		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+		"tar-fs": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"dev": true,
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
+			"requires": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"test-exclude": {
@@ -7111,82 +6874,10 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
-		"throttleit": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-			"integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-			"dev": true
-		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
-		},
-		"through2": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-			"integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-			"dev": true,
-			"requires": {
-				"readable-stream": "~1.1.9",
-				"xtend": "~2.1.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-					"dev": true
-				},
-				"object-keys": {
-					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-					"dev": true
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-					"dev": true
-				},
-				"xtend": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-					"dev": true,
-					"requires": {
-						"object-keys": "~0.4.0"
-					}
-				}
-			}
-		},
-		"tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"requires": {
-				"os-tmpdir": "~1.0.2"
-			}
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
 			"dev": true
 		},
 		"to-fast-properties": {
@@ -7198,8 +6889,7 @@
 		"to-readable-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
-			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-			"optional": true
+			"integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q=="
 		},
 		"toidentifier": {
 			"version": "1.0.0",
@@ -7215,26 +6905,19 @@
 				"punycode": "^2.1.1"
 			}
 		},
-		"trim-newlines": {
+		"trim-repeated": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-			"dev": true
+			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+			"requires": {
+				"escape-string-regexp": "^1.0.2"
+			}
 		},
 		"trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
 			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
 			"dev": true
-		},
-		"truncate-utf8-bytes": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
-			"integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
-			"optional": true,
-			"requires": {
-				"utf8-byte-length": "^1.0.1"
-			}
 		},
 		"tslib": {
 			"version": "1.14.1",
@@ -7292,7 +6975,8 @@
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+			"optional": true
 		},
 		"typedarray-to-buffer": {
 			"version": "3.1.5",
@@ -7301,6 +6985,22 @@
 			"dev": true,
 			"requires": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"ua-parser-js": {
+			"version": "0.7.23",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+			"dev": true
+		},
+		"unbzip2-stream": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+			"integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+			"dev": true,
+			"requires": {
+				"buffer": "^5.2.1",
+				"through": "^2.3.8"
 			}
 		},
 		"unified": {
@@ -7373,44 +7073,13 @@
 				"punycode": "^2.1.0"
 			}
 		},
-		"urix": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
-		},
-		"url": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-			"dev": true,
-			"requires": {
-				"punycode": "1.3.2",
-				"querystring": "0.2.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-					"dev": true
-				}
-			}
-		},
 		"url-parse-lax": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
 			"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-			"optional": true,
 			"requires": {
 				"prepend-http": "^2.0.0"
 			}
-		},
-		"utf8-byte-length": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-			"integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
-			"optional": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -7511,64 +7180,212 @@
 				"xml-name-validator": "^3.0.0"
 			}
 		},
-		"wdio-dot-reporter": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/wdio-dot-reporter/-/wdio-dot-reporter-0.0.10.tgz",
-			"integrity": "sha512-A0TCk2JdZEn3M1DSG9YYbNRcGdx/YRw19lTiRpgwzH4qqWkO/oRDZRmi3Snn4L2j54KKTfPalBhlOtc8fojVgg==",
-			"dev": true
-		},
-		"webdriverio": {
-			"version": "4.14.4",
-			"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-4.14.4.tgz",
-			"integrity": "sha512-Knp2vzuzP5c5ybgLu+zTwy/l1Gh0bRP4zAr8NWcrStbuomm9Krn9oRF0rZucT6AyORpXinETzmeowFwIoo7mNA==",
+		"webdriver": {
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/webdriver/-/webdriver-6.12.1.tgz",
+			"integrity": "sha512-3rZgAj9o2XHp16FDTzvUYaHelPMSPbO1TpLIMUT06DfdZjNYIzZiItpIb/NbQDTPmNhzd9cuGmdI56WFBGY2BA==",
 			"dev": true,
 			"requires": {
-				"archiver": "~2.1.0",
-				"babel-runtime": "^6.26.0",
-				"css-parse": "^2.0.0",
-				"css-value": "~0.0.1",
-				"deepmerge": "~2.0.1",
-				"ejs": "~2.5.6",
-				"gaze": "~1.1.2",
-				"glob": "~7.1.1",
-				"grapheme-splitter": "^1.0.2",
-				"inquirer": "~3.3.0",
-				"json-stringify-safe": "~5.0.1",
-				"mkdirp": "~0.5.1",
-				"npm-install-package": "~2.1.0",
-				"optimist": "~0.6.1",
-				"q": "~1.5.0",
-				"request": "^2.83.0",
-				"rgb2hex": "^0.1.9",
-				"safe-buffer": "~5.1.1",
-				"supports-color": "~5.0.0",
-				"url": "~0.11.0",
-				"wdio-dot-reporter": "~0.0.8",
-				"wgxpath": "~1.0.0"
+				"@wdio/config": "6.12.1",
+				"@wdio/logger": "6.10.10",
+				"@wdio/protocols": "6.12.0",
+				"@wdio/utils": "6.11.0",
+				"got": "^11.0.2",
+				"lodash.merge": "^4.6.1"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+				"@sindresorhus/is": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+					"integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.0.1.tgz",
-					"integrity": "sha512-7FQGOlSQ+AQxBNXJpVDj8efTA/FtyB5wcNE1omXXJ0cq6jm1jjDwuROlYDbnzHqdNPqliWFhcioCWSyav+xBnA==",
+				"@szmarczak/http-timer": {
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+					"integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"defer-to-connect": "^2.0.0"
+					}
+				},
+				"cacheable-request": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+					"integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+					"dev": true,
+					"requires": {
+						"clone-response": "^1.0.2",
+						"get-stream": "^5.1.0",
+						"http-cache-semantics": "^4.0.0",
+						"keyv": "^4.0.0",
+						"lowercase-keys": "^2.0.0",
+						"normalize-url": "^4.1.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"decompress-response": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+					"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+					"dev": true,
+					"requires": {
+						"mimic-response": "^3.1.0"
+					}
+				},
+				"defer-to-connect": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+					"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+					"dev": true
+				},
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"got": {
+					"version": "11.8.1",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
+					"integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+					"dev": true,
+					"requires": {
+						"@sindresorhus/is": "^4.0.0",
+						"@szmarczak/http-timer": "^4.0.5",
+						"@types/cacheable-request": "^6.0.1",
+						"@types/responselike": "^1.0.0",
+						"cacheable-lookup": "^5.0.3",
+						"cacheable-request": "^7.0.1",
+						"decompress-response": "^6.0.0",
+						"http2-wrapper": "^1.0.0-beta.5.2",
+						"lowercase-keys": "^2.0.0",
+						"p-cancelable": "^2.0.0",
+						"responselike": "^2.0.0"
+					}
+				},
+				"json-buffer": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+					"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+					"dev": true
+				},
+				"keyv": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+					"integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+					"dev": true,
+					"requires": {
+						"json-buffer": "3.0.1"
+					}
+				},
+				"lowercase-keys": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+					"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+					"dev": true
+				},
+				"mimic-response": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+					"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+					"dev": true
+				},
+				"p-cancelable": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+					"integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+					"dev": true
+				},
+				"responselike": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+					"integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+					"dev": true,
+					"requires": {
+						"lowercase-keys": "^2.0.0"
 					}
 				}
 			}
 		},
-		"wgxpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wgxpath/-/wgxpath-1.0.0.tgz",
-			"integrity": "sha1-7vikudVYzEla06mit1FZfs2a9pA=",
-			"dev": true
+		"webdriverio": {
+			"version": "6.12.1",
+			"resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-6.12.1.tgz",
+			"integrity": "sha512-Nx7ge0vTWHVIRUbZCT+IuMwB5Q0Q5nLlYdgnmmJviUKLuc3XtaEBkYPTbhHWHgSBXsPZMIc023vZKNkn+6iyeQ==",
+			"dev": true,
+			"requires": {
+				"@types/puppeteer-core": "^5.4.0",
+				"@wdio/config": "6.12.1",
+				"@wdio/logger": "6.10.10",
+				"@wdio/repl": "6.11.0",
+				"@wdio/utils": "6.11.0",
+				"archiver": "^5.0.0",
+				"atob": "^2.1.2",
+				"css-shorthand-properties": "^1.1.1",
+				"css-value": "^0.0.1",
+				"devtools": "6.12.1",
+				"fs-extra": "^9.0.1",
+				"get-port": "^5.1.1",
+				"grapheme-splitter": "^1.0.2",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.isobject": "^3.0.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.zip": "^4.2.0",
+				"minimatch": "^3.0.4",
+				"puppeteer-core": "^5.1.0",
+				"resq": "^1.9.1",
+				"rgb2hex": "0.2.3",
+				"serialize-error": "^8.0.0",
+				"webdriver": "6.12.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+					"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+					"dev": true,
+					"requires": {
+						"at-least-node": "^1.0.0",
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"jsonfile": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+					"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^2.0.0"
+					}
+				},
+				"serialize-error": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.0.1.tgz",
+					"integrity": "sha512-r5o60rWFS+8/b49DNAbB+GXZA0SpDpuWE758JxDKgRTga05r3U5lwyksE91dYKDhXSmnu36RALj615E6Aj5pSg==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.20.2"
+					}
+				},
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
 		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
@@ -7657,12 +7474,6 @@
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
 			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
 		},
-		"wordwrap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-			"dev": true
-		},
 		"workerpool": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
@@ -7739,12 +7550,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-			"dev": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"dev": true
 		},
 		"y18n": {
@@ -7878,15 +7683,27 @@
 			"dev": true
 		},
 		"zip-stream": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-			"integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+			"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
 			"dev": true,
 			"requires": {
-				"archiver-utils": "^1.3.0",
-				"compress-commons": "^1.2.0",
-				"lodash": "^4.8.0",
-				"readable-stream": "^2.0.0"
+				"archiver-utils": "^2.1.0",
+				"compress-commons": "^4.0.2",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"zwitch": {

--- a/package.json
+++ b/package.json
@@ -58,14 +58,14 @@
 		"nyc": "^15.1.0",
 		"prettier": "^2.2.1",
 		"pretty-quick": "^3.1.0",
-		"spectron": "^10.0.1",
+		"spectron": "^13.0.0",
 		"stylelint": "^13.8.0",
 		"stylelint-config-prettier": "^8.0.2",
 		"stylelint-config-standard": "^20.0.0",
 		"stylelint-prettier": "^1.1.2"
 	},
 	"optionalDependencies": {
-		"electron": "^8.5.3"
+		"electron": "^11.2.1"
 	},
 	"dependencies": {
 		"colors": "^1.4.0",

--- a/tests/configs/empty_ipWhiteList.js
+++ b/tests/configs/empty_ipWhiteList.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/env.js
+++ b/tests/configs/env.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/auth-default.js
+++ b/tests/configs/modules/calendar/auth-default.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/basic-auth.js
+++ b/tests/configs/modules/calendar/basic-auth.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/custom.js
+++ b/tests/configs/modules/calendar/custom.js
@@ -11,7 +11,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/default.js
+++ b/tests/configs/modules/calendar/default.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/fail-basic-auth.js
+++ b/tests/configs/modules/calendar/fail-basic-auth.js
@@ -15,7 +15,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/calendar/old-basic-auth.js
+++ b/tests/configs/modules/calendar/old-basic-auth.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_12hr.js
+++ b/tests/configs/modules/clock/clock_12hr.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_24hr.js
+++ b/tests/configs/modules/clock/clock_24hr.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_analog.js
+++ b/tests/configs/modules/clock/clock_analog.js
@@ -11,7 +11,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_displaySeconds_false.js
+++ b/tests/configs/modules/clock/clock_displaySeconds_false.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/clock_showPeriodUpper.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/clock_showWeek.js
+++ b/tests/configs/modules/clock/clock_showWeek.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/es/clock_12hr.js
+++ b/tests/configs/modules/clock/es/clock_12hr.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/es/clock_24hr.js
+++ b/tests/configs/modules/clock/es/clock_24hr.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/es/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/es/clock_showPeriodUpper.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/clock/es/clock_showWeek.js
+++ b/tests/configs/modules/clock/es/clock_showWeek.js
@@ -16,7 +16,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/compliments/compliments_anytime.js
+++ b/tests/configs/modules/compliments/compliments_anytime.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -14,7 +14,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/compliments/compliments_only_anytime.js
+++ b/tests/configs/modules/compliments/compliments_only_anytime.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/compliments/compliments_parts_day.js
+++ b/tests/configs/modules/compliments/compliments_parts_day.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/display.js
+++ b/tests/configs/modules/display.js
@@ -14,7 +14,8 @@ var config = {
 		width: 800,
 		height: 600,
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/helloworld/helloworld.js
+++ b/tests/configs/modules/helloworld/helloworld.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/helloworld/helloworld_default.js
+++ b/tests/configs/modules/helloworld/helloworld_default.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/newsfeed/default.js
+++ b/tests/configs/modules/newsfeed/default.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/positions.js
+++ b/tests/configs/modules/positions.js
@@ -15,7 +15,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/currentweather_compliments.js
+++ b/tests/configs/modules/weather/currentweather_compliments.js
@@ -15,7 +15,8 @@ let config = {
 	electronOptions: {
 		fullscreen: false,
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/currentweather_default.js
+++ b/tests/configs/modules/weather/currentweather_default.js
@@ -14,7 +14,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/currentweather_options.js
+++ b/tests/configs/modules/weather/currentweather_options.js
@@ -14,7 +14,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/currentweather_units.js
+++ b/tests/configs/modules/weather/currentweather_units.js
@@ -14,7 +14,8 @@ let config = {
 	units: "imperial",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/forecastweather_default.js
+++ b/tests/configs/modules/weather/forecastweather_default.js
@@ -14,7 +14,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/modules/weather/forecastweather_options.js
+++ b/tests/configs/modules/weather/forecastweather_options.js
@@ -14,7 +14,8 @@ let config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/noIpWhiteList.js
+++ b/tests/configs/noIpWhiteList.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/port_8090.js
+++ b/tests/configs/port_8090.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	},
 

--- a/tests/configs/without_modules.js
+++ b/tests/configs/without_modules.js
@@ -13,7 +13,8 @@ var config = {
 	units: "metric",
 	electronOptions: {
 		webPreferences: {
-			nodeIntegration: true
+			nodeIntegration: true,
+			enableRemoteModule: true
 		}
 	}
 };

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -31,25 +31,25 @@ describe("Electron app environment", function () {
 		return helpers.stopApplication(app);
 	});
 
-	it("should open a browserwindow", function () {
+	it("should open a browserwindow", async function () {
+		await app.client.waitUntilWindowLoaded();
+		app.browserWindow.focus();
+		const cnt = await app.client.getWindowCount();
+		const min = await app.browserWindow.isMinimized();
+		const dev = await app.browserWindow.isDevToolsOpened();
+		const vis = await app.browserWindow.isVisible();
+		const foc = await app.browserWindow.isFocused();
+		const bounds = await app.browserWindow.getBounds();
+		const title = await app.browserWindow.getTitle();
 		return (
-			app.client
-				.waitUntilWindowLoaded()
-				// .browserWindow.focus()
-				.getWindowCount()
-				.should.eventually.equal(1)
-				.browserWindow.isMinimized()
-				.should.eventually.be.false.browserWindow.isDevToolsOpened()
-				.should.eventually.be.false.browserWindow.isVisible()
-				.should.eventually.be.true.browserWindow.isFocused()
-				.should.eventually.be.true.browserWindow.getBounds()
-				.should.eventually.have.property("width")
-				.and.be.above(0)
-				.browserWindow.getBounds()
-				.should.eventually.have.property("height")
-				.and.be.above(0)
-				.browserWindow.getTitle()
-				.should.eventually.equal("MagicMirror²")
+			cnt.should.equal(1) &&
+			min.should.be.false &&
+			dev.should.be.false &&
+			vis.should.be.true &&
+			foc.should.be.true &&
+			bounds.should.have.property("width").and.be.above(0) &&
+			bounds.should.have.property("height").and.be.above(0) &&
+			title.should.equal("MagicMirror²")
 		);
 	});
 

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -30,14 +30,16 @@ describe("Clock set to spanish language module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/es/clock_24hr.js";
 		});
 
-		it("shows date with correct format", function () {
-			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+		it("shows date with correct format", async function () {
+			const dateRegex = /^(?:lunes|martes|mi  rcoles|jueves|viernes|s  bado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
+			const elem = await app.client.$(".clock .date");
+			return elem.getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
-		it("shows time in 24hr format", function () {
+		it("shows time in 24hr format", async function () {
 			const timeRegex = /^(?:2[0-3]|[01]\d):[0-5]\d[0-5]\d$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -47,14 +49,16 @@ describe("Clock set to spanish language module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/es/clock_12hr.js";
 		});
 
-		it("shows date with correct format", function () {
+		it("shows date with correct format", async function () {
 			const dateRegex = /^(?:lunes|martes|miércoles|jueves|viernes|sábado|domingo), \d{1,2} de (?:enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre) de \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			const elem = await app.client.$(".clock .date");
+			return elem.getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
-		it("shows time in 12hr format", function () {
+		it("shows time in 12hr format", async function () {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -64,9 +68,10 @@ describe("Clock set to spanish language module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/es/clock_showPeriodUpper.js";
 		});
 
-		it("shows 12hr time with upper case AM/PM", function () {
+		it("shows 12hr time with upper case AM/PM", async function () {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[AP]M$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -76,9 +81,10 @@ describe("Clock set to spanish language module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/es/clock_showWeek.js";
 		});
 
-		it("shows week with correct format", function () {
+		it("shows week with correct format", async function () {
 			const weekRegex = /^Semana [0-9]{1,2}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .week").should.eventually.match(weekRegex);
+			const elem = await app.client.$(".clock .week");
+			elem.getText(".clock .week").should.eventually.match(weekRegex);
 		});
 	});
 });

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -32,14 +32,16 @@ describe("Clock module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_24hr.js";
 		});
 
-		it("should show the date in the correct format", function () {
+		it("should show the date in the correct format", async function () {
 			const dateRegex = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (?:January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}, \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			const elem = await app.client.$(".clock .date");
+			return elem.getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
-		it("should show the time in 24hr format", function () {
+		it("should show the time in 24hr format", async function () {
 			const timeRegex = /^(?:2[0-3]|[01]\d):[0-5]\d[0-5]\d$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -49,14 +51,16 @@ describe("Clock module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_12hr.js";
 		});
 
-		it("should show the date in the correct format", function () {
+		it("should show the date in the correct format", async function () {
 			const dateRegex = /^(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (?:January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}, \d{4}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .date").should.eventually.match(dateRegex);
+			const elem = await app.client.$(".clock .date");
+			return elem.getText(".clock .date").should.eventually.match(dateRegex);
 		});
 
-		it("should show the time in 12hr format", function () {
+		it("should show the time in 12hr format", async function () {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -66,9 +70,10 @@ describe("Clock module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_showPeriodUpper.js";
 		});
 
-		it("should show 12hr time with upper case AM/PM", function () {
+		it("should show 12hr time with upper case AM/PM", async function () {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[0-5]\d[AP]M$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -78,9 +83,10 @@ describe("Clock module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_displaySeconds_false.js";
 		});
 
-		it("should show 12hr time without seconds am/pm", function () {
+		it("should show 12hr time without seconds am/pm", async function () {
 			const timeRegex = /^(?:1[0-2]|[1-9]):[0-5]\d[ap]m$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .time").should.eventually.match(timeRegex);
+			const elem = await app.client.$(".clock .time");
+			return elem.getText(".clock .time").should.eventually.match(timeRegex);
 		});
 	});
 
@@ -90,15 +96,17 @@ describe("Clock module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/clock/clock_showWeek.js";
 		});
 
-		it("should show the week in the correct format", function () {
+		it("should show the week in the correct format", async function () {
 			const weekRegex = /^Week [0-9]{1,2}$/;
-			return app.client.waitUntilWindowLoaded().getText(".clock .week").should.eventually.match(weekRegex);
+			const elem = await app.client.$(".clock .week");
+			return elem.getText(".clock .week").should.eventually.match(weekRegex);
 		});
 
-		it("should show the week with the correct number of week of year", function () {
+		it("should show the week with the correct number of week of year", async function () {
 			const currentWeekNumber = moment().week();
 			const weekToShow = "Week " + currentWeekNumber;
-			return app.client.waitUntilWindowLoaded().getText(".clock .week").should.eventually.equal(weekToShow);
+			const elem = await app.client.$(".clock .week");
+			return elem.getText(".clock .week").should.eventually.equal(weekToShow);
 		});
 	});
 

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -31,42 +31,36 @@ describe("Compliments module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_parts_day.js";
 		});
 
-		it("if Morning compliments for that part of day", function () {
+		it("if Morning compliments for that part of day", async function () {
 			var hour = new Date().getHours();
 			if (hour >= 3 && hour < 12) {
 				// if morning check
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Hi", "Good Morning", "Morning test"]);
-					});
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Hi", "Good Morning", "Morning test"]);
+				});
 			}
 		});
 
-		it("if Afternoon show Compliments for that part of day", function () {
+		it("if Afternoon show Compliments for that part of day", async function () {
 			var hour = new Date().getHours();
 			if (hour >= 12 && hour < 17) {
 				// if morning check
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Hello", "Good Afternoon", "Afternoon test"]);
-					});
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Hello", "Good Afternoon", "Afternoon test"]);
+				});
 			}
 		});
 
-		it("if Evening show Compliments for that part of day", function () {
+		it("if Evening show Compliments for that part of day", async function () {
 			var hour = new Date().getHours();
 			if (!(hour >= 3 && hour < 12) && !(hour >= 12 && hour < 17)) {
 				// if evening check
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Hello There", "Good Evening", "Evening test"]);
-					});
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Hello There", "Good Evening", "Evening test"]);
+				});
 			}
 		});
 	});
@@ -78,13 +72,11 @@ describe("Compliments module", function () {
 				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_anytime.js";
 			});
 
-			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", function () {
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Anytime here"]);
-					});
+			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", async function () {
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Anytime here"]);
+				});
 			});
 		});
 
@@ -94,13 +86,11 @@ describe("Compliments module", function () {
 				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_only_anytime.js";
 			});
 
-			it("Show anytime compliments", function () {
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Anytime here"]);
-					});
+			it("Show anytime compliments", async function () {
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Anytime here"]);
+				});
 			});
 		});
 	});
@@ -112,13 +102,11 @@ describe("Compliments module", function () {
 				process.env.MM_CONFIG_FILE = "tests/configs/modules/compliments/compliments_date.js";
 			});
 
-			it("Show happy new year compliment on new years day", function () {
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText(".compliments")
-					.then(function (text) {
-						expect(text).to.be.oneOf(["Happy new year!"]);
-					});
+			it("Show happy new year compliment on new years day", async function () {
+				const elem = await app.client.$(".compliments");
+				return elem.getText(".compliments").then(function (text) {
+					expect(text).to.be.oneOf(["Happy new year!"]);
+				});
 			});
 		});
 	});

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -30,8 +30,9 @@ describe("Test helloworld module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/helloworld/helloworld.js";
 		});
 
-		it("Test message helloworld module", function () {
-			return app.client.waitUntilWindowLoaded().getText(".helloworld").should.eventually.equal("Test HelloWorld Module");
+		it("Test message helloworld module", async function () {
+			const elem = await app.client.$("helloworld");
+			return elem.getText(".helloworld").should.eventually.equal("Test HelloWorld Module");
 		});
 	});
 
@@ -41,8 +42,9 @@ describe("Test helloworld module", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/modules/helloworld/helloworld_default.js";
 		});
 
-		it("Test message helloworld module", function () {
-			return app.client.waitUntilWindowLoaded().getText(".helloworld").should.eventually.equal("Hello World!");
+		it("Test message helloworld module", async function () {
+			const elem = await app.client.$("helloworld");
+			return elem.getText(".helloworld").should.eventually.equal("Hello World!");
 		});
 	});
 });

--- a/tests/e2e/modules/weather_spec.js
+++ b/tests/e2e/modules/weather_spec.js
@@ -43,7 +43,7 @@ describe("Weather module", function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
+				return await app.client.$(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
 			});
 
 			it("should render sunrise", async function () {
@@ -53,9 +53,9 @@ describe("Weather module", function () {
 				const weather = generateWeather({ sys: { sunrise, sunset } });
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather .normal.medium span.wi.dimmed.wi-sunrise", 10000);
+				await app.client.$(".weather .normal.medium span.wi.dimmed.wi-sunrise", 10000);
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(4)", "12:00 am", 10000);
+				return await app.client.$(".weather .normal.medium span:nth-child(4)", "12:00 am", 10000);
 			});
 
 			it("should render sunset", async function () {
@@ -65,25 +65,25 @@ describe("Weather module", function () {
 				const weather = generateWeather({ sys: { sunrise, sunset } });
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather .normal.medium span.wi.dimmed.wi-sunset", 10000);
+				await app.client.$(".weather .normal.medium span.wi.dimmed.wi-sunset", 10000);
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(4)", "11:59 pm", 10000);
+				return await app.client.$(".weather .normal.medium span:nth-child(4)", "11:59 pm", 10000);
 			});
 
 			it("should render temperature with icon", async function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather .large.light span.wi.weathericon.wi-snow", 10000);
+				await app.client.$(".weather .large.light span.wi.weathericon.wi-snow", 10000);
 
-				return app.client.waitUntilTextExists(".weather .large.light span.bright", "1.5°", 10000);
+				return await app.client.$(".weather .large.light span.bright", "1.5°", 10000);
 			});
 
 			it("should render feels like temperature", async function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span.dimmed", "Feels like -5.6°", 10000);
+				return await app.client.$(".weather .normal.medium span.dimmed", "Feels like -5.6°", 10000);
 			});
 		});
 
@@ -96,7 +96,7 @@ describe("Weather module", function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				return app.client.waitUntilTextExists(".compliments .module-content span", "snow", 10000);
+				return await app.client.$(".compliments .module-content span", "snow", 10000);
 			});
 		});
 
@@ -109,15 +109,15 @@ describe("Weather module", function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "12", 10000);
+				return await app.client.$(".weather .normal.medium span:nth-child(2)", "12", 10000);
 			});
 
 			it("should render showWindDirectionAsArrow = true", async function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather .normal.medium sup i.fa-long-arrow-up", 10000);
-				const element = await app.client.getHTML(".weather .normal.medium sup i.fa-long-arrow-up");
+				const elem = await app.client.$(".weather .normal.medium sup i.fa-long-arrow-up", 10000);
+				const element = await elem.getHTML(".weather .normal.medium sup i.fa-long-arrow-up");
 
 				expect(element).to.include("transform:rotate(250deg);");
 			});
@@ -126,17 +126,17 @@ describe("Weather module", function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(3)", "93", 10000);
-				return app.client.waitForExist(".weather .normal.medium sup i.wi-humidity", 10000);
+				await app.client.$(".weather .normal.medium span:nth-child(3)", "93", 10000);
+				return await app.client.$(".weather .normal.medium sup i.wi-humidity", 10000);
 			});
 
 			it("should render degreeLabel = true", async function () {
 				const weather = generateWeather();
 				await setup({ template, data: weather });
 
-				await app.client.waitUntilTextExists(".weather .large.light span.bright", "1°C", 10000);
+				await app.client.$(".weather .large.light span.bright", "1°C", 10000);
 
-				return app.client.waitUntilTextExists(".weather .normal.medium span.dimmed", "Feels like -6°C", 10000);
+				return await app.client.$(".weather .normal.medium span.dimmed", "Feels like -6°C", 10000);
 			});
 		});
 
@@ -158,9 +158,9 @@ describe("Weather module", function () {
 				});
 				await setup({ template, data: weather });
 
-				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
-				await app.client.waitUntilTextExists(".weather .large.light span.bright", "34,7°", 10000);
-				return app.client.waitUntilTextExists(".weather .normal.medium span.dimmed", "22,0°", 10000);
+				await app.client.$(".weather .normal.medium span:nth-child(2)", "6 WSW", 10000);
+				await app.client.$(".weather .large.light span.bright", "34,7°", 10000);
+				return await app.client.$(".weather .normal.medium span.dimmed", "22,0°", 10000);
 			});
 
 			it("should render decimalSymbol = ','", async function () {
@@ -176,9 +176,9 @@ describe("Weather module", function () {
 				});
 				await setup({ template, data: weather });
 
-				await app.client.waitUntilTextExists(".weather .normal.medium span:nth-child(3)", "93,7", 10000);
-				await app.client.waitUntilTextExists(".weather .large.light span.bright", "34,7°", 10000);
-				return app.client.waitUntilTextExists(".weather .normal.medium span.dimmed", "22,0°", 10000);
+				await app.client.$(".weather .normal.medium span:nth-child(3)", "93,7", 10000);
+				await app.client.$(".weather .large.light span.bright", "34,7°", 10000);
+				return await app.client.$(".weather .normal.medium span.dimmed", "22,0°", 10000);
 			});
 		});
 	});
@@ -202,7 +202,7 @@ describe("Weather module", function () {
 				const days = ["Today", "Tomorrow", "Sun", "Mon", "Tue"];
 
 				for (const [index, day] of days.entries()) {
-					await app.client.waitUntilTextExists(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(1)`, day, 10000);
+					await app.client.$(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(1)`, day, 10000);
 				}
 			});
 
@@ -213,7 +213,7 @@ describe("Weather module", function () {
 				const icons = ["day-cloudy", "rain", "day-sunny", "day-sunny", "day-sunny"];
 
 				for (const [index, icon] of icons.entries()) {
-					await app.client.waitForExist(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`, 10000);
+					await app.client.$(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`, 10000);
 				}
 			});
 
@@ -224,7 +224,7 @@ describe("Weather module", function () {
 				const temperatures = ["24.4°", "21.0°", "22.9°", "23.4°", "20.6°"];
 
 				for (const [index, temp] of temperatures.entries()) {
-					await app.client.waitUntilTextExists(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(3)`, temp, 10000);
+					await app.client.$(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(3)`, temp, 10000);
 				}
 			});
 
@@ -235,7 +235,7 @@ describe("Weather module", function () {
 				const temperatures = ["15.3°", "13.6°", "13.8°", "13.9°", "10.9°"];
 
 				for (const [index, temp] of temperatures.entries()) {
-					await app.client.waitUntilTextExists(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(4)`, temp, 10000);
+					await app.client.$(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(4)`, temp, 10000);
 				}
 			});
 
@@ -245,10 +245,10 @@ describe("Weather module", function () {
 
 				const opacities = [1, 1, 0.8, 0.5333333333333333, 0.2666666666666667];
 
-				await app.client.waitForExist(".weather table.small", 10000);
+				const elem = await app.client.$(".weather table.small", 10000);
 
 				for (const [index, opacity] of opacities.entries()) {
-					const html = await app.client.getHTML(`.weather table.small tr:nth-child(${index + 1})`);
+					const html = await elem.getHTML(`.weather table.small tr:nth-child(${index + 1})`);
 					expect(html).to.includes(`<tr style="opacity: ${opacity};">`);
 				}
 			});
@@ -263,14 +263,14 @@ describe("Weather module", function () {
 				const weather = generateWeatherForecast();
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather table.myTableClass", 10000);
+				await app.client.$(".weather table.myTableClass", 10000);
 			});
 
 			it("should render colored rows", async function () {
 				const weather = generateWeatherForecast();
 				await setup({ template, data: weather });
 
-				await app.client.waitForExist(".weather table.myTableClass", 10000);
+				await app.client.$(".weather table.myTableClass", 10000);
 
 				const rows = await app.client.$$(".weather table.myTableClass tr.colored");
 

--- a/tests/e2e/modules_display_spec.js
+++ b/tests/e2e/modules_display_spec.js
@@ -29,13 +29,13 @@ describe("Display of modules", function () {
 		});
 
 		it("should show the test header", async () => {
-			await app.client.waitForExist("#module_0_helloworld", 10000);
-			return app.client.element("#module_0_helloworld .module-header").isVisible().should.eventually.equal(true).getText("#module_0_helloworld .module-header").should.eventually.equal("TEST_HEADER");
+			const elem = await app.client.$("#module_0_helloworld .module-header", 10000);
+			return elem.getText("#module_0_helloworld .module-header").should.eventually.equal("TEST_HEADER");
 		});
 
 		it("should show no header if no header text is specified", async () => {
-			await app.client.waitForExist("#module_1_helloworld", 10000);
-			return app.client.element("#module_1_helloworld .module-header").isVisible().should.eventually.equal(false);
+			const elem = await app.client.$("#module_1_helloworld .module-header", 10000);
+			return elem.getText("#module_1_helloworld .module-header").should.eventually.equal(false);
 		});
 	});
 });

--- a/tests/e2e/modules_position_spec.js
+++ b/tests/e2e/modules_position_spec.js
@@ -33,10 +33,9 @@ describe("Position of modules", function () {
 			position = positions[idx];
 			className = position.replace("_", ".");
 			it("show text in " + position, function () {
-				return app.client
-					.waitUntilWindowLoaded()
-					.getText("." + className)
-					.should.eventually.equal("Text in " + position);
+				app.client.$("." + className).then((result) => {
+					return this.getText("." + className).should.eventually.equal("Text in " + position);
+				});
 			});
 		}
 	});

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -29,11 +29,13 @@ describe("Check configuration without modules", function () {
 		process.env.MM_CONFIG_FILE = "tests/configs/without_modules.js";
 	});
 
-	it("Show the message MagicMirror title", function () {
-		return app.client.waitUntilWindowLoaded().getText("#module_1_helloworld .module-content").should.eventually.equal("Magic Mirror2");
+	it("Show the message MagicMirror title", async function () {
+		const elem = await app.client.$("#module_1_helloworld .module-content");
+		return elem.getText("#module_1_helloworld .module-content").should.eventually.equal("Magic Mirror2");
 	});
 
-	it("Show the text Michael's website", function () {
-		return app.client.waitUntilWindowLoaded().getText("#module_5_helloworld .module-content").should.eventually.equal("www.michaelteeuw.nl");
+	it("Show the text Michael's website", async function () {
+		const elem = await app.client.$("#module_5_helloworld .module-content");
+		return elem.getText("#module_5_helloworld .module-content").should.eventually.equal("www.michaelteeuw.nl");
 	});
 });


### PR DESCRIPTION
Managed to update electron to v11.

In the past updates of electron were discussed controversially. So I'm excited if this will ever be merged.

Done in this PR:
- update electron and spectron in `package.json`
- added `enableRemoteModule: true` to all test configs (see https://www.electronjs.org/docs/breaking-changes#default-changed-enableremotemodule-defaults-to-false)
- update several e2e tests due to breaking changes in spectron (see https://github.com/electron-userland/spectron/issues/647)
- tested this setup on a raspberry pi 3 with no problems (using several modules)