### PR TITLE
fix 2488, west of UTC day shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix updatenotification creating zombie processes by setting a timeout for the git process
 - Fix weather module openweathermap not loading if lat and lon set without onecall.
 - Fix calendar daylight savings offset calculation if recurring start date before 2007
+- Fix calendar time/date adjustment when time with GMT offset is different day (#2488)
 
 ## [2.14.0] - 2021-01-01
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -314,18 +314,19 @@ const CalendarUtils = {
 								duration = 24 * 60 * 60 * 1000;
 								Log.debug("new recurring date is " + date);
 							}
-						} else {  // not full day, but luxon can still screw up the date on the rule processing
+						} else {
+							// not full day, but luxon can still screw up the date on the rule processing
 							// get time zone offset of the rule calculated event
-							let dateoffset = date.getTimezoneOffset()
+							let dateoffset = date.getTimezoneOffset();
 							// reduce the time by the offset
 							Log.debug(" recurring date is " + date + " offset is " + dateoffset);
-							let dh = moment(date).format("HH")
-							Log.debug(" recurring date is " + date + " offset is " + dateoffset/60 +" Hour is "+dh);
+							let dh = moment(date).format("HH");
+							Log.debug(" recurring date is " + date + " offset is " + dateoffset / 60 + " Hour is " + dh);
 
 							// we need to correct the date to get back to the right event for
-							if(dateoffset <0){
+							if (dateoffset < 0) {
 								// if the date hour is less than the offset
-								if( (dh) < Math.abs(dateoffset/60)){
+								if (dh < Math.abs(dateoffset / 60)) {
 									// reduce the time by the offset
 									Log.debug(" recurring date is " + date + " offset is " + dateoffset);
 									// apply the correction to the date/time to get it UTC relative
@@ -336,14 +337,14 @@ const CalendarUtils = {
 									Log.debug("new recurring date1 is " + date);
 								}
 							} else {
-						  	// if the date hour is less than the offset
-								if( (24-dh) < Math.abs(dateoffset/60)){
-										// apply the correction to the date/time back to right day
-										date = new Date(date.getTime() + Math.abs(24*60) * 60000);
-										// the duration was calculated way back at the top before we could correct the start time..
-										// fix it for this event entry
-										//duration = 24 * 60 * 60 * 1000;
-										Log.debug("new recurring date2 is " + date);
+								// if the date hour is less than the offset
+								if (24 - dh < Math.abs(dateoffset / 60)) {
+									// apply the correction to the date/time back to right day
+									date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
+									// the duration was calculated way back at the top before we could correct the start time..
+									// fix it for this event entry
+									//duration = 24 * 60 * 60 * 1000;
+									Log.debug("new recurring date2 is " + date);
 								}
 							}
 						}


### PR DESCRIPTION
- Does the pull request solve a **related** issue?
- If so, can you reference the issue?
- #2488 
- What does the pull request accomplish? Use a list if needed.
- If it includes major visual changes please add screenshots.
- if the time of the event is close to end of day, less than the timezone offset,  10pm  for instance in NY UTC +5
the rule calculator will see the wrong day (utc clock internally)
we need to detect and correct that as the rrule processor assumes LOCAL time in date/time values
