### PR TITLE
Remove valid-url library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ _This release is scheduled to be released on 2021-04-01._
 
 - Removed danger.js library.
 - Removed `ical` which was substituted by `node-ical` in release `v2.13.0`. Module developers must install this dependency themselves in the module folder if needed.
+- Removed valid-url library.
 
 ### Fixed
 

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -5,7 +5,6 @@
  * MIT Licensed.
  */
 const NodeHelper = require("node_helper");
-const validUrl = require("valid-url");
 const CalendarFetcher = require("./calendarfetcher.js");
 const Log = require("logger");
 
@@ -38,7 +37,9 @@ module.exports = NodeHelper.create({
 	 * @param {string} identifier ID of the module
 	 */
 	createFetcher: function (url, fetchInterval, excludedEvents, maximumEntries, maximumNumberOfDays, auth, broadcastPastEvents, selfSignedCert, identifier) {
-		if (!validUrl.isUri(url)) {
+		try {
+			new URL(url);
+		} catch (error) {
 			this.sendSocketNotification("INCORRECT_URL", { id: identifier, url: url });
 			return;
 		}

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -87,6 +87,8 @@ Module.register("newsfeed", {
 			}
 
 			this.loaded = true;
+		} else if (notification === "INCORRECT_URL") {
+			Log.error("Newsfeed Error. Incorrect url: " + payload.url);
 		}
 	},
 

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -6,7 +6,6 @@
  */
 
 const NodeHelper = require("node_helper");
-const validUrl = require("valid-url");
 const NewsfeedFetcher = require("./newsfeedfetcher.js");
 const Log = require("logger");
 
@@ -36,8 +35,10 @@ module.exports = NodeHelper.create({
 		const encoding = feed.encoding || "UTF-8";
 		const reloadInterval = feed.reloadInterval || config.reloadInterval || 5 * 60 * 1000;
 
-		if (!validUrl.isUri(url)) {
-			this.sendSocketNotification("INCORRECT_URL", url);
+		try {
+			new URL(url);
+		} catch (error) {
+			this.sendSocketNotification("INCORRECT_URL", { url: url });
 			return;
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5856,9 +5856,9 @@
 			"dev": true
 		},
 		"simple-git": {
-			"version": "2.36.2",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.36.2.tgz",
-			"integrity": "sha512-orBEf65GfSiQMsYedbJXSiRNnIRvhbeE5rrxZuEimCpWxDZOav0KLy2IEiPi1YJCF+zaC2quiJF8A4TsxI9/tw==",
+			"version": "2.37.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.37.0.tgz",
+			"integrity": "sha512-ZK6qRnP+Xa2v23UEZDNHUfzswsuNCDHOQpWZRkpqNaXn7V5wVBBx3zRJLji3pROJGzrzA7mXwY7preL5EKuAaQ==",
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -6568,11 +6568,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
-		},
-		"valid-url": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-			"integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -84,9 +84,8 @@
 		"node-ical": "^0.12.9",
 		"rrule": "^2.6.8",
 		"rrule-alt": "^2.2.8",
-		"simple-git": "^2.36.2",
-		"socket.io": "^4.0.0",
-		"valid-url": "^1.0.9"
+		"simple-git": "^2.37.0",
+		"socket.io": "^4.0.0"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",


### PR DESCRIPTION
Removes the old valid-url library which can be replaced by a simple node method/constructor.

Also handles an invalid url in the newsfeed module better by logging the error into the console