### PR TITLE
Node fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Dont update the DOM when a module is not displayed.
 - Cleaned up jsdoc and tests.
 - Exposed logger as node module for easier access for 3rd party modules
+- Replaced deprecated `request` package with `node-fetch` and `digest-fetch`
 
 ### Removed
 

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -6,7 +6,10 @@
  */
 const Log = require("logger");
 const ical = require("node-ical");
-const request = require("request");
+const fetch = require("node-fetch");
+const digest = require("digest-fetch");
+const https = require("https");
+const base64 = require("base-64");
 
 /**
  * Moment date
@@ -41,387 +44,383 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumEn
 	 * Initiates calendar fetch.
 	 */
 	const fetchCalendar = function () {
+		function getFetcher(url, auth) {
+			const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
+			let headers = {
+				"User-Agent": "Mozilla/5.0 (Node.js " + nodeVersion + ") MagicMirror/" + global.version + " (https://github.com/MichMich/MagicMirror/)"
+			};
+			let httpsAgent = null;
+
+			if (selfSignedCert) {
+				httpsAgent = new https.Agent({
+					rejectUnauthorized: false
+				});
+			}
+			if (auth) {
+				if (auth.method === "bearer") {
+					headers.Authorization = "Bearer " + auth.pass;
+				} else if (auth.method === "digest") {
+					return new digest(auth.user, auth.pass).fetch(url, { headers: headers, httpsAgent: httpsAgent });
+				} else {
+					headers.Authorization = "Basic " + base64.encode(auth.user + ":" + auth.pass);
+				}
+			}
+			return fetch(url, { headers: headers, httpsAgent: httpsAgent });
+		}
 		clearTimeout(reloadTimer);
 		reloadTimer = null;
 
-		const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
-		const opts = {
-			headers: {
-				"User-Agent": "Mozilla/5.0 (Node.js " + nodeVersion + ") MagicMirror/" + global.version + " (https://github.com/MichMich/MagicMirror/)"
-			},
-			gzip: true
-		};
-
-		if (selfSignedCert) {
-			var agentOptions = {
-				rejectUnauthorized: false
-			};
-			opts.agentOptions = agentOptions;
-		}
-
-		if (auth) {
-			if (auth.method === "bearer") {
-				opts.auth = {
-					bearer: auth.pass
-				};
-			} else {
-				opts.auth = {
-					user: auth.user,
-					pass: auth.pass,
-					sendImmediately: auth.method !== "digest"
-				};
-			}
-		}
-
-		request(url, opts, function (err, r, requestData) {
-			if (err) {
-				fetchFailedCallback(self, err);
+		getFetcher(url, auth)
+			.catch((error) => {
+				fetchFailedCallback(self, error);
 				scheduleTimer();
-				return;
-			} else if (r.statusCode !== 200) {
-				fetchFailedCallback(self, r.statusCode + ": " + r.statusMessage);
-				scheduleTimer();
-				return;
-			}
+			})
+			.then((response) => {
+				if (response.status !== 200) {
+					fetchFailedCallback(self, response.statusText);
+					scheduleTimer();
+				}
+				return response;
+			})
+			.then((response) => response.text())
+			.then((responseData) => {
+				let data = [];
 
-			let data = [];
-
-			try {
-				data = ical.parseICS(requestData);
-			} catch (error) {
-				fetchFailedCallback(self, error.message);
-				scheduleTimer();
-				return;
-			}
-
-			Log.debug(" parsed data=" + JSON.stringify(data));
-
-			const newEvents = [];
-
-			// limitFunction doesn't do much limiting, see comment re: the dates array in rrule section below as to why we need to do the filtering ourselves
-			const limitFunction = function (date, i) {
-				return true;
-			};
-
-			const eventDate = function (event, time) {
-				return isFullDayEvent(event) ? moment(event[time], "YYYYMMDD") : moment(new Date(event[time]));
-			};
-			Log.debug("there are " + Object.entries(data).length + " calendar entries");
-			Object.entries(data).forEach(([key, event]) => {
-				const now = new Date();
-				const today = moment().startOf("day").toDate();
-				const future = moment().startOf("day").add(maximumNumberOfDays, "days").subtract(1, "seconds").toDate(); // Subtract 1 second so that events that start on the middle of the night will not repeat.
-				let past = today;
-				Log.debug("have entries ");
-				if (includePastEvents) {
-					past = moment().startOf("day").subtract(maximumNumberOfDays, "days").toDate();
+				try {
+					data = ical.parseICS(responseData);
+				} catch (error) {
+					fetchFailedCallback(self, error.message);
+					scheduleTimer();
 				}
 
-				// FIXME: Ugly fix to solve the facebook birthday issue.
-				// Otherwise, the recurring events only show the birthday for next year.
-				let isFacebookBirthday = false;
-				if (typeof event.uid !== "undefined") {
-					if (event.uid.indexOf("@facebook.com") !== -1) {
-						isFacebookBirthday = true;
+				Log.debug(" parsed data=" + JSON.stringify(data));
+
+				const newEvents = [];
+
+				// limitFunction doesn't do much limiting, see comment re: the dates array in rrule section below as to why we need to do the filtering ourselves
+				const limitFunction = function (date, i) {
+					return true;
+				};
+
+				const eventDate = function (event, time) {
+					return isFullDayEvent(event) ? moment(event[time], "YYYYMMDD") : moment(new Date(event[time]));
+				};
+				Log.debug("there are " + Object.entries(data).length + " calendar entries");
+				Object.entries(data).forEach(([key, event]) => {
+					const now = new Date();
+					const today = moment().startOf("day").toDate();
+					const future = moment().startOf("day").add(maximumNumberOfDays, "days").subtract(1, "seconds").toDate(); // Subtract 1 second so that events that start on the middle of the night will not repeat.
+					let past = today;
+					Log.debug("have entries ");
+					if (includePastEvents) {
+						past = moment().startOf("day").subtract(maximumNumberOfDays, "days").toDate();
 					}
-				}
 
-				if (event.type === "VEVENT") {
-					let startDate = eventDate(event, "start");
-					let endDate;
+					// FIXME: Ugly fix to solve the facebook birthday issue.
+					// Otherwise, the recurring events only show the birthday for next year.
+					let isFacebookBirthday = false;
+					if (typeof event.uid !== "undefined") {
+						if (event.uid.indexOf("@facebook.com") !== -1) {
+							isFacebookBirthday = true;
+						}
+					}
 
-					Log.debug("\nevent=" + JSON.stringify(event));
-					if (typeof event.end !== "undefined") {
-						endDate = eventDate(event, "end");
-					} else if (typeof event.duration !== "undefined") {
-						endDate = startDate.clone().add(moment.duration(event.duration));
-					} else {
-						if (!isFacebookBirthday) {
-							// make copy of start date, separate storage area
-							endDate = moment(startDate.format("x"), "x");
+					if (event.type === "VEVENT") {
+						let startDate = eventDate(event, "start");
+						let endDate;
+
+						Log.debug("\nevent=" + JSON.stringify(event));
+						if (typeof event.end !== "undefined") {
+							endDate = eventDate(event, "end");
+						} else if (typeof event.duration !== "undefined") {
+							endDate = startDate.clone().add(moment.duration(event.duration));
 						} else {
-							endDate = moment(startDate).add(1, "days");
-						}
-					}
-
-					Log.debug(" start=" + startDate.toDate() + " end=" + endDate.toDate());
-
-					// calculate the duration of the event for use with recurring events.
-					let duration = parseInt(endDate.format("x")) - parseInt(startDate.format("x"));
-
-					if (event.start.length === 8) {
-						startDate = startDate.startOf("day");
-					}
-
-					const title = getTitleFromEvent(event);
-
-					let excluded = false,
-						dateFilter = null;
-
-					for (let f in excludedEvents) {
-						let filter = excludedEvents[f],
-							testTitle = title.toLowerCase(),
-							until = null,
-							useRegex = false,
-							regexFlags = "g";
-
-						if (filter instanceof Object) {
-							if (typeof filter.until !== "undefined") {
-								until = filter.until;
-							}
-
-							if (typeof filter.regex !== "undefined") {
-								useRegex = filter.regex;
-							}
-
-							// If additional advanced filtering is added in, this section
-							// must remain last as we overwrite the filter object with the
-							// filterBy string
-							if (filter.caseSensitive) {
-								filter = filter.filterBy;
-								testTitle = title;
-							} else if (useRegex) {
-								filter = filter.filterBy;
-								testTitle = title;
-								regexFlags += "i";
+							if (!isFacebookBirthday) {
+								// make copy of start date, separate storage area
+								endDate = moment(startDate.format("x"), "x");
 							} else {
-								filter = filter.filterBy.toLowerCase();
+								endDate = moment(startDate).add(1, "days");
 							}
-						} else {
-							filter = filter.toLowerCase();
 						}
 
-						if (testTitleByFilter(testTitle, filter, useRegex, regexFlags)) {
-							if (until) {
-								dateFilter = until;
-							} else {
-								excluded = true;
-							}
-							break;
-						}
-					}
+						Log.debug(" start=" + startDate.toDate() + " end=" + endDate.toDate());
 
-					if (excluded) {
-						return;
-					}
+						// calculate the duration of the event for use with recurring events.
+						let duration = parseInt(endDate.format("x")) - parseInt(startDate.format("x"));
 
-					const location = event.location || false;
-					const geo = event.geo || false;
-					const description = event.description || false;
-
-					if (typeof event.rrule !== "undefined" && event.rrule !== null && !isFacebookBirthday) {
-						const rule = event.rrule;
-						let addedEvents = 0;
-
-						const pastMoment = moment(past);
-						const futureMoment = moment(future);
-
-						// can cause problems with e.g. birthdays before 1900
-						if ((rule.options && rule.origOptions && rule.origOptions.dtstart && rule.origOptions.dtstart.getFullYear() < 1900) || (rule.options && rule.options.dtstart && rule.options.dtstart.getFullYear() < 1900)) {
-							rule.origOptions.dtstart.setYear(1900);
-							rule.options.dtstart.setYear(1900);
+						if (event.start.length === 8) {
+							startDate = startDate.startOf("day");
 						}
 
-						// For recurring events, get the set of start dates that fall within the range
-						// of dates we're looking for.
-						// kblankenship1989 - to fix issue #1798, converting all dates to locale time first, then converting back to UTC time
-						let pastLocal = 0;
-						let futureLocal = 0;
-						if (isFullDayEvent(event)) {
-							// if full day event, only use the date part of the ranges
-							pastLocal = pastMoment.toDate();
-							futureLocal = futureMoment.toDate();
-						} else {
-							// if we want past events
-							if (includePastEvents) {
-								// use the calculated past time for the between from
-								pastLocal = pastMoment.toDate();
-							} else {
-								// otherwise use NOW.. cause we shouldnt use any before now
-								pastLocal = moment().toDate(); //now
-							}
-							futureLocal = futureMoment.toDate(); // future
-						}
-						Log.debug(" between=" + pastLocal + " to " + futureLocal);
-						const dates = rule.between(pastLocal, futureLocal, true, limitFunction);
-						Log.debug("title=" + event.summary + " dates=" + JSON.stringify(dates));
-						// The "dates" array contains the set of dates within our desired date range range that are valid
-						// for the recurrence rule. *However*, it's possible for us to have a specific recurrence that
-						// had its date changed from outside the range to inside the range.  For the time being,
-						// we'll handle this by adding *all* recurrence entries into the set of dates that we check,
-						// because the logic below will filter out any recurrences that don't actually belong within
-						// our display range.
-						// Would be great if there was a better way to handle this.
-						if (event.recurrences !== undefined) {
-							for (let r in event.recurrences) {
-								// Only add dates that weren't already in the range we added from the rrule so that
-								// we don"t double-add those events.
-								if (moment(new Date(r)).isBetween(pastMoment, futureMoment) !== true) {
-									dates.push(new Date(r));
+						const title = getTitleFromEvent(event);
+
+						let excluded = false,
+							dateFilter = null;
+
+						for (let f in excludedEvents) {
+							let filter = excludedEvents[f],
+								testTitle = title.toLowerCase(),
+								until = null,
+								useRegex = false,
+								regexFlags = "g";
+
+							if (filter instanceof Object) {
+								if (typeof filter.until !== "undefined") {
+									until = filter.until;
 								}
+
+								if (typeof filter.regex !== "undefined") {
+									useRegex = filter.regex;
+								}
+
+								// If additional advanced filtering is added in, this section
+								// must remain last as we overwrite the filter object with the
+								// filterBy string
+								if (filter.caseSensitive) {
+									filter = filter.filterBy;
+									testTitle = title;
+								} else if (useRegex) {
+									filter = filter.filterBy;
+									testTitle = title;
+									regexFlags += "i";
+								} else {
+									filter = filter.filterBy.toLowerCase();
+								}
+							} else {
+								filter = filter.toLowerCase();
+							}
+
+							if (testTitleByFilter(testTitle, filter, useRegex, regexFlags)) {
+								if (until) {
+									dateFilter = until;
+								} else {
+									excluded = true;
+								}
+								break;
 							}
 						}
-						// Loop through the set of date entries to see which recurrences should be added to our event list.
-						for (let d in dates) {
-							let date = dates[d];
-							// ical.js started returning recurrences and exdates as ISOStrings without time information.
-							// .toISOString().substring(0,10) is the method they use to calculate keys, so we'll do the same
-							// (see https://github.com/peterbraden/ical.js/pull/84 )
-							const dateKey = date.toISOString().substring(0, 10);
-							let curEvent = event;
-							let showRecurrence = true;
 
-							// for full day events, the time might be off from RRULE/Luxon problem
+						if (excluded) {
+							return;
+						}
+
+						const location = event.location || false;
+						const geo = event.geo || false;
+						const description = event.description || false;
+
+						if (typeof event.rrule !== "undefined" && event.rrule !== null && !isFacebookBirthday) {
+							const rule = event.rrule;
+							let addedEvents = 0;
+
+							const pastMoment = moment(past);
+							const futureMoment = moment(future);
+
+							// can cause problems with e.g. birthdays before 1900
+							if ((rule.options && rule.origOptions && rule.origOptions.dtstart && rule.origOptions.dtstart.getFullYear() < 1900) || (rule.options && rule.options.dtstart && rule.options.dtstart.getFullYear() < 1900)) {
+								rule.origOptions.dtstart.setYear(1900);
+								rule.options.dtstart.setYear(1900);
+							}
+
+							// For recurring events, get the set of start dates that fall within the range
+							// of dates we're looking for.
+							// kblankenship1989 - to fix issue #1798, converting all dates to locale time first, then converting back to UTC time
+							let pastLocal = 0;
+							let futureLocal = 0;
 							if (isFullDayEvent(event)) {
-								Log.debug("fullday");
-								// if the offset is  negative, east of GMT where the problem is
-								if (date.getTimezoneOffset() < 0) {
-									// get the offset of today where we are processing
-									// this will be the correction we need to apply
-									let nowOffset = new Date().getTimezoneOffset();
-									Log.debug("now offset is " + nowOffset);
-									// reduce the time by the offset
-									Log.debug(" recurring date is " + date + " offset is " + date.getTimezoneOffset());
-									// apply the correction to the date/time to get it UTC relative
-									date = new Date(date.getTime() - Math.abs(nowOffset) * 60000);
-									// the duration was calculated way back at the top before we could correct the start time..
-									// fix it for this event entry
-									duration = 24 * 60 * 60 * 1000;
-									Log.debug("new recurring date is " + date);
+								// if full day event, only use the date part of the ranges
+								pastLocal = pastMoment.toDate();
+								futureLocal = futureMoment.toDate();
+							} else {
+								// if we want past events
+								if (includePastEvents) {
+									// use the calculated past time for the between from
+									pastLocal = pastMoment.toDate();
+								} else {
+									// otherwise use NOW.. cause we shouldnt use any before now
+									pastLocal = moment().toDate(); //now
+								}
+								futureLocal = futureMoment.toDate(); // future
+							}
+							Log.debug(" between=" + pastLocal + " to " + futureLocal);
+							const dates = rule.between(pastLocal, futureLocal, true, limitFunction);
+							Log.debug("title=" + event.summary + " dates=" + JSON.stringify(dates));
+							// The "dates" array contains the set of dates within our desired date range range that are valid
+							// for the recurrence rule. *However*, it's possible for us to have a specific recurrence that
+							// had its date changed from outside the range to inside the range.  For the time being,
+							// we'll handle this by adding *all* recurrence entries into the set of dates that we check,
+							// because the logic below will filter out any recurrences that don't actually belong within
+							// our display range.
+							// Would be great if there was a better way to handle this.
+							if (event.recurrences !== undefined) {
+								for (let r in event.recurrences) {
+									// Only add dates that weren't already in the range we added from the rrule so that
+									// we don"t double-add those events.
+									if (moment(new Date(r)).isBetween(pastMoment, futureMoment) !== true) {
+										dates.push(new Date(r));
+									}
 								}
 							}
-							startDate = moment(date);
+							// Loop through the set of date entries to see which recurrences should be added to our event list.
+							for (let d in dates) {
+								let date = dates[d];
+								// ical.js started returning recurrences and exdates as ISOStrings without time information.
+								// .toISOString().substring(0,10) is the method they use to calculate keys, so we'll do the same
+								// (see https://github.com/peterbraden/ical.js/pull/84 )
+								const dateKey = date.toISOString().substring(0, 10);
+								let curEvent = event;
+								let showRecurrence = true;
 
-							let adjustDays = getCorrection(event, date);
+								// for full day events, the time might be off from RRULE/Luxon problem
+								if (isFullDayEvent(event)) {
+									Log.debug("fullday");
+									// if the offset is  negative, east of GMT where the problem is
+									if (date.getTimezoneOffset() < 0) {
+										// get the offset of today where we are processing
+										// this will be the correction we need to apply
+										let nowOffset = new Date().getTimezoneOffset();
+										Log.debug("now offset is " + nowOffset);
+										// reduce the time by the offset
+										Log.debug(" recurring date is " + date + " offset is " + date.getTimezoneOffset());
+										// apply the correction to the date/time to get it UTC relative
+										date = new Date(date.getTime() - Math.abs(nowOffset) * 60000);
+										// the duration was calculated way back at the top before we could correct the start time..
+										// fix it for this event entry
+										duration = 24 * 60 * 60 * 1000;
+										Log.debug("new recurring date is " + date);
+									}
+								}
+								startDate = moment(date);
 
-							// For each date that we're checking, it's possible that there is a recurrence override for that one day.
-							if (curEvent.recurrences !== undefined && curEvent.recurrences[dateKey] !== undefined) {
-								// We found an override, so for this recurrence, use a potentially different title, start date, and duration.
-								curEvent = curEvent.recurrences[dateKey];
-								startDate = moment(curEvent.start);
-								duration = parseInt(moment(curEvent.end).format("x")) - parseInt(startDate.format("x"));
+								let adjustDays = getCorrection(event, date);
+
+								// For each date that we're checking, it's possible that there is a recurrence override for that one day.
+								if (curEvent.recurrences !== undefined && curEvent.recurrences[dateKey] !== undefined) {
+									// We found an override, so for this recurrence, use a potentially different title, start date, and duration.
+									curEvent = curEvent.recurrences[dateKey];
+									startDate = moment(curEvent.start);
+									duration = parseInt(moment(curEvent.end).format("x")) - parseInt(startDate.format("x"));
+								}
+								// If there's no recurrence override, check for an exception date.  Exception dates represent exceptions to the rule.
+								else if (curEvent.exdate !== undefined && curEvent.exdate[dateKey] !== undefined) {
+									// This date is an exception date, which means we should skip it in the recurrence pattern.
+									showRecurrence = false;
+								}
+								Log.debug("duration=" + duration);
+
+								endDate = moment(parseInt(startDate.format("x")) + duration, "x");
+								if (startDate.format("x") === endDate.format("x")) {
+									endDate = endDate.endOf("day");
+								}
+
+								const recurrenceTitle = getTitleFromEvent(curEvent);
+
+								// If this recurrence ends before the start of the date range, or starts after the end of the date range, don"t add
+								// it to the event list.
+								if (endDate.isBefore(past) || startDate.isAfter(future)) {
+									showRecurrence = false;
+								}
+
+								if (timeFilterApplies(now, endDate, dateFilter)) {
+									showRecurrence = false;
+								}
+
+								if (showRecurrence === true) {
+									Log.debug("saving event =" + description);
+									addedEvents++;
+									newEvents.push({
+										title: recurrenceTitle,
+										startDate: (adjustDays ? (adjustDays > 0 ? startDate.add(adjustDays, "hours") : startDate.subtract(Math.abs(adjustDays), "hours")) : startDate).format("x"),
+										endDate: (adjustDays ? (adjustDays > 0 ? endDate.add(adjustDays, "hours") : endDate.subtract(Math.abs(adjustDays), "hours")) : endDate).format("x"),
+										fullDayEvent: isFullDayEvent(event),
+										recurringEvent: true,
+										class: event.class,
+										firstYear: event.start.getFullYear(),
+										location: location,
+										geo: geo,
+										description: description
+									});
+								}
 							}
-							// If there's no recurrence override, check for an exception date.  Exception dates represent exceptions to the rule.
-							else if (curEvent.exdate !== undefined && curEvent.exdate[dateKey] !== undefined) {
-								// This date is an exception date, which means we should skip it in the recurrence pattern.
-								showRecurrence = false;
+							// end recurring event parsing
+						} else {
+							// Single event.
+							const fullDayEvent = isFacebookBirthday ? true : isFullDayEvent(event);
+							// Log.debug("full day event")
+
+							if (includePastEvents) {
+								// Past event is too far in the past, so skip.
+								if (endDate < past) {
+									return;
+								}
+							} else {
+								// It's not a fullday event, and it is in the past, so skip.
+								if (!fullDayEvent && endDate < new Date()) {
+									return;
+								}
+
+								// It's a fullday event, and it is before today, So skip.
+								if (fullDayEvent && endDate <= today) {
+									return;
+								}
 							}
-							Log.debug("duration=" + duration);
 
-							endDate = moment(parseInt(startDate.format("x")) + duration, "x");
-							if (startDate.format("x") === endDate.format("x")) {
-								endDate = endDate.endOf("day");
-							}
-
-							const recurrenceTitle = getTitleFromEvent(curEvent);
-
-							// If this recurrence ends before the start of the date range, or starts after the end of the date range, don"t add
-							// it to the event list.
-							if (endDate.isBefore(past) || startDate.isAfter(future)) {
-								showRecurrence = false;
+							// It exceeds the maximumNumberOfDays limit, so skip.
+							if (startDate > future) {
+								return;
 							}
 
 							if (timeFilterApplies(now, endDate, dateFilter)) {
-								showRecurrence = false;
-							}
-
-							if (showRecurrence === true) {
-								Log.debug("saving event =" + description);
-								addedEvents++;
-								newEvents.push({
-									title: recurrenceTitle,
-									startDate: (adjustDays ? (adjustDays > 0 ? startDate.add(adjustDays, "hours") : startDate.subtract(Math.abs(adjustDays), "hours")) : startDate).format("x"),
-									endDate: (adjustDays ? (adjustDays > 0 ? endDate.add(adjustDays, "hours") : endDate.subtract(Math.abs(adjustDays), "hours")) : endDate).format("x"),
-									fullDayEvent: isFullDayEvent(event),
-									recurringEvent: true,
-									class: event.class,
-									firstYear: event.start.getFullYear(),
-									location: location,
-									geo: geo,
-									description: description
-								});
-							}
-						}
-						// end recurring event parsing
-					} else {
-						// Single event.
-						const fullDayEvent = isFacebookBirthday ? true : isFullDayEvent(event);
-						// Log.debug("full day event")
-
-						if (includePastEvents) {
-							// Past event is too far in the past, so skip.
-							if (endDate < past) {
-								return;
-							}
-						} else {
-							// It's not a fullday event, and it is in the past, so skip.
-							if (!fullDayEvent && endDate < new Date()) {
 								return;
 							}
 
-							// It's a fullday event, and it is before today, So skip.
-							if (fullDayEvent && endDate <= today) {
-								return;
+							// Adjust start date so multiple day events will be displayed as happening today even though they started some days ago already
+							if (fullDayEvent && startDate <= today) {
+								startDate = moment(today);
 							}
+							// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)
+							if (fullDayEvent && startDate.format("x") === endDate.format("x")) {
+								endDate = endDate.endOf("day");
+							}
+							// get correction for date saving and dst change between now and then
+							let adjustDays = getCorrection(event, startDate.toDate());
+							// Every thing is good. Add it to the list.
+							newEvents.push({
+								title: title,
+								startDate: (adjustDays ? (adjustDays > 0 ? startDate.add(adjustDays, "hours") : startDate.subtract(Math.abs(adjustDays), "hours")) : startDate).format("x"),
+								endDate: (adjustDays ? (adjustDays > 0 ? endDate.add(adjustDays, "hours") : endDate.subtract(Math.abs(adjustDays), "hours")) : endDate).format("x"),
+								fullDayEvent: fullDayEvent,
+								class: event.class,
+								location: location,
+								geo: geo,
+								description: description
+							});
 						}
-
-						// It exceeds the maximumNumberOfDays limit, so skip.
-						if (startDate > future) {
-							return;
-						}
-
-						if (timeFilterApplies(now, endDate, dateFilter)) {
-							return;
-						}
-
-						// Adjust start date so multiple day events will be displayed as happening today even though they started some days ago already
-						if (fullDayEvent && startDate <= today) {
-							startDate = moment(today);
-						}
-						// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)
-						if (fullDayEvent && startDate.format("x") === endDate.format("x")) {
-							endDate = endDate.endOf("day");
-						}
-						// get correction for date saving and dst change between now and then
-						let adjustDays = getCorrection(event, startDate.toDate());
-						// Every thing is good. Add it to the list.
-						newEvents.push({
-							title: title,
-							startDate: (adjustDays ? (adjustDays > 0 ? startDate.add(adjustDays, "hours") : startDate.subtract(Math.abs(adjustDays), "hours")) : startDate).format("x"),
-							endDate: (adjustDays ? (adjustDays > 0 ? endDate.add(adjustDays, "hours") : endDate.subtract(Math.abs(adjustDays), "hours")) : endDate).format("x"),
-							fullDayEvent: fullDayEvent,
-							class: event.class,
-							location: location,
-							geo: geo,
-							description: description
-						});
 					}
+				});
+
+				newEvents.sort(function (a, b) {
+					return a.startDate - b.startDate;
+				});
+
+				// include up to maximumEntries current or upcoming events
+				// If past events should be included, include all past events
+				const now = moment();
+				var entries = 0;
+				events = [];
+				for (let ne of newEvents) {
+					if (moment(ne.endDate, "x").isBefore(now)) {
+						if (includePastEvents) events.push(ne);
+						continue;
+					}
+					entries++;
+					// If max events has been saved, skip the rest
+					if (entries > maximumEntries) break;
+					events.push(ne);
 				}
+
+				self.broadcastEvents();
+				scheduleTimer();
 			});
-
-			newEvents.sort(function (a, b) {
-				return a.startDate - b.startDate;
-			});
-
-			// include up to maximumEntries current or upcoming events
-			// If past events should be included, include all past events
-			const now = moment();
-			var entries = 0;
-			events = [];
-			for (let ne of newEvents) {
-				if (moment(ne.endDate, "x").isBefore(now)) {
-					if (includePastEvents) events.push(ne);
-					continue;
-				}
-				entries++;
-				// If max events has been saved, skip the rest
-				if (entries > maximumEntries) break;
-				events.push(ne);
-			}
-
-			self.broadcastEvents();
-			scheduleTimer();
-		});
 	};
 
 	/*

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -6,7 +6,7 @@
  */
 const Log = require("logger");
 const FeedMe = require("feedme");
-const request = require("request");
+const fetch = require("node-fetch");
 const iconv = require("iconv-lite");
 
 /**
@@ -79,22 +79,20 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 		});
 
 		const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
-		const opts = {
-			headers: {
-				"User-Agent": "Mozilla/5.0 (Node.js " + nodeVersion + ") MagicMirror/" + global.version + " (https://github.com/MichMich/MagicMirror/)",
-				"Cache-Control": "max-age=0, no-cache, no-store, must-revalidate",
-				Pragma: "no-cache"
-			},
-			encoding: null
+		const headers = {
+			"User-Agent": "Mozilla/5.0 (Node.js " + nodeVersion + ") MagicMirror/" + global.version + " (https://github.com/MichMich/MagicMirror/)",
+			"Cache-Control": "max-age=0, no-cache, no-store, must-revalidate",
+			Pragma: "no-cache"
 		};
 
-		request(url, opts)
-			.on("error", function (error) {
+		fetch(url, { headers: headers })
+			.catch((error) => {
 				fetchFailedCallback(self, error);
 				scheduleTimer();
 			})
-			.pipe(iconv.decodeStream(encoding))
-			.pipe(parser);
+			.then((res) => {
+				res.body.pipe(iconv.decodeStream(encoding)).pipe(parser);
+			});
 	};
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,165 +5,213 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-			"dev": true,
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+			"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 			"requires": {
 				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+			"integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+			"dev": true
+		},
 		"@babel/core": {
-			"version": "7.12.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
-			"integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.8.tgz",
+			"integrity": "sha512-oYapIySGw1zGhEFRd6lzWNLWFX2s5dA/jm+Pw/+59ZdXtjyIuwlXbrId22Md0rgZVop+aVoqow2riXhBLNyuQg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.1",
-				"@babel/helper-module-transforms": "^7.12.1",
-				"@babel/helpers": "^7.12.1",
-				"@babel/parser": "^7.12.3",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.0",
+				"@babel/helper-compilation-targets": "^7.13.8",
+				"@babel/helper-module-transforms": "^7.13.0",
+				"@babel/helpers": "^7.13.0",
+				"@babel/parser": "^7.13.4",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
+				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
 				"lodash": "^4.17.19",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
+				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-			"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+			"version": "7.13.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+			"integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5",
+				"@babel/types": "^7.13.0",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.8.tgz",
+			"integrity": "sha512-pBljUGC1y3xKLn1nrx2eAhurLMA8OqBtBP/JwG4U8skN7kf8/aqwwxpV1N6T0e7r6+7uNitIa/fUxPFagSXp3A==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.13.8",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-			"integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/helper-get-function-arity": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-			"integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-			"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
+			"integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.13.0"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+			"integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.5"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
-			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
+			"integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/helper-replace-supers": "^7.12.1",
-				"@babel/helper-simple-access": "^7.12.1",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/helper-validator-identifier": "^7.10.4",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.1",
-				"@babel/types": "^7.12.1",
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/helper-replace-supers": "^7.13.0",
+				"@babel/helper-simple-access": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/helper-validator-identifier": "^7.12.11",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0",
 				"lodash": "^4.17.19"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-			"integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-			"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
+			"integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.12.1",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/helper-member-expression-to-functions": "^7.13.0",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
-			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
+			"integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
-			"integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
+				"@babel/types": "^7.12.13"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+			"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==",
+			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
-			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
+			"integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.12.5",
-				"@babel/types": "^7.12.5"
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.0"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"version": "7.13.8",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.8.tgz",
+			"integrity": "sha512-4vrIhfJyfNf+lCtXC2ck1rKSzDwciqF7IWFhXXrSOUC2O5DrVp+w4c6ed4AllTxhTkUP5x2tYj41VaxdVMMRDw==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.12.11",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -186,6 +234,29 @@
 						"supports-color": "^5.3.0"
 					}
 				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -197,39 +268,59 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-			"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+			"version": "7.13.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.9.tgz",
+			"integrity": "sha512-nEUfRiARCcaVo3ny3ZQjURjHQZUo/JkEw7rLlSZy/psWGnvwXFtPcr6jb7Yb41DVW5LTe6KRq9LGleRNsg1Frw==",
 			"dev": true
 		},
 		"@babel/template": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-			"integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/parser": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/code-frame": "^7.12.13",
+				"@babel/parser": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-			"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
+			"integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.12.5",
-				"@babel/helper-function-name": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/parser": "^7.12.5",
-				"@babel/types": "^7.12.5",
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.13.0",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/parser": "^7.13.0",
+				"@babel/types": "^7.13.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.19"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.13",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+					"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.12.13"
+					}
+				},
 				"globals": {
 					"version": "11.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -239,24 +330,23 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.12.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-			"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
+			"integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/helper-validator-identifier": "^7.12.11",
 				"lodash": "^4.17.19",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
 		"@electron/get": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.3.tgz",
-			"integrity": "sha512-NFwSnVZQK7dhOYF1NQCt+HGqgL1aNdj0LUSx75uCqnZJqyiWCVdAMFV4b4/kC8HjUJAnsvdSEmjEt4G2qNQ9+Q==",
+			"version": "1.12.4",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
+			"integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
 			"requires": {
 				"debug": "^4.1.1",
 				"env-paths": "^2.2.0",
-				"filenamify": "^4.1.0",
 				"fs-extra": "^8.1.0",
 				"global-agent": "^2.0.2",
 				"global-tunnel-ng": "^2.7.1",
@@ -264,19 +354,12 @@
 				"progress": "^2.0.3",
 				"semver": "^6.2.0",
 				"sumchecker": "^3.0.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
-			"integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+			"integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
@@ -285,7 +368,6 @@
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^3.13.1",
-				"lodash": "^4.17.20",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
 			}
@@ -319,11 +401,32 @@
 						"path-exists": "^4.0.0"
 					}
 				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
 				},
 				"resolve-from": {
 					"version": "5.0.0",
@@ -334,9 +437,9 @@
 			}
 		},
 		"@istanbuljs/schema": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
-			"integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
 			"dev": true
 		},
 		"@kwsites/file-exists": {
@@ -509,9 +612,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "12.19.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-			"integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+			"version": "12.20.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
+			"integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -526,9 +629,9 @@
 			"dev": true
 		},
 		"@types/puppeteer": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.2.tgz",
-			"integrity": "sha512-yjbHoKjZFOGqA6bIEI2dfBE5UPqU0YGWzP+ipDVP1iGzmlhksVKTBVZfT3Aj3wnvmcJ2PQ9zcncwOwyavmafBw==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.3.tgz",
+			"integrity": "sha512-3nE8YgR9DIsgttLW+eJf6mnXxq8Ge+27m5SU3knWmrlfl6+KOG0Bf9f7Ua7K+C4BnaTMAh3/UpySqdAYvrsvjg==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
@@ -601,57 +704,6 @@
 				"loglevel": "^1.6.0",
 				"loglevel-plugin-prefix": "^0.8.4",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"@wdio/protocols": {
@@ -733,14 +785,6 @@
 			"requires": {
 				"clean-stack": "^2.0.0",
 				"indent-string": "^4.0.0"
-			},
-			"dependencies": {
-				"indent-string": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-					"dev": true
-				}
 			}
 		},
 		"ajv": {
@@ -765,11 +809,11 @@
 			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 		},
 		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "^2.0.1"
 			}
 		},
 		"anymatch": {
@@ -964,6 +1008,11 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base-64": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+			"integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+		},
 		"base64-arraybuffer": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
@@ -1004,9 +1053,9 @@
 			"dev": true
 		},
 		"bl": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-			"integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 			"dev": true,
 			"requires": {
 				"buffer": "^5.5.0",
@@ -1216,13 +1265,19 @@
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
+				},
+				"quick-lru": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+					"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+					"dev": true
 				}
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001192",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001192.tgz",
-			"integrity": "sha512-63OrUnwJj5T1rUmoyqYTdRWBqFFxZFlyZnRRjDR8NSUQFB6A+j/uBORU/SyJ5WzDLg4SPiZH40hQCBNdZ/jmAw==",
+			"version": "1.0.30001196",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
+			"integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
 			"dev": true
 		},
 		"caseless": {
@@ -1231,16 +1286,16 @@
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"chai": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.0.tgz",
-			"integrity": "sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.3.tgz",
+			"integrity": "sha512-MPSLOZwxxnA0DhLE84klnGPojWFK5KuhP7/j5dTsxpr2S3XlkqJP5WbyYl1gCTWvG2Z5N+HD4F472WsbEZL6Pw==",
 			"dev": true,
 			"requires": {
 				"assertion-error": "^1.1.0",
 				"check-error": "^1.0.2",
 				"deep-eql": "^3.0.1",
 				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
+				"pathval": "^1.1.1",
 				"type-detect": "^4.0.5"
 			}
 		},
@@ -1254,13 +1309,12 @@
 			}
 		},
 		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+			"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
 			}
 		},
 		"character-entities": {
@@ -1321,6 +1375,14 @@
 				"lighthouse-logger": "^1.0.0",
 				"mkdirp": "^0.5.3",
 				"rimraf": "^3.0.2"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				}
 			}
 		},
 		"ci-info": {
@@ -1349,25 +1411,6 @@
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^7.0.0"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-					"integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				}
 			}
 		},
 		"clone-regexp": {
@@ -1388,17 +1431,17 @@
 			}
 		},
 		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "~1.1.4"
 			}
 		},
 		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"colorette": {
 			"version": "1.2.2",
@@ -1443,9 +1486,9 @@
 			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"compress-commons": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
-			"integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.0.tgz",
+			"integrity": "sha512-ofaaLqfraD1YRTkrRKPCrGJ1pFeDG/MVCkVVV2FNGeWquSlqw5wOrwOfPQ1xF2u+blpeWASie5EubHz+vsNIgA==",
 			"dev": true,
 			"requires": {
 				"buffer-crc32": "^0.2.13",
@@ -1495,12 +1538,12 @@
 			}
 		},
 		"console-stamp": {
-			"version": "3.0.0-rc4.2",
-			"resolved": "https://registry.npmjs.org/console-stamp/-/console-stamp-3.0.0-rc4.2.tgz",
-			"integrity": "sha512-ncGYdZsfDbBYYiaPXr9NHfZbSSkoVzYyh8nHji9/3ovw35Jn4ozo0btcirtfIznXT4xNgBQW+IyTVLISnNumdQ==",
+			"version": "3.0.0-rc4.3",
+			"resolved": "https://registry.npmjs.org/console-stamp/-/console-stamp-3.0.0-rc4.3.tgz",
+			"integrity": "sha512-NE9IGO0q+gVReZqX+ArFZOKCVPIOIef6huPNxlvsjYahHL9rVYuBUBkK0hLOlW90jH2Y2yo/Ubm2vDNym37WBw==",
 			"requires": {
-				"chalk": "^2.4.2",
-				"dateformat": "^3.0.3"
+				"chalk": "^4.1.0",
+				"dateformat": "^4.0.0"
 			}
 		},
 		"content-disposition": {
@@ -1536,9 +1579,9 @@
 			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
 		},
 		"core-js": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-			"integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+			"integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
 			"optional": true
 		},
 		"core-util-is": {
@@ -1566,26 +1609,6 @@
 				"parse-json": "^5.0.0",
 				"path-type": "^4.0.0",
 				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"parse-json": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-					"integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
-					"dev": true,
-					"requires": {
-						"@babel/code-frame": "^7.0.0",
-						"error-ex": "^1.3.1",
-						"json-parse-even-better-errors": "^2.3.0",
-						"lines-and-columns": "^1.1.6"
-					}
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
-				}
 			}
 		},
 		"crc-32": {
@@ -1599,9 +1622,9 @@
 			}
 		},
 		"crc32-stream": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
-			"integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
+			"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
 			"dev": true,
 			"requires": {
 				"crc-32": "^1.2.0",
@@ -1630,6 +1653,11 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"crypto-js": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+			"integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
 		},
 		"css-shorthand-properties": {
 			"version": "1.1.1",
@@ -1689,53 +1717,25 @@
 				"abab": "^2.0.3",
 				"whatwg-mimetype": "^2.3.0",
 				"whatwg-url": "^8.0.0"
-			},
-			"dependencies": {
-				"tr46": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-					"dev": true,
-					"requires": {
-						"punycode": "^2.1.1"
-					}
-				},
-				"webidl-conversions": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^2.0.2",
-						"webidl-conversions": "^6.1.0"
-					}
-				}
 			}
 		},
 		"dateformat": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.5.1.tgz",
+			"integrity": "sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q=="
 		},
 		"debug": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-			"integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
 		},
 		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+			"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
 			"dev": true
 		},
 		"decamelize-keys": {
@@ -1748,6 +1748,12 @@
 				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -1797,14 +1803,6 @@
 			"dev": true,
 			"requires": {
 				"strip-bom": "^4.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-					"dev": true
-				}
 			}
 		},
 		"defer-to-connect": {
@@ -1872,10 +1870,19 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
 			"dev": true
+		},
+		"digest-fetch": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.1.6.tgz",
+			"integrity": "sha512-CFNX4+TkxecH2L2bw6tI9RAJ7xQuE3j/fDxZe6HOyazR5lhGhF76Pxhb0/Lam3vtGsZPop3RMXydWsNZ//TJwA==",
+			"requires": {
+				"base-64": "^0.1.0",
+				"crypto-js": "^3.1.9-1"
+			}
 		},
 		"dir-glob": {
 			"version": "3.0.1",
@@ -2034,16 +2041,15 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.675",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.675.tgz",
-			"integrity": "sha512-GEQw+6dNWjueXGkGfjgm7dAMtXfEqrfDG3uWcZdeaD4cZ3dKYdPRQVruVXQRXtPLtOr5GNVVlNLRMChOZ611pQ==",
+			"version": "1.3.681",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.681.tgz",
+			"integrity": "sha512-W6uYvSUTHuyX2DZklIESAqx57jfmGjUkd7Z3RWqLdj9Mmt39ylhBuvFXlskQnvBHj0MYXIeQI+mjiwVddZLSvA==",
 			"dev": true
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"encodeurl": {
 			"version": "1.0.2",
@@ -2076,19 +2082,6 @@
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
 					"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ws": {
-					"version": "7.4.3",
-					"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-					"integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
 				}
 			}
 		},
@@ -2145,9 +2138,9 @@
 			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
 		},
 		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 		},
 		"escodegen": {
 			"version": "1.14.3",
@@ -2192,13 +2185,6 @@
 					"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 					"dev": true
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"optional": true
-				},
 				"type-check": {
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -2211,12 +2197,12 @@
 			}
 		},
 		"eslint": {
-			"version": "7.20.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
-			"integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
+			"version": "7.21.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.21.0.tgz",
+			"integrity": "sha512-W2aJbXpMNofUp0ztQaF40fveSsJBjlSCSWpy//gzfTvwC+USs/nceBrKmlJOiM8r1bLwP2EuYkCqArn/6QTIgg==",
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.3.0",
+				"@eslint/eslintrc": "^0.4.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
 				"cross-spawn": "^7.0.2",
@@ -2229,7 +2215,7 @@
 				"espree": "^7.3.1",
 				"esquery": "^1.4.0",
 				"esutils": "^2.0.2",
-				"file-entry-cache": "^6.0.0",
+				"file-entry-cache": "^6.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^5.0.0",
 				"globals": "^12.1.0",
@@ -2254,63 +2240,12 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.12.11",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-					"requires": {
-						"@babel/highlight": "^7.10.4"
-					}
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
 				"semver": {
 					"version": "7.3.4",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
 					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"requires": {
 						"lru-cache": "^6.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"requires": {
-						"has-flag": "^4.0.0"
 					}
 				}
 			}
@@ -2336,15 +2271,6 @@
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
 				"semver": {
 					"version": "7.3.4",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -2460,6 +2386,34 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"execa": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^7.0.0",
+				"get-stream": "^5.0.0",
+				"human-signals": "^1.1.1",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.0",
+				"onetime": "^5.1.0",
+				"signal-exit": "^3.0.2",
+				"strip-final-newline": "^2.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				}
+			}
 		},
 		"execall": {
 			"version": "2.0.0",
@@ -2662,21 +2616,6 @@
 				"flat-cache": "^3.0.4"
 			}
 		},
-		"filename-reserved-regex": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
-			"integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
-		},
-		"filenamify": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.2.0.tgz",
-			"integrity": "sha512-pkgE+4p7N1n7QieOopmn3TqJaefjdWXwEkj2XLZJLKfOgcQKkn11ahvGNgTD8mLggexLiDFQxeTs14xVU22XPA==",
-			"requires": {
-				"filename-reserved-regex": "^2.0.0",
-				"strip-outer": "^1.0.1",
-				"trim-repeated": "^1.0.0"
-			}
-		},
 		"fill-range": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2724,6 +2663,54 @@
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.2",
 				"pkg-dir": "^4.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				}
 			}
 		},
 		"find-up": {
@@ -2734,35 +2721,6 @@
 			"requires": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
-			},
-			"dependencies": {
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				}
 			}
 		},
 		"find-versions": {
@@ -3032,9 +2990,9 @@
 			}
 		},
 		"globalthis": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
-			"integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
+			"integrity": "sha512-ZQnSFO1la8P7auIOQECnm0sSuoMeaSq0EEdXMBFF2QJO4uNcwbyhSgG3MruWNbFTqCLmxVwGOl7LZ9kASvHdeQ==",
 			"optional": true,
 			"requires": {
 				"define-properties": "^1.1.3"
@@ -3096,9 +3054,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+			"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
 		},
 		"grapheme-splitter": {
 			"version": "1.0.4",
@@ -3142,9 +3100,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"hasha": {
 			"version": "5.2.2",
@@ -3156,12 +3114,6 @@
 				"type-fest": "^0.8.0"
 			},
 			"dependencies": {
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
 				"type-fest": {
 					"version": "0.8.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -3273,21 +3225,13 @@
 			}
 		},
 		"http2-wrapper": {
-			"version": "1.0.0-beta.5.2",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-			"integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
 			"dev": true,
 			"requires": {
 				"quick-lru": "^5.1.1",
 				"resolve-alpn": "^1.0.0"
-			},
-			"dependencies": {
-				"quick-lru": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-					"dev": true
-				}
 			}
 		},
 		"https-proxy-agent": {
@@ -3322,109 +3266,6 @@
 				"please-upgrade-node": "^3.2.0",
 				"slash": "^3.0.0",
 				"which-pm-runs": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"find-up": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^6.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"locate-path": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^5.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-					"dev": true,
-					"requires": {
-						"yocto-queue": "^0.1.0"
-					}
-				},
-				"p-locate": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^3.0.2"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"pkg-dir": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-					"dev": true,
-					"requires": {
-						"find-up": "^5.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"ical": {
@@ -3465,9 +3306,9 @@
 			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 		},
 		"import-fresh": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-			"integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -3511,9 +3352,9 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -3574,9 +3415,9 @@
 			"dev": true
 		},
 		"is-core-module": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
-			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+			"integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -3600,10 +3441,9 @@
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-fullwidth-code-point": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-			"dev": true
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"is-glob": {
 			"version": "4.0.1",
@@ -3641,6 +3481,12 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
 			"integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -3703,14 +3549,6 @@
 				"@istanbuljs/schema": "^0.1.2",
 				"istanbul-lib-coverage": "^3.0.0",
 				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-lib-processinfo": {
@@ -3728,15 +3566,6 @@
 				"uuid": "^3.3.3"
 			},
 			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
 				"uuid": {
 					"version": "3.4.0",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -3754,23 +3583,6 @@
 				"istanbul-lib-coverage": "^3.0.0",
 				"make-dir": "^3.0.0",
 				"supports-color": "^7.1.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"istanbul-lib-source-maps": {
@@ -3782,14 +3594,6 @@
 				"debug": "^4.1.1",
 				"istanbul-lib-coverage": "^3.0.0",
 				"source-map": "^0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-reports": {
@@ -3808,9 +3612,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-			"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+			"version": "3.14.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+			"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -3871,32 +3675,6 @@
 						"psl": "^1.1.28",
 						"punycode": "^2.1.1"
 					}
-				},
-				"tr46": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-					"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-					"dev": true,
-					"requires": {
-						"punycode": "^2.1.1"
-					}
-				},
-				"webidl-conversions": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
-					"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
-					"dev": true
-				},
-				"whatwg-url": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
-					"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
-					"dev": true,
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^2.0.2",
-						"webidl-conversions": "^6.1.0"
-					}
 				}
 			}
 		},
@@ -3938,9 +3716,9 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
@@ -4043,12 +3821,12 @@
 			"dev": true
 		},
 		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^4.1.0"
+				"p-locate": "^5.0.0"
 			}
 		},
 		"lodash": {
@@ -4135,57 +3913,6 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"loglevel": {
@@ -4220,9 +3947,9 @@
 			}
 		},
 		"luxon": {
-			"version": "1.25.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.25.0.tgz",
-			"integrity": "sha512-hEgLurSH8kQRjY6i4YLey+mcKVAWXbDNlZRmM6AgWDJ1cY3atl8Ztf5wEY7VBReFbmGnwQPz7KYJblL8B2k0jQ==",
+			"version": "1.26.0",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
+			"integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
 			"optional": true
 		},
 		"make-dir": {
@@ -4232,14 +3959,6 @@
 			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
 			}
 		},
 		"map-obj": {
@@ -4261,14 +3980,6 @@
 			"optional": true,
 			"requires": {
 				"escape-string-regexp": "^4.0.0"
-			},
-			"dependencies": {
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"optional": true
-				}
 			}
 		},
 		"mathml-tag-names": {
@@ -4335,6 +4046,12 @@
 				"yargs-parser": "^20.2.3"
 			},
 			"dependencies": {
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
 				"type-fest": {
 					"version": "0.18.1",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
@@ -4391,16 +4108,16 @@
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
 		},
 		"mime-db": {
-			"version": "1.44.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+			"integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
 		},
 		"mime-types": {
-			"version": "2.1.27",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"version": "2.1.29",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+			"integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
 			"requires": {
-				"mime-db": "1.44.0"
+				"mime-db": "1.46.0"
 			}
 		},
 		"mimic-fn": {
@@ -4511,41 +4228,6 @@
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 					"dev": true
 				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					},
-					"dependencies": {
-						"ms": {
-							"version": "2.1.2",
-							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-							"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-							"dev": true
-						}
-					}
-				},
-				"diff": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-					"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"js-yaml": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
@@ -4649,9 +4331,9 @@
 			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
 		},
 		"nise": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
-			"integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+			"integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.0",
@@ -4681,8 +4363,7 @@
 		"node-fetch": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-			"dev": true
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-ical": {
 			"version": "0.12.8",
@@ -4775,14 +4456,15 @@
 			"requires": {
 				"config-chain": "^1.1.11",
 				"pify": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"optional": true
-				}
+			}
+		},
+		"npm-run-path": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+			"dev": true,
+			"requires": {
+				"path-key": "^3.0.0"
 			}
 		},
 		"num2fraction": {
@@ -4832,21 +4514,6 @@
 				"yargs": "^15.0.2"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"camelcase": {
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -4864,25 +4531,10 @@
 						"wrap-ansi": "^6.2.0"
 					}
 				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"find-up": {
@@ -4895,52 +4547,38 @@
 						"path-exists": "^4.0.0"
 					}
 				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
 				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
 				},
 				"resolve-from": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
-				},
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"string-width": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
 				},
 				"wrap-ansi": {
 					"version": "6.2.0",
@@ -4952,6 +4590,12 @@
 						"string-width": "^4.1.0",
 						"strip-ansi": "^6.0.0"
 					}
+				},
+				"y18n": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+					"integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "15.4.1",
@@ -5050,21 +4694,21 @@
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
 		},
 		"p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"requires": {
-				"p-try": "^2.0.0"
+				"yocto-queue": "^0.1.0"
 			}
 		},
 		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.2.0"
+				"p-limit": "^3.0.2"
 			}
 		},
 		"p-map": {
@@ -5194,31 +4838,19 @@
 			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
 			"dev": true
 		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+			"optional": true
+		},
 		"pkg-dir": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
 			"dev": true,
 			"requires": {
-				"find-up": "^4.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^5.0.0",
-						"path-exists": "^4.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				}
+				"find-up": "^5.0.0"
 			}
 		},
 		"please-upgrade-node": {
@@ -5241,10 +4873,62 @@
 				"supports-color": "^6.1.0"
 			},
 			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"supports-color": {
@@ -5379,15 +5063,6 @@
 				"multimatch": "^4.0.0"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
 				"chalk": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -5396,38 +5071,6 @@
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"execa": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-					"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^7.0.0",
-						"get-stream": "^5.0.0",
-						"human-signals": "^1.1.1",
-						"is-stream": "^2.0.0",
-						"merge-stream": "^2.0.0",
-						"npm-run-path": "^4.0.0",
-						"onetime": "^5.1.0",
-						"signal-exit": "^3.0.2",
-						"strip-final-newline": "^2.0.0"
 					}
 				},
 				"find-up": {
@@ -5440,55 +5083,37 @@
 						"path-exists": "^4.0.0"
 					}
 				},
-				"get-stream": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"ignore": {
 					"version": "5.1.8",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
 					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
 					"dev": true
 				},
-				"is-stream": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-					"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-					"dev": true
-				},
-				"npm-run-path": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-					"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 					"dev": true,
 					"requires": {
-						"path-key": "^3.0.0"
+						"p-locate": "^4.1.0"
 					}
 				},
-				"path-exists": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^4.0.0"
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
 					}
 				}
 			}
@@ -5590,6 +5215,16 @@
 						"yauzl": "^2.10.0"
 					}
 				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"get-stream": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -5597,6 +5232,42 @@
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
 					}
 				}
 			}
@@ -5613,9 +5284,9 @@
 			"dev": true
 		},
 		"quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true
 		},
 		"randombytes": {
@@ -5699,6 +5370,12 @@
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
 				"type-fest": {
 					"version": "0.6.0",
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
@@ -5726,6 +5403,33 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
 					}
 				},
 				"type-fest": {
@@ -5910,12 +5614,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.18.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
-			"integrity": "sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.0.0",
+				"is-core-module": "^2.2.0",
 				"path-parse": "^1.0.6"
 			}
 		},
@@ -6037,10 +5741,9 @@
 			}
 		},
 		"semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -6155,9 +5858,9 @@
 			"dev": true
 		},
 		"simple-git": {
-			"version": "2.35.2",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.35.2.tgz",
-			"integrity": "sha512-UjOKsrz92Bx7z00Wla5V6qLSf5X2XSp0sL2gzKw1Bh7iJfDPDaU7gK5avIup0yo1/sMOSUMQer2b9GcnF6nmTQ==",
+			"version": "2.36.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.36.0.tgz",
+			"integrity": "sha512-EJNaUgGYzBnQiyEkNZgbQSg76agbEDqlgHDr8DAXqV8xWvcefydbipye7YXtHMGbbEK998dcFezS8qF0sepZ5Q==",
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -6188,20 +5891,11 @@
 				"supports-color": "^7.1.0"
 			},
 			"dependencies": {
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -6219,34 +5913,6 @@
 				"ansi-styles": "^4.0.0",
 				"astral-regex": "^2.0.0",
 				"is-fullwidth-code-point": "^3.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				}
 			}
 		},
 		"socket.io": {
@@ -6263,16 +5929,6 @@
 				"engine.io": "~4.1.0",
 				"socket.io-adapter": "~2.1.0",
 				"socket.io-parser": "~4.0.3"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				}
 			}
 		},
 		"socket.io-adapter": {
@@ -6288,22 +5944,12 @@
 				"@types/component-emitter": "^1.2.10",
 				"component-emitter": "~1.3.0",
 				"debug": "~4.3.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"requires": {
-						"ms": "2.1.2"
-					}
-				}
 			}
 		},
 		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true
 		},
 		"spawn-wrap": {
@@ -6318,17 +5964,6 @@
 				"rimraf": "^3.0.0",
 				"signal-exit": "^3.0.2",
 				"which": "^2.0.1"
-			},
-			"dependencies": {
-				"rimraf": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-					"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-					"dev": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				}
 			}
 		},
 		"spdx-correct": {
@@ -6424,30 +6059,13 @@
 			"dev": true
 		},
 		"string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-			"dev": true,
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+			"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^3.0.0"
-					}
-				}
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.0"
 			}
 		},
 		"string_decoder": {
@@ -6465,6 +6083,12 @@
 			"requires": {
 				"ansi-regex": "^5.0.0"
 			}
+		},
+		"strip-bom": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+			"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+			"dev": true
 		},
 		"strip-final-newline": {
 			"version": "2.0.0",
@@ -6485,14 +6109,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
-		},
-		"strip-outer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
-			"integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
 		},
 		"style-search": {
 			"version": "0.1.0",
@@ -6556,65 +6172,10 @@
 				"write-file-atomic": "^3.0.3"
 			},
 			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
 				"ignore": {
 					"version": "5.1.8",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
 					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"dev": true
 				},
 				"resolve-from": {
@@ -6622,26 +6183,6 @@
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-					"integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -6667,9 +6208,9 @@
 			}
 		},
 		"stylelint-prettier": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.1.2.tgz",
-			"integrity": "sha512-8QZ+EtBpMCXYB6cY0hNE3aCDKMySIx4Q8/malLaqgU/KXXa6Cj2KK8ulG1AJvUMD5XSSP8rOotqaCzR/BW6qAA==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/stylelint-prettier/-/stylelint-prettier-1.2.0.tgz",
+			"integrity": "sha512-/MYz6W2CNgKHblPzPtk7cybu8H5dGG3c2GevL64RButERj1uJg4SdBIIat1hMfDOmN6QQpldc6tCc//ZAWh9WQ==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -6693,11 +6234,11 @@
 			}
 		},
 		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
 			}
 		},
 		"svg-tags": {
@@ -6734,30 +6275,10 @@
 						"uri-js": "^4.2.2"
 					}
 				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-				},
 				"json-schema-traverse": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
-				},
-				"string-width": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-					"integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
 				}
 			}
 		},
@@ -6855,19 +6376,20 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"tr46": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+			"integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+			"dev": true,
+			"requires": {
+				"punycode": "^2.1.1"
+			}
+		},
 		"trim-newlines": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
 			"integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
 			"dev": true
-		},
-		"trim-repeated": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-			"integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-			"requires": {
-				"escape-string-regexp": "^1.0.2"
-			}
 		},
 		"trough": {
 			"version": "1.0.5",
@@ -6944,9 +6466,9 @@
 			}
 		},
 		"ua-parser-js": {
-			"version": "0.7.23",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-			"integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
+			"version": "0.7.24",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+			"integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==",
 			"dev": true
 		},
 		"unbzip2-stream": {
@@ -7014,9 +6536,9 @@
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
 		},
 		"uri-js": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-			"integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -7173,9 +6695,9 @@
 					}
 				},
 				"defer-to-connect": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-					"integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+					"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
 					"dev": true
 				},
 				"get-stream": {
@@ -7188,9 +6710,9 @@
 					}
 				},
 				"got": {
-					"version": "11.8.1",
-					"resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-					"integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+					"version": "11.8.2",
+					"resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+					"integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
 					"dev": true,
 					"requires": {
 						"@sindresorhus/is": "^4.0.0",
@@ -7326,6 +6848,12 @@
 				}
 			}
 		},
+		"webidl-conversions": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+			"integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+			"dev": true
+		},
 		"whatwg-encoding": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -7351,6 +6879,17 @@
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
 			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
 			"dev": true
+		},
+		"whatwg-url": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.4.0.tgz",
+			"integrity": "sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==",
+			"dev": true,
+			"requires": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^2.0.2",
+				"webidl-conversions": "^6.1.0"
+			}
 		},
 		"which": {
 			"version": "2.0.2",
@@ -7379,6 +6918,39 @@
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
 			}
 		},
 		"word-wrap": {
@@ -7401,49 +6973,6 @@
 				"ansi-styles": "^4.0.0",
 				"string-width": "^4.1.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-					"integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				}
 			}
 		},
 		"wrappy": {
@@ -7464,10 +6993,9 @@
 			}
 		},
 		"ws": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-			"integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
-			"dev": true
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+			"integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",
@@ -7482,9 +7010,9 @@
 			"dev": true
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+			"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
 			"dev": true
 		},
 		"yallist": {
@@ -7511,31 +7039,6 @@
 				"string-width": "^4.2.0",
 				"y18n": "^5.0.5",
 				"yargs-parser": "^20.2.2"
-			},
-			"dependencies": {
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.1.tgz",
-					"integrity": "sha512-LL0OLyN6AnfV9xqGQpDBwedT2Rt63737LxvsRxbcwpa2aIeynBApG2Sm//F3TaLHIR1aJBN52DWklc06b94o5Q==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"y18n": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
-					"integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
-					"dev": true
-				}
 			}
 		},
 		"yargs-parser": {
@@ -7554,14 +7057,6 @@
 				"decamelize": "^4.0.0",
 				"flat": "^5.0.2",
 				"is-plain-obj": "^2.1.0"
-			},
-			"dependencies": {
-				"decamelize": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-					"dev": true
-				}
 			}
 		},
 		"yauzl": {
@@ -7580,13 +7075,13 @@
 			"dev": true
 		},
 		"zip-stream": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
-			"integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
+			"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
 			"dev": true,
 			"requires": {
 				"archiver-utils": "^2.1.0",
-				"compress-commons": "^4.0.2",
+				"compress-commons": "^4.1.0",
 				"readable-stream": "^3.6.0"
 			},
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
 	"dependencies": {
 		"colors": "^1.4.0",
 		"console-stamp": "^3.0.0-rc4.2",
+		"digest-fetch": "^1.1.6",
 		"eslint": "^7.20.0",
 		"express": "^4.17.1",
 		"express-ipfilter": "^1.1.2",
@@ -80,8 +81,8 @@
 		"iconv-lite": "^0.6.2",
 		"module-alias": "^2.2.2",
 		"moment": "^2.29.1",
+		"node-fetch": "^2.6.1",
 		"node-ical": "^0.12.8",
-		"request": "^2.88.2",
 		"rrule": "^2.6.8",
 		"rrule-alt": "^2.2.8",
 		"simple-git": "^2.35.2",

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -1,5 +1,5 @@
 const helpers = require("./global-setup");
-const request = require("request");
+const fetch = require("node-fetch");
 const expect = require("chai").expect;
 
 const describe = global.describe;
@@ -46,15 +46,15 @@ describe("Electron app environment", function () {
 	});
 
 	it("get request from http://localhost:8080 should return 200", function (done) {
-		request.get("http://localhost:8080", function (err, res, body) {
-			expect(res.statusCode).to.equal(200);
+		fetch("http://localhost:8080").then((res) => {
+			expect(res.status).to.equal(200);
 			done();
 		});
 	});
 
 	it("get request from http://localhost:8080/nothing should return 404", function (done) {
-		request.get("http://localhost:8080/nothing", function (err, res, body) {
-			expect(res.statusCode).to.equal(404);
+		fetch("http://localhost:8080/nothing").then((res) => {
+			expect(res.status).to.equal(404);
 			done();
 		});
 	});

--- a/tests/e2e/fonts.js
+++ b/tests/e2e/fonts.js
@@ -1,5 +1,5 @@
 const helpers = require("./global-setup");
-const request = require("request");
+const fetch = require("node-fetch");
 const expect = require("chai").expect;
 const forEach = require("mocha-each");
 
@@ -40,8 +40,8 @@ describe("All font files from roboto.css should be downloadable", function () {
 
 	forEach(fontFiles).it("should return 200 HTTP code for file '%s'", (fontFile, done) => {
 		var fontUrl = "http://localhost:8080/fonts/" + fontFile;
-		request.get(fontUrl, function (err, res, body) {
-			expect(res.statusCode).to.equal(200);
+		fetch(fontUrl).then((res) => {
+			expect(res.status).to.equal(200);
 			done();
 		});
 	});

--- a/tests/e2e/ipWhistlist_spec.js
+++ b/tests/e2e/ipWhistlist_spec.js
@@ -1,5 +1,5 @@
 const helpers = require("./global-setup");
-const request = require("request");
+const fetch = require("node-fetch");
 const expect = require("chai").expect;
 
 const describe = global.describe;
@@ -32,8 +32,8 @@ describe("ipWhitelist directive configuration", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/noIpWhiteList.js";
 		});
 		it("should return 403", function (done) {
-			request.get("http://localhost:8080", function (err, res, body) {
-				expect(res.statusCode).to.equal(403);
+			fetch("http://localhost:8080").then((res) => {
+				expect(res.status).to.equal(403);
 				done();
 			});
 		});
@@ -45,8 +45,8 @@ describe("ipWhitelist directive configuration", function () {
 			process.env.MM_CONFIG_FILE = "tests/configs/empty_ipWhiteList.js";
 		});
 		it("should return 200", function (done) {
-			request.get("http://localhost:8080", function (err, res, body) {
-				expect(res.statusCode).to.equal(200);
+			fetch("http://localhost:8080").then((res) => {
+				expect(res.status).to.equal(200);
 				done();
 			});
 		});

--- a/tests/e2e/port_config.js
+++ b/tests/e2e/port_config.js
@@ -1,5 +1,5 @@
 const helpers = require("./global-setup");
-const request = require("request");
+const fetch = require("node-fetch");
 const expect = require("chai").expect;
 
 const describe = global.describe;
@@ -33,8 +33,8 @@ describe("port directive configuration", function () {
 		});
 
 		it("should return 200", function (done) {
-			request.get("http://localhost:8090", function (err, res, body) {
-				expect(res.statusCode).to.equal(200);
+			fetch("http://localhost:8090").then((res) => {
+				expect(res.status).to.equal(200);
 				done();
 			});
 		});
@@ -52,8 +52,8 @@ describe("port directive configuration", function () {
 		});
 
 		it("should return 200", function (done) {
-			request.get("http://localhost:8100", function (err, res, body) {
-				expect(res.statusCode).to.equal(200);
+			fetch("http://localhost:8100").then((res) => {
+				expect(res.status).to.equal(200);
 				done();
 			});
 		});

--- a/tests/e2e/vendor_spec.js
+++ b/tests/e2e/vendor_spec.js
@@ -1,5 +1,5 @@
 const helpers = require("./global-setup");
-const request = require("request");
+const fetch = require("node-fetch");
 const expect = require("chai").expect;
 
 const describe = global.describe;
@@ -32,8 +32,8 @@ describe("Vendors", function () {
 		Object.keys(vendors).forEach((vendor) => {
 			it(`should return 200 HTTP code for vendor "${vendor}"`, function () {
 				var urlVendor = "http://localhost:8080/vendor/" + vendors[vendor];
-				request.get(urlVendor, function (err, res, body) {
-					expect(res.statusCode).to.equal(200);
+				fetch(urlVendor).then((res) => {
+					expect(res.status).to.equal(200);
 				});
 			});
 		});
@@ -41,8 +41,8 @@ describe("Vendors", function () {
 		Object.keys(vendors).forEach((vendor) => {
 			it(`should return 404 HTTP code for vendor https://localhost/"${vendor}"`, function () {
 				var urlVendor = "http://localhost:8080/" + vendors[vendor];
-				request.get(urlVendor, function (err, res, body) {
-					expect(res.statusCode).to.equal(404);
+				fetch(urlVendor).then((res) => {
+					expect(res.status).to.equal(404);
 				});
 			});
 		});


### PR DESCRIPTION
closes #2468

This PR replaces the deprecated `request` package with `node-fetch`.

The replacement in the newsfeed module and the e2e tests are straight forward.

In the calendar module are 3 auth methods used: base, bearer and digest. For digest the package `digest-fetch` is used additionally.

Remark: There are no tests available for bearer and digest auth, so these cases should be reviewed in detail.