### PR TITLE
added possibility to move 3rd-party-modules into another directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Added locale to sample config file
 - Added support for self-signed certificates for the default calendar module (#466)
 - Added hiddenOnStartup flag to module config (#2475)
+- Added possibility to move 3rd-party-modules into another parent directory than `modules` (should be a directory beside `modules`)
 
 ### Updated
 

--- a/js/app.js
+++ b/js/app.js
@@ -106,7 +106,7 @@ function App() {
 	function loadModule(module, callback) {
 		const elements = module.split("/");
 		const moduleName = elements[elements.length - 1];
-		let moduleFolder = `${__dirname}/../modules/${module}`;
+		let moduleFolder = `${__dirname}/../${config.paths.modules}/${module}`;
 
 		if (defaultModules.includes(moduleName)) {
 			moduleFolder = `${__dirname}/../modules/default/${module}`;

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -73,7 +73,8 @@ var defaults = {
 	],
 
 	paths: {
-		modules: "modules",
+		// only change these variables in your config if you know what you are doing!
+		modules: "modules", // parent directory for 3rd-party-modules, can be changed to another directory beside `modules`.
 		vendor: "vendor"
 	}
 };

--- a/js/loader.js
+++ b/js/loader.js
@@ -91,7 +91,7 @@ var Loader = (function () {
 			var moduleFolder = config.paths.modules + "/" + module;
 
 			if (defaultModules.indexOf(moduleName) !== -1) {
-				moduleFolder = config.paths.modules + "/default/" + module;
+				moduleFolder = "modules/default/" + module;
 			}
 
 			if (moduleData.disabled === true) {

--- a/js/server.js
+++ b/js/server.js
@@ -63,10 +63,12 @@ function Server(config, callback) {
 
 	app.use("/js", express.static(__dirname));
 
-	const directories = ["/config", "/css", "/fonts", "/modules", "/" + config.paths.modules, "/vendor", "/translations", "/tests/configs"];
+	const directories = ["/config", "/css", "/fonts", "/modules/default", "/" + config.paths.modules, "/vendor", "/translations", "/tests/configs"];
 	for (const directory of directories) {
 		app.use(directory, express.static(path.resolve(global.root_path + directory)));
 	}
+
+	app.use("/modules", express.static(path.resolve(global.root_path + "/" + config.paths.modules)));
 
 	app.get("/version", function (req, res) {
 		res.send(global.version);

--- a/js/server.js
+++ b/js/server.js
@@ -63,7 +63,7 @@ function Server(config, callback) {
 
 	app.use("/js", express.static(__dirname));
 
-	const directories = ["/config", "/css", "/fonts", "/modules", "/vendor", "/translations", "/tests/configs"];
+	const directories = ["/config", "/css", "/fonts", "/modules", "/" + config.paths.modules, "/vendor", "/translations", "/tests/configs"];
 	for (const directory of directories) {
 		app.use(directory, express.static(path.resolve(global.root_path + directory)));
 	}


### PR DESCRIPTION
Inspired by the discussion with @buxxi [here](https://github.com/MichMich/MagicMirror/issues/2471#issuecomment-798600037) this PR adds the possiblity to use another directory than `modules` as parent directory for 3rd-party-modules.

This change simplifies every docker setup because we can now map only the 3rd-party-modules to the host (at the moment the default modules are always included). The new folder should be a subdirectory of the magic mirror main directory.

I used the existing `paths.modules` variable and did minimal code changes.

I see only downsides for modules who are working as module manager for magicmirror:
- MMM-Remote-Control: Minimal backward compatibel code change, I would make a PR in this repo
- mmpm: Will inform the author

Will set this PR to draft and wait for reactions before merging.