### PR TITLE
Bump node-ical to v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _This release is scheduled to be released on 2021-04-01._
 
 ### Updated
 
+- Bump node-ical to v0.13.0 (now last runtime dependency using deprecated `request` package is removed).
+
 ### Removed
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -4375,12 +4375,12 @@
 			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
 		},
 		"node-ical": {
-			"version": "0.12.9",
-			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.12.9.tgz",
-			"integrity": "sha512-5nUEZfZPpBpeZbmYCCmNRLsoP08+SGZy/fKxNBX9k67JMUTMFPLEyZ0CXApPDIExX0izMRndG1PsymhEkkSL2Q==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.13.0.tgz",
+			"integrity": "sha512-hfV7HsY0oTehirXLtkKgAdVomSv6/zjSw66z/RTkKfEp9MwwIz1asyE/g9x4ZKWE2YqGnr81Se5zSRcligPY5Q==",
 			"requires": {
 				"moment-timezone": "^0.5.31",
-				"request": "^2.88.2",
+				"node-fetch": "^2.6.1",
 				"rrule": "2.6.8",
 				"uuid": "^8.3.1"
 			}

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 		"module-alias": "^2.2.2",
 		"moment": "^2.29.1",
 		"node-fetch": "^2.6.1",
-		"node-ical": "^0.12.9",
+		"node-ical": "^0.13.0",
 		"rrule": "^2.6.8",
 		"rrule-alt": "^2.2.8",
 		"simple-git": "^2.37.0",


### PR DESCRIPTION
related to [remove request package](https://github.com/MichMich/MagicMirror/issues/2468#issuecomment-791637779).

The new version of `node-ical` is using `node-fetch` so with this PR the last runtime dependency using `request` is gone.