### PR TITLE
Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ _This release is scheduled to be released on 2021-04-01._
 - Checks and applies the showDescription setting for the newsfeed module again
 - Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`
 
-
 ## [2.15.0] - 2021-04-01
 
 Special thanks to the following contributors: @EdgardosReis, @MystaraTheGreat, @TheDuffman85, @ashishtank, @buxxi, @codac, @fewieden, @khassel, @klaernie, @qu1que, @rejas, @sdetweil & @thomasrockhu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _This release is scheduled to be released on 2021-04-01._
 
 - Fix calendar start function logging inconsistency.
 - Fix updatenotification start function logging inconsistency.
+- Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`
 
 ## [2.15.0] - 2021-04-01
 

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -59,9 +59,8 @@ WeatherProvider.register("ukmetofficedatahub", {
 		let queryStrings = "?";
 		queryStrings += "latitude=" + this.config.lat;
 		queryStrings += "&longitude=" + this.config.lon;
-		if (this.config.appendLocationNameToHeader) {
-			queryStrings += "&includeLocationName=" + true;
-		}
+		queryStrings += "&includeLocationName=" + true;
+		
 
 		// Return URL, making sure there is a trailing "/" in the base URL.
 		return this.config.apiBase + (this.config.apiBase.endsWith("/") ? "" : "/") + forecastType + queryStrings;

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -60,7 +60,6 @@ WeatherProvider.register("ukmetofficedatahub", {
 		queryStrings += "latitude=" + this.config.lat;
 		queryStrings += "&longitude=" + this.config.lon;
 		queryStrings += "&includeLocationName=" + true;
-		
 
 		// Return URL, making sure there is a trailing "/" in the base URL.
 		return this.config.apiBase + (this.config.apiBase.endsWith("/") ? "" : "/") + forecastType + queryStrings;


### PR DESCRIPTION
Fixes #2524 supersedes #2521 all credits to @B1gG