### PR TITLE
Warn dom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Converted newsfeed module to use templates.
 - Update documentation and help screen about invalid config files.
 - Moving weather provider specific code and configuration into each provider and making hourly part of the interface.
+- Dont update the DOM when a module is not displayed.
 
 ### Removed
 

--- a/js/main.js
+++ b/js/main.js
@@ -547,6 +547,11 @@ var MM = (function () {
 				return;
 			}
 
+			if (!module.data.position) {
+				Log.warn("module tries to update the DOM without being displayed.");
+				return;
+			}
+
 			// Further implementation is done in the private method.
 			updateDom(module, speed);
 		},


### PR DESCRIPTION
There was an issue in my module where it called the updateDOM method even if it wasnt displaying anything on the screen but just running in the node process: https://github.com/rejas/MMM-MotionDetector/issues/42

This PR checks before actually running the updateDOM if the module is actually on the screen. If not it returns without calling the method and prints a warning on the screen.