### PR TITLE
Make self signed certs to work with calendar module

### DIFF
--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -51,6 +51,13 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumEn
 			gzip: true
 		};
 
+        if (selfSignedCert) {
+            var agentOptions = {
+                rejectUnauthorized: false
+            };
+            opts.agentOptions = agentOptions;
+        }
+
 		if (auth) {
 			if (auth.method === "bearer") {
 				opts.auth = {

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -51,12 +51,12 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumEn
 			gzip: true
 		};
 
-        if (selfSignedCert) {
-            var agentOptions = {
+		if (selfSignedCert) {
+			var agentOptions = {
                 rejectUnauthorized: false
-            };
-            opts.agentOptions = agentOptions;
-        }
+			};
+			opts.agentOptions = agentOptions;
+		}
 
 		if (auth) {
 			if (auth.method === "bearer") {


### PR DESCRIPTION
Many people use Own-/Nextcloud and https protocol. The changes are supposed to make the calendar module work even with self-signed certificates. This is supposed to close issue #466.
