### PR TITLE
Allowing openweathermap config lat and lon to function without onecall, overrides locationID and location since more specific.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix socket.io backward compatibility with socket v2 clients
 - 3rd party module language loading if language is English
 - Fix e2e tests after spectron update
+- Fix weather module openweathermap not loading if lat and lon set without onecall.
 
 ## [2.14.0] - 2021-01-01
 

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -465,6 +465,8 @@ WeatherProvider.register("openweathermap", {
 			} else {
 				params += "&exclude=minutely";
 			}
+		} else if (this.config.lat && this.config.lon) {
+			params += "lat=" + this.config.lat + "&lon=" + this.config.lon;
 		} else if (this.config.locationID) {
 			params += "id=" + this.config.locationID;
 		} else if (this.config.location) {


### PR DESCRIPTION
OpenWeatherMap in the weather module would not function with just latitude and longitude (not using onecall). Adding two lines of code to allow them and assuming they should take precedence over locationID and location. Without this change, the module just says "Loading…" even with valid lon and lat set in config. Sorry for mistakes – first pull request.