### PR TITLE
Fixing fetch option httpsAgent to agent in calendar module (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix decimalSymbol in the forcast part of the new weather module #2530
 - Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`
 - Fix alert not recognizing multiple alerts (#2522)
+- Fix fetch option httpsAgent to agent in calendar module (#466)
 
 ## [2.15.0] - 2021-04-01
 

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -52,13 +52,13 @@ const CalendarFetcher = function (url, reloadInterval, excludedEvents, maximumEn
 			if (auth.method === "bearer") {
 				headers.Authorization = "Bearer " + auth.pass;
 			} else if (auth.method === "digest") {
-				fetcher = new digest(auth.user, auth.pass).fetch(url, { headers: headers, httpsAgent: httpsAgent });
+				fetcher = new digest(auth.user, auth.pass).fetch(url, { headers: headers, agent: httpsAgent });
 			} else {
 				headers.Authorization = "Basic " + Buffer.from(auth.user + ":" + auth.pass).toString("base64");
 			}
 		}
 		if (fetcher === null) {
-			fetcher = fetch(url, { headers: headers, httpsAgent: httpsAgent });
+			fetcher = fetch(url, { headers: headers, agent: httpsAgent });
 		}
 
 		fetcher


### PR DESCRIPTION
There was an error in the fetch options where httpsAgent: httpsAgent was triggered and therefore the fetcher did not set the option properly.
The correct option name is "agent" and not "httpsAgent".

This is a follow up fix for the issue #466.
