### PR TITLE
exposed logger as node module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Bump electron to v11.
 - Dont update the DOM when a module is not displayed.
 - Cleaned up jsdoc and tests.
+- Exposed logger as node module for easier access for 3rd party modules
 
 ### Removed
 

--- a/js/app.js
+++ b/js/app.js
@@ -4,15 +4,16 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-const fs = require("fs");
-const path = require("path");
-const Log = require(`${__dirname}/logger`);
-const Server = require(`${__dirname}/server`);
-const Utils = require(`${__dirname}/utils`);
-const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`);
 
 // Alias modules mentioned in package.js under _moduleAliases.
 require("module-alias/register");
+
+const fs = require("fs");
+const path = require("path");
+const Log = require("logger");
+const Server = require(`${__dirname}/server`);
+const Utils = require(`${__dirname}/utils`);
+const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`);
 
 // Get version number.
 global.version = require(`${__dirname}/../package.json`).version;

--- a/js/electron.js
+++ b/js/electron.js
@@ -2,7 +2,7 @@
 
 const electron = require("electron");
 const core = require("./app.js");
-const Log = require("./logger.js");
+const Log = require("logger");
 
 // Config
 let config = process.env.config ? JSON.parse(process.env.config) : {};

--- a/js/node_helper.js
+++ b/js/node_helper.js
@@ -5,7 +5,7 @@
  * MIT Licensed.
  */
 const Class = require("./class.js");
-const Log = require("./logger.js");
+const Log = require("logger");
 const express = require("express");
 
 const NodeHelper = Class.extend({

--- a/js/server.js
+++ b/js/server.js
@@ -11,7 +11,7 @@ const ipfilter = require("express-ipfilter").IpFilter;
 const fs = require("fs");
 const helmet = require("helmet");
 
-const Log = require("./logger.js");
+const Log = require("logger");
 const Utils = require("./utils.js");
 
 /**

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -4,7 +4,7 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-const Log = require("../../../js/logger.js");
+const Log = require("logger");
 const ical = require("node-ical");
 const request = require("request");
 

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -7,7 +7,7 @@
 const NodeHelper = require("node_helper");
 const validUrl = require("valid-url");
 const CalendarFetcher = require("./calendarfetcher.js");
-const Log = require("../../../js/logger");
+const Log = require("logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/modules/default/currentweather/node_helper.js
+++ b/modules/default/currentweather/node_helper.js
@@ -1,5 +1,5 @@
 const NodeHelper = require("node_helper");
-const Log = require("../../../js/logger");
+const Log = require("logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -4,7 +4,7 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-const Log = require("../../../js/logger.js");
+const Log = require("logger");
 const FeedMe = require("feedme");
 const request = require("request");
 const iconv = require("iconv-lite");

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -8,7 +8,7 @@
 const NodeHelper = require("node_helper");
 const validUrl = require("valid-url");
 const NewsfeedFetcher = require("./newsfeedfetcher.js");
-const Log = require("../../../js/logger");
+const Log = require("logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -3,7 +3,7 @@ const simpleGits = [];
 const fs = require("fs");
 const path = require("path");
 const defaultModules = require(__dirname + "/../defaultmodules.js");
-const Log = require(__dirname + "/../../../js/logger.js");
+const Log = require("logger");
 const NodeHelper = require("node_helper");
 
 module.exports = NodeHelper.create({

--- a/modules/default/weatherforecast/node_helper.js
+++ b/modules/default/weatherforecast/node_helper.js
@@ -1,5 +1,5 @@
 const NodeHelper = require("node_helper");
-const Log = require("../../../js/logger");
+const Log = require("logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
 		"valid-url": "^1.0.9"
 	},
 	"_moduleAliases": {
-		"node_helper": "js/node_helper.js"
+		"node_helper": "js/node_helper.js",
+		"logger": "js/logger.js"
 	},
 	"engines": {
 		"node": ">=10"

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -1,5 +1,5 @@
 const app = require("../js/app.js");
-const Log = require("../js/logger.js");
+const Log = require("logger");
 
 app.start(function (config) {
 	var bindAddress = config.address ? config.address : "localhost";


### PR DESCRIPTION
This makes it easier for 3rd party modules to use the logger in the node helper with the according `logLevels` instead of console logs.

You only need to do `const Log = require('logger');` in a module.