### PR TITLE
Fix single day events not respecting the maximumNumberOfDays setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,8 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix socket.io backward compatibility with socket v2 clients
 - 3rd party module language loading if language is English
 - Fix e2e tests after spectron update
-
+- Fix single day events not respecting the maximumNumberOfDays setting in the calendar module
+- 
 ## [2.14.0] - 2021-01-01
 
 Special thanks to the following contributors: @Alvinger, @AndyPoms, @ashishtank, @bluemanos, @flopp999, @jakemulley, @jakobsarwary1, @marvai-vgtu, @mirontoli, @rejas, @sdetweil, @Snille & @Sub028.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -538,7 +538,9 @@ Module.register("calendar", {
 						}
 					}
 				} else {
-					events.push(event);
+					if (event.endDate > now && event.endDate <= future) {
+						events.push(event);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Purpose
Fix single day events not respecting the maximumNumberOfDays setting

## Repro steps
- Add a calendar on `config.js` with the setting `maximumNumberOfDays` set to 1
- In this calendar create an event which happen the day after tomorrow

- See that the event is displayed in the MagicMirror

## Configuration used
```
{
      module: "calendar",
      position: "top_right",
      header: "Calendar",
      config: {
        colored: true,
        coloredSymbolOnly: false,
        maximumNumberOfDays: 1,
        timeFormat: 'relative',
        calendars: [
          {
            url:"<Placeholder>",
            symbol: 'tools',
            timeClass: "bold"
          },
        ]
      }
}
  ``` 