### PR TITLE
Fix decimalSymbol for forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix calendar start function logging inconsistency.
 - Fix updatenotification start function logging inconsistency.
 - Checks and applies the showDescription setting for the newsfeed module again
+- Fix decimalSymbol in the forcast part of the new weather module #2530
 
 ## [2.15.0] - 2021-04-01
 

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -14,10 +14,10 @@
                 {% endif %}
                 <td class="bright weather-icon"><span class="wi weathericon wi-{{ f.weatherType }}"></span></td>
                 <td class="align-right bright max-temp">
-                    {{ f.maxTemperature | roundValue | decimalSymbol | unit("temperature") }}
+                    {{ f.maxTemperature | roundValue | unit("temperature") | decimalSymbol }}
                 </td>
                 <td class="align-right min-temp">
-                    {{ f.minTemperature | roundValue | decimalSymbol | unit("temperature") }}
+                    {{ f.minTemperature | roundValue | unit("temperature") | decimalSymbol }}
                 </td>
                 {% if config.showPrecipitationAmount %}
                     <td class="align-right bright precipitation">

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -14,10 +14,10 @@
                 {% endif %}
                 <td class="bright weather-icon"><span class="wi weathericon wi-{{ f.weatherType }}"></span></td>
                 <td class="align-right bright max-temp">
-                    {{ f.maxTemperature | roundValue | unit("temperature") }}
+                    {{ f.maxTemperature | roundValue | decimalSymbol | unit("temperature") }}
                 </td>
                 <td class="align-right min-temp">
-                    {{ f.minTemperature | roundValue | unit("temperature") }}
+                    {{ f.minTemperature | roundValue | decimalSymbol | unit("temperature") }}
                 </td>
                 {% if config.showPrecipitationAmount %}
                     <td class="align-right bright precipitation">


### PR DESCRIPTION
With this, the `decimalSymbol` config also works at the forecast part of the new weather module.

This solves the issue #2530.