### PR TITLE
added locale to sample config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Portuguese translations for "MODULE_CONFIG_CHANGED" and PRECIP.
 - Respect parameter ColoredSymbolOnly also for custom events
 - Added a new parameter to hide time portion on relative times
+- Added locale to sample config file
 
 ### Updated
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -28,6 +28,7 @@ var config = {
 	httpsCertificate: "", 	// HTTPS Certificate path, only require when useHttps is true
 
 	language: "en",
+	locale: "en-US",
 	logLevel: ["INFO", "LOG", "WARN", "ERROR"], // Add "DEBUG" for even more logging
 	timeFormat: 24,
 	units: "metric",


### PR DESCRIPTION
Some of my modules make use of the locale config option. Since this could be useful for others I thought why not adding it to the sample config file.
