### PR TITLE
Fix basic auth in calendar module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Update documentation and help screen about invalid config files.
 - Moving weather provider specific code and configuration into each provider and making hourly part of the interface.
 - Bump electron to v11 and enable contextIsolation.
-- Dont update the DOM when a module is not displayed.
+- Don't update the DOM when a module is not displayed.
 - Cleaned up jsdoc and tests.
 - Exposed logger as node module for easier access for 3rd party modules
 - Replaced deprecated `request` package with `node-fetch` and `digest-fetch`
@@ -492,7 +492,7 @@ A huge, huge, huge thanks to user @fewieden for all his hard work on the new `we
 ### Fixed
 
 - Fixed gzip encoded calendar loading issue #1400.
-- Mixup between german and spanish translation for newsfeed.
+- Fixed mixup between german and spanish translation for newsfeed.
 - Fixed close dates to be absolute, if no configured in the config.js - module Calendar
 - Fixed the updatenotification module message about new commits in the repository, so they can be correctly localized in singular and plural form.
 - Fix for weatherforecast rainfall rounding [#1374](https://github.com/MichMich/MagicMirror/issues/1374)

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -10,7 +10,6 @@ const ical = require("node-ical");
 const fetch = require("node-fetch");
 const digest = require("digest-fetch");
 const https = require("https");
-const base64 = require("base-64");
 
 /**
  *

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -55,7 +55,7 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumEn
 			} else if (auth.method === "digest") {
 				fetcher = new digest(auth.user, auth.pass).fetch(url, { headers: headers, httpsAgent: httpsAgent });
 			} else {
-				headers.Authorization = "Basic " + base64.encode(auth.user + ":" + auth.pass);
+				headers.Authorization = "Basic " + Buffer.from(auth.user + ":" + auth.pass).toString("base64");
 			}
 		}
 		if (fetcher === null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1400,6 +1400,12 @@
 				}
 			}
 		},
+		"ci-info": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+			"dev": true
+		},
 		"clarinet": {
 			"version": "0.12.4",
 			"resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.4.tgz",
@@ -1481,6 +1487,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+			"dev": true
+		},
+		"compare-versions": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+			"integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
 			"dev": true
 		},
 		"component-emitter": {
@@ -2732,6 +2744,15 @@
 				"path-exists": "^4.0.0"
 			}
 		},
+		"find-versions": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+			"integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+			"dev": true,
+			"requires": {
+				"semver-regex": "^3.1.2"
+			}
+		},
 		"flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -3251,10 +3272,22 @@
 			"dev": true
 		},
 		"husky": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-5.1.3.tgz",
-			"integrity": "sha512-fbNJ+Gz5wx2LIBtMweJNY1D7Uc8p1XERi5KNRMccwfQA+rXlxWNSdUxswo0gT8XqxywTIw7Ywm/F4v/O35RdMg==",
-			"dev": true
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+			"integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0",
+				"ci-info": "^2.0.0",
+				"compare-versions": "^3.6.0",
+				"cosmiconfig": "^7.0.0",
+				"find-versions": "^4.0.0",
+				"opencollective-postinstall": "^2.0.2",
+				"pkg-dir": "^5.0.0",
+				"please-upgrade-node": "^3.2.0",
+				"slash": "^3.0.0",
+				"which-pm-runs": "^1.0.0"
+			}
 		},
 		"iconv-lite": {
 			"version": "0.6.2",
@@ -4634,6 +4667,12 @@
 				"mimic-fn": "^2.1.0"
 			}
 		},
+		"opencollective-postinstall": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+			"dev": true
+		},
 		"optionator": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -4802,6 +4841,24 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 			"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 			"optional": true
+		},
+		"pkg-dir": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+			"dev": true,
+			"requires": {
+				"find-up": "^5.0.0"
+			}
+		},
+		"please-upgrade-node": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+			"dev": true,
+			"requires": {
+				"semver-compare": "^1.0.0"
+			}
 		},
 		"postcss": {
 			"version": "7.0.35",
@@ -5689,8 +5746,13 @@
 		"semver-compare": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-			"optional": true
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+		},
+		"semver-regex": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.2.tgz",
+			"integrity": "sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -6839,6 +6901,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"which-pm-runs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
 			"dev": true
 		},
 		"wide-align": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2278,9 +2278,9 @@
 			"dev": true
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "32.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.2.0.tgz",
-			"integrity": "sha512-ikeVeF3JVmzjcmGd04OZK0rXjgiw46TWtNX+OhyF2jQlw3w1CAU1vyAyLv8PZcIjp7WxP4N20Vg1CI9bp/52dw==",
+			"version": "32.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.3.0.tgz",
+			"integrity": "sha512-zyx7kajDK+tqS1bHuY5sapkad8P8KT0vdd/lE55j47VPG2MeenSYuIY/M/Pvmzq5g0+3JB+P3BJGUXmHxtuKPQ==",
 			"dev": true,
 			"requires": {
 				"comment-parser": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"eslint-plugin-jsdoc": "^32.2.0",
 		"eslint-plugin-prettier": "^3.3.1",
 		"express-basic-auth": "^1.2.0",
-		"husky": "^5.1.3",
+		"husky": "^4.3.8",
 		"jsdom": "^16.5.1",
 		"lodash": "^4.17.21",
 		"mocha": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"chai": "^4.3.4",
 		"chai-as-promised": "^7.1.1",
 		"eslint-config-prettier": "^8.1.0",
-		"eslint-plugin-jsdoc": "^32.2.0",
+		"eslint-plugin-jsdoc": "^32.3.0",
 		"eslint-plugin-prettier": "^3.3.1",
 		"express-basic-auth": "^1.2.0",
 		"husky": "^4.3.8",

--- a/tests/servers/basic-auth.js
+++ b/tests/servers/basic-auth.js
@@ -3,9 +3,7 @@ const auth = require("express-basic-auth");
 const express = require("express");
 const app = express();
 
-var server;
-
-var basicAuth = auth({
+const basicAuth = auth({
 	realm: "MagicMirror Area restricted.",
 	users: { MagicMirror: "CallMeADog" }
 });
@@ -13,14 +11,14 @@ var basicAuth = auth({
 app.use(basicAuth);
 
 // Set available directories
-var directories = ["/tests/configs"];
-var directory;
-var rootPath = path.resolve(__dirname + "/../../");
+const directories = ["/tests/configs"];
+const rootPath = path.resolve(__dirname + "/../../");
 
-for (var i in directories) {
-	directory = directories[i];
+for (let directory of directories) {
 	app.use(directory, express.static(path.resolve(rootPath + directory)));
 }
+
+let server;
 
 exports.listen = function () {
 	server = app.listen.apply(app, arguments);


### PR DESCRIPTION
After the latest round of merges I updated my MM to the latest develop branch. Turned out that the calendar wasnt loading anything anymore.

The authentication failed due to the base64 encoding of user/password not being accepted.

This PR fixes it by using a different base64 encoding method that is recommended for node. Or where did you get yours from @khassel ?

So no CHANGELOG entry since it fixes something that was just introduced. Also downgraded husky which was accidently upgraded to the next major version.