### PR TITLE
Convert code to look a little more like es6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _This release is scheduled to be released on 2021-04-01._
 
 - Bump node-ical to v0.13.0 (now last runtime dependency using deprecated `request` package is removed).
 - Use codecov in informational mode
+- Refactor code into es6 where possible (e.g. var -> let/const)
 
 ### Removed
 

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -2,7 +2,7 @@
 
 // Use separate scope to prevent global scope pollution
 (function () {
-	var config = {};
+	const config = {};
 
 	/**
 	 * Helper function to get server address/hostname from either the commandline or env
@@ -17,8 +17,8 @@
 		 * @returns {string} the value of the parameter
 		 */
 		function getCommandLineParameter(key, defaultValue = undefined) {
-			var index = process.argv.indexOf(`--${key}`);
-			var value = index > -1 ? process.argv[index + 1] : undefined;
+			const index = process.argv.indexOf(`--${key}`);
+			const value = index > -1 ? process.argv[index + 1] : undefined;
 			return value !== undefined ? String(value) : defaultValue;
 		}
 
@@ -43,7 +43,7 @@
 			// Select http or https module, depending on requested url
 			const lib = url.startsWith("https") ? require("https") : require("http");
 			const request = lib.get(url, (response) => {
-				var configData = "";
+				let configData = "";
 
 				// Gather incoming data
 				response.on("data", function (chunk) {
@@ -79,15 +79,15 @@
 	getServerAddress();
 
 	(config.address && config.port) || fail();
-	var prefix = config.tls ? "https://" : "http://";
+	const prefix = config.tls ? "https://" : "http://";
 
 	// Only start the client if a non-local server was provided
 	if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].indexOf(config.address) === -1) {
 		getServerConfig(`${prefix}${config.address}:${config.port}/config/`)
 			.then(function (configReturn) {
 				// Pass along the server config via an environment variable
-				var env = Object.create(process.env);
-				var options = { env: env };
+				const env = Object.create(process.env);
+				const options = { env: env };
 				configReturn.address = config.address;
 				configReturn.port = config.port;
 				configReturn.tls = config.tls;

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -7,8 +7,7 @@
  * See https://github.com/MichMich/MagicMirror#configuration
  *
  */
-
-var config = {
+let config = {
 	address: "localhost", 	// Address to listen on, can be:
 							// - "localhost", "127.0.0.1", "::1" to listen on loopback interface
 							// - another specific IPv4/6 to listen on a specific interface

--- a/js/defaults.js
+++ b/js/defaults.js
@@ -6,12 +6,12 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-var address = "localhost";
-var port = 8080;
+const address = "localhost";
+let port = 8080;
 if (typeof mmPort !== "undefined") {
 	port = mmPort;
 }
-var defaults = {
+const defaults = {
 	address: address,
 	port: port,
 	basePath: "/",

--- a/js/loader.js
+++ b/js/loader.js
@@ -6,24 +6,24 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-var Loader = (function () {
+const Loader = (function () {
 	/* Create helper variables */
 
-	var loadedModuleFiles = [];
-	var loadedFiles = [];
-	var moduleObjects = [];
+	const loadedModuleFiles = [];
+	const loadedFiles = [];
+	const moduleObjects = [];
 
 	/* Private Methods */
 
 	/**
 	 * Loops thru all modules and requests load for every module.
 	 */
-	var loadModules = function () {
-		var moduleData = getModuleData();
+	const loadModules = function () {
+		let moduleData = getModuleData();
 
-		var loadNextModule = function () {
+		const loadNextModule = function () {
 			if (moduleData.length > 0) {
-				var nextModule = moduleData[0];
+				const nextModule = moduleData[0];
 				loadModule(nextModule, function () {
 					moduleData = moduleData.slice(1);
 					loadNextModule();
@@ -46,9 +46,8 @@ var Loader = (function () {
 	/**
 	 * Loops thru all modules and requests start for every module.
 	 */
-	var startModules = function () {
-		for (var m in moduleObjects) {
-			var module = moduleObjects[m];
+	const startModules = function () {
+		for (const module of moduleObjects) {
 			module.start();
 		}
 
@@ -56,7 +55,7 @@ var Loader = (function () {
 		MM.modulesStarted(moduleObjects);
 
 		// Starting modules also hides any modules that have requested to be initially hidden
-		for (let thisModule of moduleObjects) {
+		for (const thisModule of moduleObjects) {
 			if (thisModule.data.hiddenOnStartup) {
 				Log.info("Initially hiding " + thisModule.name);
 				thisModule.hide();
@@ -69,7 +68,7 @@ var Loader = (function () {
 	 *
 	 * @returns {object[]} module data as configured in config
 	 */
-	var getAllModules = function () {
+	const getAllModules = function () {
 		return config.modules;
 	};
 
@@ -78,29 +77,28 @@ var Loader = (function () {
 	 *
 	 * @returns {object[]} Module information.
 	 */
-	var getModuleData = function () {
-		var modules = getAllModules();
-		var moduleFiles = [];
+	const getModuleData = function () {
+		const modules = getAllModules();
+		const moduleFiles = [];
 
-		for (var m in modules) {
-			var moduleData = modules[m];
-			var module = moduleData.module;
+		modules.forEach(function (moduleData, index) {
+			const module = moduleData.module;
 
-			var elements = module.split("/");
-			var moduleName = elements[elements.length - 1];
-			var moduleFolder = config.paths.modules + "/" + module;
+			const elements = module.split("/");
+			const moduleName = elements[elements.length - 1];
+			let moduleFolder = config.paths.modules + "/" + module;
 
 			if (defaultModules.indexOf(moduleName) !== -1) {
 				moduleFolder = config.paths.modules + "/default/" + module;
 			}
 
 			if (moduleData.disabled === true) {
-				continue;
+				return;
 			}
 
 			moduleFiles.push({
-				index: m,
-				identifier: "module_" + m + "_" + module,
+				index: index,
+				identifier: "module_" + index + "_" + module,
 				name: moduleName,
 				path: moduleFolder + "/",
 				file: moduleName + ".js",
@@ -111,7 +109,7 @@ var Loader = (function () {
 				config: moduleData.config,
 				classes: typeof moduleData.classes !== "undefined" ? moduleData.classes + " " + module : module
 			});
-		}
+		});
 
 		return moduleFiles;
 	};
@@ -122,11 +120,11 @@ var Loader = (function () {
 	 * @param {object} module Information about the module we want to load.
 	 * @param {Function} callback Function called when done.
 	 */
-	var loadModule = function (module, callback) {
-		var url = module.path + module.file;
+	const loadModule = function (module, callback) {
+		const url = module.path + module.file;
 
-		var afterLoad = function () {
-			var moduleObject = Module.create(module.name);
+		const afterLoad = function () {
+			const moduleObject = Module.create(module.name);
 			if (moduleObject) {
 				bootstrapModule(module, moduleObject, function () {
 					callback();
@@ -153,7 +151,7 @@ var Loader = (function () {
 	 * @param {Module} mObj Modules instance.
 	 * @param {Function} callback Function called when done.
 	 */
-	var bootstrapModule = function (module, mObj, callback) {
+	const bootstrapModule = function (module, mObj, callback) {
 		Log.info("Bootstrapping module: " + module.name);
 
 		mObj.setData(module);
@@ -177,13 +175,14 @@ var Loader = (function () {
 	 * @param {string} fileName Path of the file we want to load.
 	 * @param {Function} callback Function called when done.
 	 */
-	var loadFile = function (fileName, callback) {
-		var extension = fileName.slice((Math.max(0, fileName.lastIndexOf(".")) || Infinity) + 1);
+	const loadFile = function (fileName, callback) {
+		const extension = fileName.slice((Math.max(0, fileName.lastIndexOf(".")) || Infinity) + 1);
+		let script, stylesheet;
 
 		switch (extension.toLowerCase()) {
 			case "js":
 				Log.log("Load script: " + fileName);
-				var script = document.createElement("script");
+				script = document.createElement("script");
 				script.type = "text/javascript";
 				script.src = fileName;
 				script.onload = function () {
@@ -202,7 +201,7 @@ var Loader = (function () {
 				break;
 			case "css":
 				Log.log("Load stylesheet: " + fileName);
-				var stylesheet = document.createElement("link");
+				stylesheet = document.createElement("link");
 				stylesheet.rel = "stylesheet";
 				stylesheet.type = "text/css";
 				stylesheet.href = fileName;

--- a/js/main.js
+++ b/js/main.js
@@ -6,25 +6,25 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-var MM = (function () {
-	var modules = [];
+const MM = (function () {
+	let modules = [];
 
 	/* Private Methods */
 
 	/**
 	 * Create dom objects for all modules that are configured for a specific position.
 	 */
-	var createDomObjects = function () {
-		var domCreationPromises = [];
+	const createDomObjects = function () {
+		const domCreationPromises = [];
 
 		modules.forEach(function (module) {
 			if (typeof module.data.position !== "string") {
 				return;
 			}
 
-			var wrapper = selectWrapper(module.data.position);
+			const wrapper = selectWrapper(module.data.position);
 
-			var dom = document.createElement("div");
+			const dom = document.createElement("div");
 			dom.id = module.identifier;
 			dom.className = module.name;
 
@@ -35,7 +35,7 @@ var MM = (function () {
 			dom.opacity = 0;
 			wrapper.appendChild(dom);
 
-			var moduleHeader = document.createElement("header");
+			const moduleHeader = document.createElement("header");
 			moduleHeader.innerHTML = module.getHeader();
 			moduleHeader.className = "module-header";
 			dom.appendChild(moduleHeader);
@@ -46,11 +46,11 @@ var MM = (function () {
 				moduleHeader.style.display = "block;";
 			}
 
-			var moduleContent = document.createElement("div");
+			const moduleContent = document.createElement("div");
 			moduleContent.className = "module-content";
 			dom.appendChild(moduleContent);
 
-			var domCreationPromise = updateDom(module, 0);
+			const domCreationPromise = updateDom(module, 0);
 			domCreationPromises.push(domCreationPromise);
 			domCreationPromise
 				.then(function () {
@@ -73,11 +73,11 @@ var MM = (function () {
 	 *
 	 * @returns {HTMLElement} the wrapper element
 	 */
-	var selectWrapper = function (position) {
-		var classes = position.replace("_", " ");
-		var parentWrapper = document.getElementsByClassName(classes);
+	const selectWrapper = function (position) {
+		const classes = position.replace("_", " ");
+		const parentWrapper = document.getElementsByClassName(classes);
 		if (parentWrapper.length > 0) {
-			var wrapper = parentWrapper[0].getElementsByClassName("container");
+			const wrapper = parentWrapper[0].getElementsByClassName("container");
 			if (wrapper.length > 0) {
 				return wrapper[0];
 			}
@@ -92,9 +92,9 @@ var MM = (function () {
 	 * @param {Module} sender The module that sent the notification.
 	 * @param {Module} [sendTo] The (optional) module to send the notification to.
 	 */
-	var sendNotification = function (notification, payload, sender, sendTo) {
-		for (var m in modules) {
-			var module = modules[m];
+	const sendNotification = function (notification, payload, sender, sendTo) {
+		for (const m in modules) {
+			const module = modules[m];
 			if (module !== sender && (!sendTo || module === sendTo)) {
 				module.notificationReceived(notification, payload, sender);
 			}
@@ -109,10 +109,10 @@ var MM = (function () {
 	 *
 	 * @returns {Promise} Resolved when the dom is fully updated.
 	 */
-	var updateDom = function (module, speed) {
+	const updateDom = function (module, speed) {
 		return new Promise(function (resolve) {
-			var newContentPromise = module.getDom();
-			var newHeader = module.getHeader();
+			const newHeader = module.getHeader();
+			let newContentPromise = module.getDom();
 
 			if (!(newContentPromise instanceof Promise)) {
 				// convert to a promise if not already one to avoid if/else's everywhere
@@ -121,7 +121,7 @@ var MM = (function () {
 
 			newContentPromise
 				.then(function (newContent) {
-					var updatePromise = updateDomWithContent(module, speed, newHeader, newContent);
+					const updatePromise = updateDomWithContent(module, speed, newHeader, newContent);
 
 					updatePromise.then(resolve).catch(Log.error);
 				})
@@ -139,7 +139,7 @@ var MM = (function () {
 	 *
 	 * @returns {Promise} Resolved when the module dom has been updated.
 	 */
-	var updateDomWithContent = function (module, speed, newHeader, newContent) {
+	const updateDomWithContent = function (module, speed, newHeader, newContent) {
 		return new Promise(function (resolve) {
 			if (module.hidden || !speed) {
 				updateModuleContent(module, newHeader, newContent);
@@ -177,23 +177,23 @@ var MM = (function () {
 	 *
 	 * @returns {boolean} True if the module need an update, false otherwise
 	 */
-	var moduleNeedsUpdate = function (module, newHeader, newContent) {
-		var moduleWrapper = document.getElementById(module.identifier);
+	const moduleNeedsUpdate = function (module, newHeader, newContent) {
+		const moduleWrapper = document.getElementById(module.identifier);
 		if (moduleWrapper === null) {
 			return false;
 		}
 
-		var contentWrapper = moduleWrapper.getElementsByClassName("module-content");
-		var headerWrapper = moduleWrapper.getElementsByClassName("module-header");
+		const contentWrapper = moduleWrapper.getElementsByClassName("module-content");
+		const headerWrapper = moduleWrapper.getElementsByClassName("module-header");
 
-		var headerNeedsUpdate = false;
-		var contentNeedsUpdate = false;
+		let headerNeedsUpdate = false;
+		let contentNeedsUpdate;
 
 		if (headerWrapper.length > 0) {
 			headerNeedsUpdate = newHeader !== headerWrapper[0].innerHTML;
 		}
 
-		var tempContentWrapper = document.createElement("div");
+		const tempContentWrapper = document.createElement("div");
 		tempContentWrapper.appendChild(newContent);
 		contentNeedsUpdate = tempContentWrapper.innerHTML !== contentWrapper[0].innerHTML;
 
@@ -207,13 +207,13 @@ var MM = (function () {
 	 * @param {string} newHeader The new header that is generated.
 	 * @param {HTMLElement} newContent The new content that is generated.
 	 */
-	var updateModuleContent = function (module, newHeader, newContent) {
-		var moduleWrapper = document.getElementById(module.identifier);
+	const updateModuleContent = function (module, newHeader, newContent) {
+		const moduleWrapper = document.getElementById(module.identifier);
 		if (moduleWrapper === null) {
 			return;
 		}
-		var headerWrapper = moduleWrapper.getElementsByClassName("module-header");
-		var contentWrapper = moduleWrapper.getElementsByClassName("module-content");
+		const headerWrapper = moduleWrapper.getElementsByClassName("module-header");
+		const contentWrapper = moduleWrapper.getElementsByClassName("module-content");
 
 		contentWrapper[0].innerHTML = "";
 		contentWrapper[0].appendChild(newContent);
@@ -234,7 +234,7 @@ var MM = (function () {
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the hide method.
 	 */
-	var hideModule = function (module, speed, callback, options) {
+	const hideModule = function (module, speed, callback, options) {
 		options = options || {};
 
 		// set lockString if set in options.
@@ -245,7 +245,7 @@ var MM = (function () {
 			}
 		}
 
-		var moduleWrapper = document.getElementById(module.identifier);
+		const moduleWrapper = document.getElementById(module.identifier);
 		if (moduleWrapper !== null) {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			moduleWrapper.style.opacity = 0;
@@ -280,12 +280,12 @@ var MM = (function () {
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
 	 */
-	var showModule = function (module, speed, callback, options) {
+	const showModule = function (module, speed, callback, options) {
 		options = options || {};
 
 		// remove lockString if set in options.
 		if (options.lockString) {
-			var index = module.lockStrings.indexOf(options.lockString);
+			const index = module.lockStrings.indexOf(options.lockString);
 			if (index !== -1) {
 				module.lockStrings.splice(index, 1);
 			}
@@ -309,7 +309,7 @@ var MM = (function () {
 			module.lockStrings = [];
 		}
 
-		var moduleWrapper = document.getElementById(module.identifier);
+		const moduleWrapper = document.getElementById(module.identifier);
 		if (moduleWrapper !== null) {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			// Restore the position. See hideModule() for more info.
@@ -318,7 +318,7 @@ var MM = (function () {
 			updateWrapperStates();
 
 			// Waiting for DOM-changes done in updateWrapperStates before we can start the animation.
-			var dummy = moduleWrapper.parentElement.parentElement.offsetHeight;
+			const dummy = moduleWrapper.parentElement.parentElement.offsetHeight;
 			moduleWrapper.style.opacity = 1;
 
 			clearTimeout(module.showHideTimer);
@@ -346,14 +346,14 @@ var MM = (function () {
 	 * an ugly top margin. By using this function, the top bar will be hidden if the
 	 * update notification is not visible.
 	 */
-	var updateWrapperStates = function () {
-		var positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
+	const updateWrapperStates = function () {
+		const positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
 
 		positions.forEach(function (position) {
-			var wrapper = selectWrapper(position);
-			var moduleWrappers = wrapper.getElementsByClassName("module");
+			const wrapper = selectWrapper(position);
+			const moduleWrappers = wrapper.getElementsByClassName("module");
 
-			var showWrapper = false;
+			let showWrapper = false;
 			Array.prototype.forEach.call(moduleWrappers, function (moduleWrapper) {
 				if (moduleWrapper.style.position === "" || moduleWrapper.style.position === "static") {
 					showWrapper = true;
@@ -367,7 +367,7 @@ var MM = (function () {
 	/**
 	 * Loads the core config and combines it with the system defaults.
 	 */
-	var loadConfig = function () {
+	const loadConfig = function () {
 		// FIXME: Think about how to pass config around without breaking tests
 		/* eslint-disable */
 		if (typeof config === "undefined") {
@@ -385,7 +385,7 @@ var MM = (function () {
 	 *
 	 * @param {Module[]} modules Array of modules.
 	 */
-	var setSelectionMethodsForModules = function (modules) {
+	const setSelectionMethodsForModules = function (modules) {
 		/**
 		 * Filter modules with the specified classes.
 		 *
@@ -393,7 +393,7 @@ var MM = (function () {
 		 *
 		 * @returns {Module[]} Filtered collection of modules.
 		 */
-		var withClass = function (className) {
+		const withClass = function (className) {
 			return modulesByClass(className, true);
 		};
 
@@ -404,7 +404,7 @@ var MM = (function () {
 		 *
 		 * @returns {Module[]} Filtered collection of modules.
 		 */
-		var exceptWithClass = function (className) {
+		const exceptWithClass = function (className) {
 			return modulesByClass(className, false);
 		};
 
@@ -416,17 +416,16 @@ var MM = (function () {
 		 *
 		 * @returns {Module[]} Filtered collection of modules.
 		 */
-		var modulesByClass = function (className, include) {
-			var searchClasses = className;
+		const modulesByClass = function (className, include) {
+			let searchClasses = className;
 			if (typeof className === "string") {
 				searchClasses = className.split(" ");
 			}
 
-			var newModules = modules.filter(function (module) {
-				var classes = module.data.classes.toLowerCase().split(" ");
+			const newModules = modules.filter(function (module) {
+				const classes = module.data.classes.toLowerCase().split(" ");
 
-				for (var c in searchClasses) {
-					var searchClass = searchClasses[c];
+				for (const searchClass of searchClasses) {
 					if (classes.indexOf(searchClass.toLowerCase()) !== -1) {
 						return include;
 					}
@@ -445,8 +444,8 @@ var MM = (function () {
 		 * @param {object} module The module instance to remove from the collection.
 		 * @returns {Module[]} Filtered collection of modules.
 		 */
-		var exceptModule = function (module) {
-			var newModules = modules.filter(function (mod) {
+		const exceptModule = function (module) {
+			const newModules = modules.filter(function (mod) {
 				return mod.identifier !== module.identifier;
 			});
 
@@ -459,7 +458,7 @@ var MM = (function () {
 		 *
 		 * @param {Function} callback The function to execute with the module as an argument.
 		 */
-		var enumerate = function (callback) {
+		const enumerate = function (callback) {
 			modules.map(function (module) {
 				callback(module);
 			});
@@ -604,11 +603,11 @@ if (typeof Object.assign !== "function") {
 			if (target === undefined || target === null) {
 				throw new TypeError("Cannot convert undefined or null to object");
 			}
-			var output = Object(target);
-			for (var index = 1; index < arguments.length; index++) {
-				var source = arguments[index];
+			const output = Object(target);
+			for (let index = 1; index < arguments.length; index++) {
+				const source = arguments[index];
 				if (source !== undefined && source !== null) {
-					for (var nextKey in source) {
+					for (const nextKey in source) {
 						if (source.hasOwnProperty(nextKey)) {
 							output[nextKey] = source[nextKey];
 						}

--- a/js/module.js
+++ b/js/module.js
@@ -6,7 +6,6 @@
  *
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
- *
  */
 var Module = Class.extend({
 	/*********************************************************
@@ -82,16 +81,15 @@ var Module = Class.extend({
 	 * @returns {HTMLElement|Promise} The dom or a promise with the dom to display.
 	 */
 	getDom: function () {
-		var self = this;
-		return new Promise(function (resolve) {
-			var div = document.createElement("div");
-			var template = self.getTemplate();
-			var templateData = self.getTemplateData();
+		return new Promise((resolve) => {
+			const div = document.createElement("div");
+			const template = this.getTemplate();
+			const templateData = this.getTemplateData();
 
 			// Check to see if we need to render a template string or a file.
 			if (/^.*((\.html)|(\.njk))$/.test(template)) {
 				// the template is a filename
-				self.nunjucksEnvironment().render(template, templateData, function (err, res) {
+				this.nunjucksEnvironment().render(template, templateData, function (err, res) {
 					if (err) {
 						Log.error(err);
 					}
@@ -102,7 +100,7 @@ var Module = Class.extend({
 				});
 			} else {
 				// the template is a template string.
-				div.innerHTML = self.nunjucksEnvironment().renderString(template, templateData);
+				div.innerHTML = this.nunjucksEnvironment().renderString(template, templateData);
 
 				resolve(div);
 			}
@@ -168,15 +166,13 @@ var Module = Class.extend({
 			return this._nunjucksEnvironment;
 		}
 
-		var self = this;
-
 		this._nunjucksEnvironment = new nunjucks.Environment(new nunjucks.WebLoader(this.file(""), { async: true }), {
 			trimBlocks: true,
 			lstripBlocks: true
 		});
 
-		this._nunjucksEnvironment.addFilter("translate", function (str, variables) {
-			return nunjucks.runtime.markSafe(self.translate(str, variables));
+		this._nunjucksEnvironment.addFilter("translate", (str, variables) => {
+			return nunjucks.runtime.markSafe(this.translate(str, variables));
 		});
 
 		return this._nunjucksEnvironment;
@@ -192,14 +188,14 @@ var Module = Class.extend({
 		Log.log(this.name + " received a socket notification: " + notification + " - Payload: " + payload);
 	},
 
-	/*
+	/**
 	 * Called when the module is hidden.
 	 */
 	suspend: function () {
 		Log.log(this.name + " is suspended.");
 	},
 
-	/*
+	/**
 	 * Called when the module is shown.
 	 */
 	resume: function () {
@@ -213,7 +209,7 @@ var Module = Class.extend({
 	/**
 	 * Set the module data.
 	 *
-	 * @param {Module} data The module data
+	 * @param {object} data The module data
 	 */
 	setData: function (data) {
 		this.data = data;
@@ -245,9 +241,8 @@ var Module = Class.extend({
 			this._socket = new MMSocket(this.name);
 		}
 
-		var self = this;
-		this._socket.setNotificationCallback(function (notification, payload) {
-			self.socketNotificationReceived(notification, payload);
+		this._socket.setNotificationCallback((notification, payload) => {
+			this.socketNotificationReceived(notification, payload);
 		});
 
 		return this._socket;
@@ -288,13 +283,12 @@ var Module = Class.extend({
 	 * @param {Function} callback Function called when done.
 	 */
 	loadDependencies: function (funcName, callback) {
-		var self = this;
-		var dependencies = this[funcName]();
+		let dependencies = this[funcName]();
 
-		var loadNextDependency = function () {
+		const loadNextDependency = () => {
 			if (dependencies.length > 0) {
-				var nextDependency = dependencies[0];
-				Loader.loadFile(nextDependency, self, function () {
+				const nextDependency = dependencies[0];
+				Loader.loadFile(nextDependency, this, () => {
 					dependencies = dependencies.slice(1);
 					loadNextDependency();
 				});
@@ -400,12 +394,11 @@ var Module = Class.extend({
 		callback = callback || function () {};
 		options = options || {};
 
-		var self = this;
 		MM.hideModule(
-			self,
+			this,
 			speed,
-			function () {
-				self.suspend();
+			() => {
+				this.suspend();
 				callback();
 			},
 			options
@@ -464,9 +457,9 @@ var Module = Class.extend({
  * @returns {object} the merged config
  */
 function configMerge(result) {
-	var stack = Array.prototype.slice.call(arguments, 1);
-	var item;
-	var key;
+	const stack = Array.prototype.slice.call(arguments, 1);
+	let item, key;
+
 	while (stack.length) {
 		item = stack.shift();
 		for (key in item) {
@@ -494,11 +487,11 @@ Module.create = function (name) {
 		return;
 	}
 
-	var moduleDefinition = Module.definitions[name];
-	var clonedDefinition = cloneObject(moduleDefinition);
+	const moduleDefinition = Module.definitions[name];
+	const clonedDefinition = cloneObject(moduleDefinition);
 
 	// Note that we clone the definition. Otherwise the objects are shared, which gives problems.
-	var ModuleClass = Module.extend(clonedDefinition);
+	const ModuleClass = Module.extend(clonedDefinition);
 
 	return new ModuleClass();
 };
@@ -526,14 +519,13 @@ Module.register = function (name, moduleDefinition) {
  * number if a is smaller and 0 if they are the same
  */
 function cmpVersions(a, b) {
-	var i, diff;
-	var regExStrip0 = /(\.0+)+$/;
-	var segmentsA = a.replace(regExStrip0, "").split(".");
-	var segmentsB = b.replace(regExStrip0, "").split(".");
-	var l = Math.min(segmentsA.length, segmentsB.length);
+	const regExStrip0 = /(\.0+)+$/;
+	const segmentsA = a.replace(regExStrip0, "").split(".");
+	const segmentsB = b.replace(regExStrip0, "").split(".");
+	const l = Math.min(segmentsA.length, segmentsB.length);
 
-	for (i = 0; i < l; i++) {
-		diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10);
+	for (let i = 0; i < l; i++) {
+		let diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10);
 		if (diff) {
 			return diff;
 		}

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -6,49 +6,48 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-var MMSocket = function (moduleName) {
-	var self = this;
-
+const MMSocket = function (moduleName) {
 	if (typeof moduleName !== "string") {
 		throw new Error("Please set the module name for the MMSocket.");
 	}
 
-	self.moduleName = moduleName;
+	this.moduleName = moduleName;
 
 	// Private Methods
-	var base = "/";
+	let base = "/";
 	if (typeof config !== "undefined" && typeof config.basePath !== "undefined") {
 		base = config.basePath;
 	}
-	self.socket = io("/" + self.moduleName, {
+	this.socket = io("/" + this.moduleName, {
 		path: base + "socket.io"
 	});
-	var notificationCallback = function () {};
 
-	var onevent = self.socket.onevent;
-	self.socket.onevent = function (packet) {
-		var args = packet.data || [];
-		onevent.call(this, packet); // original call
+	let notificationCallback = function () {};
+
+	const onevent = this.socket.onevent;
+	this.socket.onevent = (packet) => {
+		const args = packet.data || [];
+		onevent.call(this.socket, packet); // original call
 		packet.data = ["*"].concat(args);
-		onevent.call(this, packet); // additional call to catch-all
+		onevent.call(this.socket, packet); // additional call to catch-all
 	};
 
 	// register catch all.
-	self.socket.on("*", function (notification, payload) {
+	this.socket.on("*", (notification, payload) => {
 		if (notification !== "*") {
 			notificationCallback(notification, payload);
 		}
 	});
 
 	// Public Methods
-	this.setNotificationCallback = function (callback) {
+	this.setNotificationCallback = (callback) => {
 		notificationCallback = callback;
 	};
 
-	this.sendNotification = function (notification, payload) {
+	this.sendNotification = (notification, payload) => {
 		if (typeof payload === "undefined") {
 			payload = {};
 		}
-		self.socket.emit(notification, payload);
+		this.socket.emit(notification, payload);
 	};
 };

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -46,62 +46,61 @@ Module.register("clock", {
 		Log.info("Starting module: " + this.name);
 
 		// Schedule update interval.
-		var self = this;
-		self.second = moment().second();
-		self.minute = moment().minute();
+		this.second = moment().second();
+		this.minute = moment().minute();
 
-		//Calculate how many ms should pass until next update depending on if seconds is displayed or not
-		var delayCalculator = function (reducedSeconds) {
-			var EXTRA_DELAY = 50; //Deliberate imperceptable delay to prevent off-by-one timekeeping errors
+		// Calculate how many ms should pass until next update depending on if seconds is displayed or not
+		const delayCalculator = (reducedSeconds) => {
+			const EXTRA_DELAY = 50; // Deliberate imperceptible delay to prevent off-by-one timekeeping errors
 
-			if (self.config.displaySeconds) {
+			if (this.config.displaySeconds) {
 				return 1000 - moment().milliseconds() + EXTRA_DELAY;
 			} else {
 				return (60 - reducedSeconds) * 1000 - moment().milliseconds() + EXTRA_DELAY;
 			}
 		};
 
-		//A recursive timeout function instead of interval to avoid drifting
-		var notificationTimer = function () {
-			self.updateDom();
+		// A recursive timeout function instead of interval to avoid drifting
+		const notificationTimer = () => {
+			this.updateDom();
 
-			//If seconds is displayed CLOCK_SECOND-notification should be sent (but not when CLOCK_MINUTE-notification is sent)
-			if (self.config.displaySeconds) {
-				self.second = moment().second();
-				if (self.second !== 0) {
-					self.sendNotification("CLOCK_SECOND", self.second);
+			// If seconds is displayed CLOCK_SECOND-notification should be sent (but not when CLOCK_MINUTE-notification is sent)
+			if (this.config.displaySeconds) {
+				this.second = moment().second();
+				if (this.second !== 0) {
+					this.sendNotification("CLOCK_SECOND", this.second);
 					setTimeout(notificationTimer, delayCalculator(0));
 					return;
 				}
 			}
 
-			//If minute changed or seconds isn't displayed send CLOCK_MINUTE-notification
-			self.minute = moment().minute();
-			self.sendNotification("CLOCK_MINUTE", self.minute);
+			// If minute changed or seconds isn't displayed send CLOCK_MINUTE-notification
+			this.minute = moment().minute();
+			this.sendNotification("CLOCK_MINUTE", this.minute);
 			setTimeout(notificationTimer, delayCalculator(0));
 		};
 
-		//Set the initial timeout with the amount of seconds elapsed as reducedSeconds so it will trigger when the minute changes
-		setTimeout(notificationTimer, delayCalculator(self.second));
+		// Set the initial timeout with the amount of seconds elapsed as reducedSeconds so it will trigger when the minute changes
+		setTimeout(notificationTimer, delayCalculator(this.second));
 
 		// Set locale.
 		moment.locale(config.language);
 	},
 	// Override dom generator.
 	getDom: function () {
-		var wrapper = document.createElement("div");
+		const wrapper = document.createElement("div");
 
 		/************************************
 		 * Create wrappers for DIGITAL clock
 		 */
 
-		var dateWrapper = document.createElement("div");
-		var timeWrapper = document.createElement("div");
-		var secondsWrapper = document.createElement("sup");
-		var periodWrapper = document.createElement("span");
-		var sunWrapper = document.createElement("div");
-		var moonWrapper = document.createElement("div");
-		var weekWrapper = document.createElement("div");
+		const dateWrapper = document.createElement("div");
+		const timeWrapper = document.createElement("div");
+		const secondsWrapper = document.createElement("sup");
+		const periodWrapper = document.createElement("span");
+		const sunWrapper = document.createElement("div");
+		const moonWrapper = document.createElement("div");
+		const weekWrapper = document.createElement("div");
 		// Style Wrappers
 		dateWrapper.className = "date normal medium";
 		timeWrapper.className = "time bright large light";
@@ -114,14 +113,13 @@ Module.register("clock", {
 		// The moment().format("h") method has a bug on the Raspberry Pi.
 		// So we need to generate the timestring manually.
 		// See issue: https://github.com/MichMich/MagicMirror/issues/181
-		var timeString;
-		var now = moment();
-		this.lastDisplayedMinute = now.minute();
+		let timeString;
+		const now = moment();
 		if (this.config.timezone) {
 			now.tz(this.config.timezone);
 		}
 
-		var hourSymbol = "HH";
+		let hourSymbol = "HH";
 		if (this.config.timeFormat !== 24) {
 			hourSymbol = "h";
 		}
@@ -160,7 +158,7 @@ Module.register("clock", {
 		 * @returns {string} The formatted time string
 		 */
 		function formatTime(config, time) {
-			var formatString = hourSymbol + ":mm";
+			let formatString = hourSymbol + ":mm";
 			if (config.showPeriod && config.timeFormat !== 24) {
 				formatString += config.showPeriodUpper ? "A" : "a";
 			}
@@ -170,7 +168,7 @@ Module.register("clock", {
 		if (this.config.showSunTimes) {
 			const sunTimes = SunCalc.getTimes(now, this.config.lat, this.config.lon);
 			const isVisible = now.isBetween(sunTimes.sunrise, sunTimes.sunset);
-			var nextEvent;
+			let nextEvent;
 			if (now.isBefore(sunTimes.sunrise)) {
 				nextEvent = sunTimes.sunrise;
 			} else if (now.isBefore(sunTimes.sunset)) {
@@ -198,7 +196,7 @@ Module.register("clock", {
 			const moonIllumination = SunCalc.getMoonIllumination(now.toDate());
 			const moonTimes = SunCalc.getMoonTimes(now, this.config.lat, this.config.lon);
 			const moonRise = moonTimes.rise;
-			var moonSet;
+			let moonSet;
 			if (moment(moonTimes.set).isAfter(moonTimes.rise)) {
 				moonSet = moonTimes.set;
 			} else {
@@ -224,6 +222,7 @@ Module.register("clock", {
 		/****************************************************************
 		 * Create wrappers for ANALOG clock, only if specified in config
 		 */
+		const clockCircle = document.createElement("div");
 
 		if (this.config.displayType !== "digital") {
 			// If it isn't 'digital', then an 'analog' clock was also requested
@@ -232,12 +231,11 @@ Module.register("clock", {
 			if (this.config.timezone) {
 				now.tz(this.config.timezone);
 			}
-			var second = now.seconds() * 6,
+			const second = now.seconds() * 6,
 				minute = now.minute() * 6 + second / 60,
 				hour = ((now.hours() % 12) / 12) * 360 + 90 + minute / 12;
 
 			// Create wrappers
-			var clockCircle = document.createElement("div");
 			clockCircle.className = "clockCircle";
 			clockCircle.style.width = this.config.analogSize;
 			clockCircle.style.height = this.config.analogSize;
@@ -252,14 +250,14 @@ Module.register("clock", {
 			} else if (this.config.analogFace !== "none") {
 				clockCircle.style.border = "2px solid white";
 			}
-			var clockFace = document.createElement("div");
+			const clockFace = document.createElement("div");
 			clockFace.className = "clockFace";
 
-			var clockHour = document.createElement("div");
+			const clockHour = document.createElement("div");
 			clockHour.id = "clockHour";
 			clockHour.style.transform = "rotate(" + hour + "deg)";
 			clockHour.className = "clockHour";
-			var clockMinute = document.createElement("div");
+			const clockMinute = document.createElement("div");
 			clockMinute.id = "clockMinute";
 			clockMinute.style.transform = "rotate(" + minute + "deg)";
 			clockMinute.className = "clockMinute";
@@ -269,7 +267,7 @@ Module.register("clock", {
 			clockFace.appendChild(clockMinute);
 
 			if (this.config.displaySeconds) {
-				var clockSecond = document.createElement("div");
+				const clockSecond = document.createElement("div");
 				clockSecond.id = "clockSecond";
 				clockSecond.style.transform = "rotate(" + second + "deg)";
 				clockSecond.className = "clockSecond";
@@ -312,14 +310,14 @@ Module.register("clock", {
 			}
 		} else {
 			// Both clocks have been configured, check position
-			var placement = this.config.analogPlacement;
+			const placement = this.config.analogPlacement;
 
-			var analogWrapper = document.createElement("div");
+			const analogWrapper = document.createElement("div");
 			analogWrapper.id = "analog";
 			analogWrapper.style.cssFloat = "none";
 			analogWrapper.appendChild(clockCircle);
 
-			var digitalWrapper = document.createElement("div");
+			const digitalWrapper = document.createElement("div");
 			digitalWrapper.id = "digital";
 			digitalWrapper.style.cssFloat = "none";
 			digitalWrapper.appendChild(dateWrapper);
@@ -328,8 +326,8 @@ Module.register("clock", {
 			digitalWrapper.appendChild(moonWrapper);
 			digitalWrapper.appendChild(weekWrapper);
 
-			var appendClocks = function (condition, pos1, pos2) {
-				var padding = [0, 0, 0, 0];
+			const appendClocks = (condition, pos1, pos2) => {
+				const padding = [0, 0, 0, 0];
 				padding[placement === condition ? pos1 : pos2] = "20px";
 				analogWrapper.style.padding = padding.join(" ");
 				if (placement === condition) {

--- a/modules/default/clock/clock_styles.css
+++ b/modules/default/clock/clock_styles.css
@@ -29,7 +29,7 @@
   position: absolute;
   top: 50%;
   left: 50%;
-  margin: -2px 0 -2px -25%; /* numbers much match negative length & thickness */
+  margin: -2px 0 -2px -25%; /* numbers must match negative length & thickness */
   padding: 2px 0 2px 25%; /* indicator length & thickness */
   background: var(--color-text-bright);
   transform-origin: 100% 50%;

--- a/modules/default/compliments/compliments.js
+++ b/modules/default/compliments/compliments.js
@@ -39,37 +39,35 @@ Module.register("compliments", {
 
 		this.lastComplimentIndex = -1;
 
-		var self = this;
 		if (this.config.remoteFile !== null) {
-			this.complimentFile(function (response) {
-				self.config.compliments = JSON.parse(response);
-				self.updateDom();
+			this.complimentFile((response) => {
+				this.config.compliments = JSON.parse(response);
+				this.updateDom();
 			});
 		}
 
 		// Schedule update timer.
-		setInterval(function () {
-			self.updateDom(self.config.fadeSpeed);
+		setInterval(() => {
+			this.updateDom(this.config.fadeSpeed);
 		}, this.config.updateInterval);
 	},
 
-	/* randomIndex(compliments)
+	/**
 	 * Generate a random index for a list of compliments.
 	 *
-	 * argument compliments Array<String> - Array with compliments.
-	 *
-	 * return Number - Random index.
+	 * @param  {string[]} compliments Array with compliments.
+	 * @returns {number} a random index of given array
 	 */
 	randomIndex: function (compliments) {
 		if (compliments.length === 1) {
 			return 0;
 		}
 
-		var generate = function () {
+		const generate = function () {
 			return Math.floor(Math.random() * compliments.length);
 		};
 
-		var complimentIndex = generate();
+		let complimentIndex = generate();
 
 		while (complimentIndex === this.lastComplimentIndex) {
 			complimentIndex = generate();
@@ -80,15 +78,15 @@ Module.register("compliments", {
 		return complimentIndex;
 	},
 
-	/* complimentArray()
+	/**
 	 * Retrieve an array of compliments for the time of the day.
 	 *
-	 * return compliments Array<String> - Array with compliments for the time of the day.
+	 * @returns {string[]} array with compliments for the time of the day.
 	 */
 	complimentArray: function () {
-		var hour = moment().hour();
-		var date = this.config.mockDate ? this.config.mockDate : moment().format("YYYY-MM-DD");
-		var compliments;
+		const hour = moment().hour();
+		const date = this.config.mockDate ? this.config.mockDate : moment().format("YYYY-MM-DD");
+		let compliments;
 
 		if (hour >= this.config.morningStartTime && hour < this.config.morningEndTime && this.config.compliments.hasOwnProperty("morning")) {
 			compliments = this.config.compliments.morning.slice(0);
@@ -99,7 +97,7 @@ Module.register("compliments", {
 		}
 
 		if (typeof compliments === "undefined") {
-			compliments = new Array();
+			compliments = [];
 		}
 
 		if (this.currentWeatherType in this.config.compliments) {
@@ -108,7 +106,7 @@ Module.register("compliments", {
 
 		compliments.push.apply(compliments, this.config.compliments.anytime);
 
-		for (var entry in this.config.compliments) {
+		for (let entry in this.config.compliments) {
 			if (new RegExp(entry).test(date)) {
 				compliments.push.apply(compliments, this.config.compliments[entry]);
 			}
@@ -117,11 +115,13 @@ Module.register("compliments", {
 		return compliments;
 	},
 
-	/* complimentFile(callback)
+	/**
 	 * Retrieve a file from the local filesystem
+	 *
+	 * @param {Function} callback Called when the file is retrieved.
 	 */
 	complimentFile: function (callback) {
-		var xobj = new XMLHttpRequest(),
+		const xobj = new XMLHttpRequest(),
 			isRemote = this.config.remoteFile.indexOf("http://") === 0 || this.config.remoteFile.indexOf("https://") === 0,
 			path = isRemote ? this.config.remoteFile : this.file(this.config.remoteFile);
 		xobj.overrideMimeType("application/json");
@@ -134,16 +134,16 @@ Module.register("compliments", {
 		xobj.send(null);
 	},
 
-	/* complimentArray()
+	/**
 	 * Retrieve a random compliment.
 	 *
-	 * return compliment string - A compliment.
+	 * @returns {string} a compliment
 	 */
 	randomCompliment: function () {
 		// get the current time of day compliments list
-		var compliments = this.complimentArray();
+		const compliments = this.complimentArray();
 		// variable for index to next message to display
-		let index = 0;
+		let index;
 		// are we randomizing
 		if (this.config.random) {
 			// yes
@@ -159,16 +159,16 @@ Module.register("compliments", {
 
 	// Override dom generator.
 	getDom: function () {
-		var wrapper = document.createElement("div");
+		const wrapper = document.createElement("div");
 		wrapper.className = this.config.classes ? this.config.classes : "thin xlarge bright pre-line";
 		// get the compliment text
-		var complimentText = this.randomCompliment();
+		const complimentText = this.randomCompliment();
 		// split it into parts on newline text
-		var parts = complimentText.split("\n");
+		const parts = complimentText.split("\n");
 		// create a span to hold it all
-		var compliment = document.createElement("span");
+		const compliment = document.createElement("span");
 		// process all the parts of the compliment text
-		for (var part of parts) {
+		for (const part of parts) {
 			// create a text element for each part
 			compliment.appendChild(document.createTextNode(part));
 			// add a break `

--- a/modules/default/defaultmodules.js
+++ b/modules/default/defaultmodules.js
@@ -1,13 +1,10 @@
-/* Magic Mirror
- * Default Modules List
+/* Magic Mirror Default Modules List
+ * Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
  *
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-
-// Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
-
-var defaultModules = ["alert", "calendar", "clock", "compliments", "currentweather", "helloworld", "newsfeed", "weatherforecast", "updatenotification", "weather"];
+const defaultModules = ["alert", "calendar", "clock", "compliments", "currentweather", "helloworld", "newsfeed", "weatherforecast", "updatenotification", "weather"];
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -18,19 +18,18 @@ Module.register("updatenotification", {
 
 	// Override start method.
 	start: function () {
-		var self = this;
 		Log.info("Starting module: " + this.name);
 		setInterval(() => {
-			self.moduleList = {};
-			self.updateDom(2);
-		}, self.config.refreshInterval);
+			this.moduleList = {};
+			this.updateDom(2);
+		}, this.config.refreshInterval);
 	},
 
 	notificationReceived: function (notification, payload, sender) {
 		if (notification === "DOM_OBJECTS_CREATED") {
 			this.sendSocketNotification("CONFIG", this.config);
 			this.sendSocketNotification("MODULES", Module.definitions);
-			//this.hide(0, { lockString: self.identifier });
+			//this.hide(0, { lockString: this.identifier });
 		}
 	},
 
@@ -42,13 +41,12 @@ Module.register("updatenotification", {
 	},
 
 	updateUI: function (payload) {
-		var self = this;
 		if (payload && payload.behind > 0) {
 			// if we haven't seen info for this module
 			if (this.moduleList[payload.module] === undefined) {
 				// save it
 				this.moduleList[payload.module] = payload;
-				self.updateDom(2);
+				this.updateDom(2);
 			}
 			//self.show(1000, { lockString: self.identifier });
 		} else if (payload && payload.behind === 0) {
@@ -56,41 +54,41 @@ Module.register("updatenotification", {
 			if (this.moduleList[payload.module] !== undefined) {
 				// remove it
 				delete this.moduleList[payload.module];
-				self.updateDom(2);
+				this.updateDom(2);
 			}
 		}
 	},
 
 	diffLink: function (module, text) {
-		var localRef = module.hash;
-		var remoteRef = module.tracking.replace(/.*\//, "");
+		const localRef = module.hash;
+		const remoteRef = module.tracking.replace(/.*\//, "");
 		return '<a href="https://github.com/MichMich/MagicMirror/compare/' + localRef + "..." + remoteRef + '" ' + 'class="xsmall dimmed" ' + 'style="text-decoration: none;" ' + 'target="_blank" >' + text + "</a>";
 	},
 
 	// Override dom generator.
 	getDom: function () {
-		var wrapper = document.createElement("div");
+		const wrapper = document.createElement("div");
 		if (this.suspended === false) {
 			// process the hash of module info found
-			for (var key of Object.keys(this.moduleList)) {
+			for (const key of Object.keys(this.moduleList)) {
 				let m = this.moduleList[key];
 
-				var message = document.createElement("div");
+				const message = document.createElement("div");
 				message.className = "small bright";
 
-				var icon = document.createElement("i");
+				const icon = document.createElement("i");
 				icon.className = "fa fa-exclamation-circle";
 				icon.innerHTML = "&nbsp;";
 				message.appendChild(icon);
 
-				var updateInfoKeyName = m.behind === 1 ? "UPDATE_INFO_SINGLE" : "UPDATE_INFO_MULTIPLE";
+				const updateInfoKeyName = m.behind === 1 ? "UPDATE_INFO_SINGLE" : "UPDATE_INFO_MULTIPLE";
 
-				var subtextHtml = this.translate(updateInfoKeyName, {
+				let subtextHtml = this.translate(updateInfoKeyName, {
 					COMMIT_COUNT: m.behind,
 					BRANCH_NAME: m.current
 				});
 
-				var text = document.createElement("span");
+				const text = document.createElement("span");
 				if (m.module === "default") {
 					text.innerHTML = this.translate("UPDATE_NOTIFICATION");
 					subtextHtml = this.diffLink(m, subtextHtml);
@@ -103,7 +101,7 @@ Module.register("updatenotification", {
 
 				wrapper.appendChild(message);
 
-				var subtext = document.createElement("div");
+				const subtext = document.createElement("div");
 				subtext.innerHTML = subtextHtml;
 				subtext.className = "xsmall dimmed";
 				wrapper.appendChild(subtext);

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -74,7 +74,7 @@ WeatherProvider.register("smhi", {
 	getClosestToCurrentTime(times) {
 		let now = moment();
 		let minDiff = undefined;
-		for (time of times) {
+		for (const time of times) {
 			let diff = Math.abs(moment(time.validTime).diff(now));
 			if (!minDiff || diff < Math.abs(moment(minDiff.validTime).diff(now))) {
 				minDiff = time;
@@ -149,13 +149,13 @@ WeatherProvider.register("smhi", {
 	 * @param coordinates
 	 */
 	convertWeatherDataGroupedByDay(allWeatherData, coordinates) {
-		var currentWeather;
+		let currentWeather;
 		let result = [];
 
 		let allWeatherObjects = this.fillInGaps(allWeatherData).map((weatherData) => this.convertWeatherDataToObject(weatherData, coordinates));
-		var dayWeatherTypes = [];
+		let dayWeatherTypes = [];
 
-		for (weatherObject of allWeatherObjects) {
+		for (const weatherObject of allWeatherObjects) {
 			//If its the first object or if a day change we need to reset the summary object
 			if (!currentWeather || !currentWeather.date.isSame(weatherObject.date, "day")) {
 				currentWeather = new WeatherObject(this.config.units, this.config.tempUnits, this.config.windUnits);
@@ -216,12 +216,12 @@ WeatherProvider.register("smhi", {
 	 */
 	fillInGaps(data) {
 		let result = [];
-		for (var i = 1; i < data.length; i++) {
+		for (const i = 1; i < data.length; i++) {
 			let to = moment(data[i].validTime);
 			let from = moment(data[i - 1].validTime);
 			let hours = moment.duration(to.diff(from)).asHours();
 			// For each hour add a datapoint but change the validTime
-			for (var j = 0; j < hours; j++) {
+			for (const j = 0; j < hours; j++) {
 				let current = Object.assign({}, data[i]);
 				current.validTime = from.clone().add(j, "hours").toISOString();
 				result.push(current);

--- a/modules/default/weather/providers/ukmetoffice.js
+++ b/modules/default/weather/providers/ukmetoffice.js
@@ -81,6 +81,7 @@ WeatherProvider.register("ukmetoffice", {
 	 */
 	generateWeatherObjectFromCurrentWeather(currentWeatherData) {
 		const currentWeather = new WeatherObject(this.config.units, this.config.tempUnits, this.config.windUnits, this.config.useKmh);
+		const location = currentWeatherData.SiteRep.DV.Location;
 
 		// data times are always UTC
 		let nowUtc = moment.utc();
@@ -88,8 +89,8 @@ WeatherProvider.register("ukmetoffice", {
 		let timeInMins = nowUtc.diff(midnightUtc, "minutes");
 
 		// loop round each of the (5) periods, look for today (the first period may be yesterday)
-		for (var i in currentWeatherData.SiteRep.DV.Location.Period) {
-			let periodDate = moment.utc(currentWeatherData.SiteRep.DV.Location.Period[i].value.substr(0, 10), "YYYY-MM-DD");
+		for (const period of location.Period) {
+			const periodDate = moment.utc(period.value.substr(0, 10), "YYYY-MM-DD");
 
 			// ignore if period is before today
 			if (periodDate.isSameOrAfter(moment.utc().startOf("day"))) {
@@ -97,17 +98,17 @@ WeatherProvider.register("ukmetoffice", {
 				if (moment().diff(periodDate, "minutes") > 0) {
 					// loop round the reports looking for the one we are in
 					// $ value specifies the time in minutes-of-the-day: 0, 180, 360,...1260
-					for (var j in currentWeatherData.SiteRep.DV.Location.Period[i].Rep) {
-						let p = currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].$;
+					for (const rep of period.Rep) {
+						const p = rep.$;
 						if (timeInMins >= p && timeInMins - 180 < p) {
 							// finally got the one we want, so populate weather object
-							currentWeather.humidity = currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].H;
-							currentWeather.temperature = this.convertTemp(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].T);
-							currentWeather.feelsLikeTemp = this.convertTemp(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].F);
-							currentWeather.precipitation = parseInt(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].Pp);
-							currentWeather.windSpeed = this.convertWindSpeed(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].S);
-							currentWeather.windDirection = this.convertWindDirection(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].D);
-							currentWeather.weatherType = this.convertWeatherType(currentWeatherData.SiteRep.DV.Location.Period[i].Rep[j].W);
+							currentWeather.humidity = rep.H;
+							currentWeather.temperature = this.convertTemp(rep.T);
+							currentWeather.feelsLikeTemp = this.convertTemp(rep.F);
+							currentWeather.precipitation = parseInt(rep.Pp);
+							currentWeather.windSpeed = this.convertWindSpeed(rep.S);
+							currentWeather.windDirection = this.convertWindDirection(rep.D);
+							currentWeather.weatherType = this.convertWeatherType(rep.W);
 						}
 					}
 				}
@@ -115,7 +116,7 @@ WeatherProvider.register("ukmetoffice", {
 		}
 
 		// determine the sunrise/sunset times - not supplied in UK Met Office data
-		let times = this.calcAstroData(currentWeatherData.SiteRep.DV.Location);
+		let times = this.calcAstroData(location);
 		currentWeather.sunrise = times[0];
 		currentWeather.sunset = times[1];
 
@@ -130,21 +131,21 @@ WeatherProvider.register("ukmetoffice", {
 
 		// loop round the (5) periods getting the data
 		// for each period array, Day is [0], Night is [1]
-		for (var j in forecasts.SiteRep.DV.Location.Period) {
+		for (const period of forecasts.SiteRep.DV.Location.Period) {
 			const weather = new WeatherObject(this.config.units, this.config.tempUnits, this.config.windUnits, this.config.useKmh);
 
 			// data times are always UTC
-			const dateStr = forecasts.SiteRep.DV.Location.Period[j].value;
+			const dateStr = period.value;
 			let periodDate = moment.utc(dateStr.substr(0, 10), "YYYY-MM-DD");
 
 			// ignore if period is before today
 			if (periodDate.isSameOrAfter(moment.utc().startOf("day"))) {
 				// populate the weather object
 				weather.date = moment.utc(dateStr.substr(0, 10), "YYYY-MM-DD");
-				weather.minTemperature = this.convertTemp(forecasts.SiteRep.DV.Location.Period[j].Rep[1].Nm);
-				weather.maxTemperature = this.convertTemp(forecasts.SiteRep.DV.Location.Period[j].Rep[0].Dm);
-				weather.weatherType = this.convertWeatherType(forecasts.SiteRep.DV.Location.Period[j].Rep[0].W);
-				weather.precipitation = parseInt(forecasts.SiteRep.DV.Location.Period[j].Rep[0].PPd);
+				weather.minTemperature = this.convertTemp(period.Rep[1].Nm);
+				weather.maxTemperature = this.convertTemp(period.Rep[0].Dm);
+				weather.weatherType = this.convertWeatherType(period.Rep[0].W);
+				weather.precipitation = parseInt(period.Rep[0].PPd);
 
 				days.push(weather);
 			}

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -48,6 +48,9 @@ Module.register("weather", {
 	// Module properties.
 	weatherProvider: null,
 
+	// Can be used by the provider to display location of event if nothing else is specified
+	firstEvent: null,
+
 	// Define required scripts.
 	getStyles: function () {
 		return ["font-awesome.css", "weather-icons.css", "weather.css"];
@@ -88,15 +91,13 @@ Module.register("weather", {
 	// Override notification handler.
 	notificationReceived: function (notification, payload, sender) {
 		if (notification === "CALENDAR_EVENTS") {
-			var senderClasses = sender.data.classes.toLowerCase().split(" ");
+			const senderClasses = sender.data.classes.toLowerCase().split(" ");
 			if (senderClasses.indexOf(this.config.calendarClass.toLowerCase()) !== -1) {
-				this.firstEvent = false;
-
-				for (var e in payload) {
-					var event = payload[e];
+				this.firstEvent = null;
+				for (let event of payload) {
 					if (event.location || event.geo) {
 						this.firstEvent = event;
-						//Log.log("First upcoming event with location: ", event);
+						Log.debug("First upcoming event with location: ", event);
 						break;
 					}
 				}
@@ -114,15 +115,15 @@ Module.register("weather", {
 	getTemplate: function () {
 		switch (this.config.type.toLowerCase()) {
 			case "current":
-				return `current.njk`;
+				return "current.njk";
 			case "hourly":
-				return `hourly.njk`;
+				return "hourly.njk";
 			case "daily":
 			case "forecast":
-				return `forecast.njk`;
+				return "forecast.njk";
 			//Make the invalid values use the "Loading..." from forecast
 			default:
-				return `forecast.njk`;
+				return "forecast.njk";
 		}
 	},
 
@@ -152,7 +153,7 @@ Module.register("weather", {
 	},
 
 	scheduleUpdate: function (delay = null) {
-		var nextLoad = this.config.updateInterval;
+		let nextLoad = this.config.updateInterval;
 		if (delay !== null && delay >= 0) {
 			nextLoad = delay;
 		}
@@ -176,8 +177,8 @@ Module.register("weather", {
 	},
 
 	roundValue: function (temperature) {
-		var decimals = this.config.roundTemp ? 0 : 1;
-		var roundValue = parseFloat(temperature).toFixed(decimals);
+		const decimals = this.config.roundTemp ? 0 : 1;
+		const roundValue = parseFloat(temperature).toFixed(decimals);
 		return roundValue === "-0" ? 0 : roundValue;
 	},
 
@@ -272,8 +273,8 @@ Module.register("weather", {
 					if (this.config.fadePoint < 0) {
 						this.config.fadePoint = 0;
 					}
-					var startingPoint = numSteps * this.config.fadePoint;
-					var numFadesteps = numSteps - startingPoint;
+					const startingPoint = numSteps * this.config.fadePoint;
+					const numFadesteps = numSteps - startingPoint;
 					if (currentStep >= startingPoint) {
 						return 1 - (currentStep - startingPoint) / numFadesteps;
 					} else {

--- a/modules/default/weather/weatherprovider.js
+++ b/modules/default/weather/weatherprovider.js
@@ -8,7 +8,7 @@
  *
  * This class is the blueprint for a weather provider.
  */
-var WeatherProvider = Class.extend({
+const WeatherProvider = Class.extend({
 	// Weather Provider Properties
 	providerName: null,
 	defaults: {},
@@ -114,7 +114,7 @@ var WeatherProvider = Class.extend({
 	// A convenience function to make requests. It returns a promise.
 	fetchData: function (url, method = "GET", data = null) {
 		return new Promise(function (resolve, reject) {
-			var request = new XMLHttpRequest();
+			const request = new XMLHttpRequest();
 			request.open(method, url, true);
 			request.onreadystatechange = function () {
 				if (this.readyState === 4) {

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -1,8 +1,8 @@
 const app = require("../js/app.js");
 const Log = require("logger");
 
-app.start(function (config) {
-	var bindAddress = config.address ? config.address : "localhost";
-	var httpType = config.useHttps ? "https" : "http";
+app.start((config) => {
+	const bindAddress = config.address ? config.address : "localhost";
+	const httpType = config.useHttps ? "https" : "http";
 	Log.log("\nReady to go! Please point your browser to: " + httpType + "://" + bindAddress + ":" + config.port);
 });

--- a/tests/configs/empty_ipWhiteList.js
+++ b/tests/configs/empty_ipWhiteList.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: [],
 

--- a/tests/configs/env.js
+++ b/tests/configs/env.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/auth-default.js
+++ b/tests/configs/modules/calendar/auth-default.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/basic-auth.js
+++ b/tests/configs/modules/calendar/basic-auth.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/changed-port.js
+++ b/tests/configs/modules/calendar/changed-port.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/custom.js
+++ b/tests/configs/modules/calendar/custom.js
@@ -1,5 +1,6 @@
 /* Magic Mirror Test config custom calendar
  *
+ * By Rejas
  * MIT Licensed.
  */
 let config = {

--- a/tests/configs/modules/calendar/default.js
+++ b/tests/configs/modules/calendar/default.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/fail-basic-auth.js
+++ b/tests/configs/modules/calendar/fail-basic-auth.js
@@ -5,8 +5,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/calendar/old-basic-auth.js
+++ b/tests/configs/modules/calendar/old-basic-auth.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/clock_12hr.js
+++ b/tests/configs/modules/clock/clock_12hr.js
@@ -3,8 +3,7 @@
  * By Sergey Morozov
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/clock_24hr.js
+++ b/tests/configs/modules/clock/clock_24hr.js
@@ -3,8 +3,7 @@
  * By Sergey Morozov
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/clock_displaySeconds_false.js
+++ b/tests/configs/modules/clock/clock_displaySeconds_false.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/clock_showPeriodUpper.js
@@ -3,8 +3,7 @@
  * By Sergey Morozov
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/clock_showWeek.js
+++ b/tests/configs/modules/clock/clock_showWeek.js
@@ -3,8 +3,7 @@
  * By Johan Hammar
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/es/clock_12hr.js
+++ b/tests/configs/modules/clock/es/clock_12hr.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/es/clock_24hr.js
+++ b/tests/configs/modules/clock/es/clock_24hr.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/es/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/es/clock_showPeriodUpper.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/es/clock_showWeek.js
+++ b/tests/configs/modules/clock/es/clock_showWeek.js
@@ -6,8 +6,7 @@
  *
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/clock/es/clock_showWeek.js
+++ b/tests/configs/modules/clock/es/clock_showWeek.js
@@ -1,9 +1,7 @@
 /* Magic Mirror Test config for default clock module
  * Language es for showWeek feature
  *
- * By Rodrigo Ramírez Norambuena
- *    https://rodrigoramirez.com
- *
+ * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
 let config = {

--- a/tests/configs/modules/compliments/compliments_anytime.js
+++ b/tests/configs/modules/compliments/compliments_anytime.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config compliments with date type
  *
  * By Rejas
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/compliments/compliments_only_anytime.js
+++ b/tests/configs/modules/compliments/compliments_only_anytime.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/compliments/compliments_parts_day.js
+++ b/tests/configs/modules/compliments/compliments_parts_day.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/display.js
+++ b/tests/configs/modules/display.js
@@ -1,5 +1,6 @@
 /* Magic Mirror Test config for display setters module using the helloworld module
  *
+ * By Rejas
  * MIT Licensed.
  */
 let config = {
@@ -37,6 +38,7 @@ let config = {
 		}
 	]
 };
+
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {
 	module.exports = config;

--- a/tests/configs/modules/display.js
+++ b/tests/configs/modules/display.js
@@ -2,7 +2,7 @@
  *
  * MIT Licensed.
  */
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/helloworld/helloworld.js
+++ b/tests/configs/modules/helloworld/helloworld.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/helloworld/helloworld_default.js
+++ b/tests/configs/modules/helloworld/helloworld_default.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/modules/positions.js
+++ b/tests/configs/modules/positions.js
@@ -5,8 +5,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 
@@ -23,9 +22,9 @@ var config = {
 	modules:
 		// Using exotic content. This is why don't accept go to JSON configuration file
 		(function () {
-			var positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
-			var modules = Array();
-			for (var idx in positions) {
+			let positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
+			let modules = Array();
+			for (let idx in positions) {
 				modules.push({
 					module: "helloworld",
 					position: positions[idx],

--- a/tests/configs/modules/positions.js
+++ b/tests/configs/modules/positions.js
@@ -1,6 +1,4 @@
-/* Magic Mirror Test config for position setters module
- *
- * For this case is using helloworld module
+/* Magic Mirror Test config for position setters module using the helloworld module
  *
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
@@ -36,6 +34,7 @@ let config = {
 			return modules;
 		})()
 };
+
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {
 	module.exports = config;

--- a/tests/configs/modules/weather/currentweather_compliments.js
+++ b/tests/configs/modules/weather/currentweather_compliments.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config current weather compliments
  *
  * By rejas https://github.com/rejas
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/weather/currentweather_default.js
+++ b/tests/configs/modules/weather/currentweather_default.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config default weather
  *
  * By fewieden https://github.com/fewieden
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/weather/currentweather_options.js
+++ b/tests/configs/modules/weather/currentweather_options.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config default weather
  *
  * By fewieden https://github.com/fewieden
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/weather/currentweather_units.js
+++ b/tests/configs/modules/weather/currentweather_units.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config default weather
  *
  * By fewieden https://github.com/fewieden
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/weather/forecastweather_default.js
+++ b/tests/configs/modules/weather/forecastweather_default.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config default weather
  *
  * By fewieden https://github.com/fewieden
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/modules/weather/forecastweather_options.js
+++ b/tests/configs/modules/weather/forecastweather_options.js
@@ -1,10 +1,8 @@
 /* Magic Mirror Test config default weather
  *
  * By fewieden https://github.com/fewieden
- *
  * MIT Licensed.
  */
-
 let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],

--- a/tests/configs/noIpWhiteList.js
+++ b/tests/configs/noIpWhiteList.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["x.x.x.x"],
 

--- a/tests/configs/port_8090.js
+++ b/tests/configs/port_8090.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8090,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1"],
 

--- a/tests/configs/without_modules.js
+++ b/tests/configs/without_modules.js
@@ -3,8 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-
-var config = {
+let config = {
 	port: 8080,
 	ipWhitelist: ["127.0.0.1", "::ffff:127.0.0.1", "::1", "::ffff:192.168.10.1"],
 

--- a/tests/e2e/dev_console.js
+++ b/tests/e2e/dev_console.js
@@ -12,7 +12,7 @@ describe("Development console tests", function () {
 	/* eslint-disable */
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	before(function () {
 		// Set config sample for use in test

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -10,7 +10,7 @@ const afterEach = global.afterEach;
 describe("Electron app environment", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	before(function () {
 		// Set config sample for use in test

--- a/tests/e2e/fonts.js
+++ b/tests/e2e/fonts.js
@@ -8,12 +8,12 @@ const describe = global.describe;
 describe("All font files from roboto.css should be downloadable", function () {
 	helpers.setupTimeout(this);
 
-	var app;
-	var fontFiles = [];
+	let app;
+	const fontFiles = [];
 	// Statements below filters out all 'url' lines in the CSS file
-	var fileContent = require("fs").readFileSync(__dirname + "/../../fonts/roboto.css", "utf8");
-	var regex = /\burl\(['"]([^'"]+)['"]\)/g;
-	var match = regex.exec(fileContent);
+	const fileContent = require("fs").readFileSync(__dirname + "/../../fonts/roboto.css", "utf8");
+	const regex = /\burl\(['"]([^'"]+)['"]\)/g;
+	let match = regex.exec(fileContent);
 	while (match !== null) {
 		// Push 1st match group onto fontFiles stack
 		fontFiles.push(match[1]);
@@ -39,7 +39,7 @@ describe("All font files from roboto.css should be downloadable", function () {
 	});
 
 	forEach(fontFiles).it("should return 200 HTTP code for file '%s'", (fontFile, done) => {
-		var fontUrl = "http://localhost:8080/fonts/" + fontFile;
+		const fontUrl = "http://localhost:8080/fonts/" + fontFile;
 		fetch(fontUrl).then((res) => {
 			expect(res.status).to.equal(200);
 			done();

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -1,13 +1,9 @@
 /*
- * Magic Mirror
- *
- * Global Setup Test Suite
+ * Magic Mirror Global Setup Test Suite
  *
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
- *
  */
-
 const Application = require("spectron").Application;
 const assert = require("assert");
 const chai = require("chai");

--- a/tests/e2e/ipWhistlist_spec.js
+++ b/tests/e2e/ipWhistlist_spec.js
@@ -10,7 +10,7 @@ const afterEach = global.afterEach;
 describe("ipWhitelist directive configuration", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers
@@ -31,6 +31,7 @@ describe("ipWhitelist directive configuration", function () {
 			// Set config sample for use in test
 			process.env.MM_CONFIG_FILE = "tests/configs/noIpWhiteList.js";
 		});
+
 		it("should return 403", function (done) {
 			fetch("http://localhost:8080").then((res) => {
 				expect(res.status).to.equal(403);
@@ -44,6 +45,7 @@ describe("ipWhitelist directive configuration", function () {
 			// Set config sample for use in test
 			process.env.MM_CONFIG_FILE = "tests/configs/empty_ipWhiteList.js";
 		});
+
 		it("should return 200", function (done) {
 			fetch("http://localhost:8080").then((res) => {
 				expect(res.status).to.equal(200);

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -8,7 +8,7 @@ const afterEach = global.afterEach;
 describe("Clock set to spanish language module", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -10,7 +10,7 @@ const afterEach = global.afterEach;
 describe("Clock module", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -9,7 +9,7 @@ const afterEach = global.afterEach;
 describe("Compliments module", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers
@@ -32,7 +32,7 @@ describe("Compliments module", function () {
 		});
 
 		it("if Morning compliments for that part of day", async function () {
-			var hour = new Date().getHours();
+			const hour = new Date().getHours();
 			if (hour >= 3 && hour < 12) {
 				// if morning check
 				const elem = await app.client.$(".compliments");
@@ -43,9 +43,9 @@ describe("Compliments module", function () {
 		});
 
 		it("if Afternoon show Compliments for that part of day", async function () {
-			var hour = new Date().getHours();
+			const hour = new Date().getHours();
 			if (hour >= 12 && hour < 17) {
-				// if morning check
+				// if afternoon check
 				const elem = await app.client.$(".compliments");
 				return elem.getText(".compliments").then(function (text) {
 					expect(text).to.be.oneOf(["Hello", "Good Afternoon", "Afternoon test"]);
@@ -54,7 +54,7 @@ describe("Compliments module", function () {
 		});
 
 		it("if Evening show Compliments for that part of day", async function () {
-			var hour = new Date().getHours();
+			const hour = new Date().getHours();
 			if (!(hour >= 3 && hour < 12) && !(hour >= 12 && hour < 17)) {
 				// if evening check
 				const elem = await app.client.$(".compliments");

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -8,7 +8,7 @@ const afterEach = global.afterEach;
 describe("Test helloworld module", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/e2e/modules_display_spec.js
+++ b/tests/e2e/modules_display_spec.js
@@ -6,7 +6,7 @@ const it = global.it;
 describe("Display of modules", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/e2e/modules_position_spec.js
+++ b/tests/e2e/modules_position_spec.js
@@ -6,7 +6,7 @@ const it = global.it;
 describe("Position of modules", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	describe("Using helloworld", function () {
 		after(function () {
@@ -25,14 +25,11 @@ describe("Position of modules", function () {
 				});
 		});
 
-		var positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
+		const positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
 
-		var position;
-		var className;
-		for (var idx in positions) {
-			position = positions[idx];
-			className = position.replace("_", ".");
-			it("show text in " + position, function () {
+		for (const position of positions) {
+			const className = position.replace("_", ".");
+			it("should show text in " + position, function () {
 				return app.client.$("." + className).then((result) => {
 					return result.getText("." + className).should.eventually.equal("Text in " + position);
 				});

--- a/tests/e2e/port_config.js
+++ b/tests/e2e/port_config.js
@@ -10,7 +10,7 @@ const afterEach = global.afterEach;
 describe("port directive configuration", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/e2e/vendor_spec.js
+++ b/tests/e2e/vendor_spec.js
@@ -10,7 +10,7 @@ const after = global.after;
 describe("Vendors", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	before(function () {
 		process.env.MM_CONFIG_FILE = "tests/configs/env.js";
@@ -31,7 +31,7 @@ describe("Vendors", function () {
 		const vendors = require(__dirname + "/../../vendor/vendor.js");
 		Object.keys(vendors).forEach((vendor) => {
 			it(`should return 200 HTTP code for vendor "${vendor}"`, function () {
-				var urlVendor = "http://localhost:8080/vendor/" + vendors[vendor];
+				const urlVendor = "http://localhost:8080/vendor/" + vendors[vendor];
 				fetch(urlVendor).then((res) => {
 					expect(res.status).to.equal(200);
 				});
@@ -40,7 +40,7 @@ describe("Vendors", function () {
 
 		Object.keys(vendors).forEach((vendor) => {
 			it(`should return 404 HTTP code for vendor https://localhost/"${vendor}"`, function () {
-				var urlVendor = "http://localhost:8080/" + vendors[vendor];
+				const urlVendor = "http://localhost:8080/" + vendors[vendor];
 				fetch(urlVendor).then((res) => {
 					expect(res.status).to.equal(404);
 				});

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -8,7 +8,7 @@ const afterEach = global.afterEach;
 describe("Check configuration without modules", function () {
 	helpers.setupTimeout(this);
 
-	var app = null;
+	let app = null;
 
 	beforeEach(function () {
 		return helpers

--- a/tests/unit/classes/utils_spec.js
+++ b/tests/unit/classes/utils_spec.js
@@ -4,7 +4,7 @@ const colors = require("colors/safe");
 
 describe("Utils", function () {
 	describe("colors", function () {
-		var colorsEnabled = colors.enabled;
+		const colorsEnabled = colors.enabled;
 
 		afterEach(function () {
 			colors.enabled = colorsEnabled;

--- a/tests/unit/functions/currentweather_spec.js
+++ b/tests/unit/functions/currentweather_spec.js
@@ -21,7 +21,7 @@ describe("Functions module currentweather", function () {
 				Module.definitions.currentweather.config.roundTemp = true;
 			});
 
-			var values = [
+			const values = [
 				// index 0 value
 				// index 1 expect
 				[1, "1"],
@@ -45,7 +45,7 @@ describe("Functions module currentweather", function () {
 				Module.definitions.currentweather.config.roundTemp = false;
 			});
 
-			var values = [
+			const values = [
 				// index 0 value
 				// index 1 expect
 				[1, "1.0"],

--- a/tests/unit/functions/weatherforecast_spec.js
+++ b/tests/unit/functions/weatherforecast_spec.js
@@ -1,7 +1,7 @@
 /* eslint no-multi-spaces: 0 */
 const expect = require("chai").expect;
 const moment = require("moment-timezone");
-var data = require("../functions/weatherforecast_data.json");
+const data = require("../functions/weatherforecast_data.json");
 
 describe("Functions module weatherforecast", function () {
 	before(function () {
@@ -21,7 +21,7 @@ describe("Functions module weatherforecast", function () {
 				Module.definitions.weatherforecast.config.roundTemp = true;
 			});
 
-			var values = [
+			const values = [
 				// index 0 value
 				// index 1 expect
 				[1, "1"],
@@ -45,7 +45,7 @@ describe("Functions module weatherforecast", function () {
 				Module.definitions.weatherforecast.config.roundTemp = false;
 			});
 
-			var values = [
+			const values = [
 				// index 0 value
 				// index 1 expect
 				[1, "1.0"],
@@ -71,8 +71,8 @@ describe("Functions module weatherforecast", function () {
 			error: function () {}
 		};
 
-		var originalLocale;
-		var originalTimeZone;
+		let originalLocale;
+		let originalTimeZone;
 		before(function () {
 			originalLocale = moment.locale();
 			originalTimeZone = moment.tz.guess();

--- a/tests/unit/global_vars/root_path_spec.js
+++ b/tests/unit/global_vars/root_path_spec.js
@@ -4,11 +4,11 @@ const expect = require("chai").expect;
 const vm = require("vm");
 
 before(function () {
-	var basedir = path.join(__dirname, "../../..");
+	const basedir = path.join(__dirname, "../../..");
 
-	var fileName = "js/app.js";
-	var filePath = path.join(basedir, fileName);
-	var code = fs.readFileSync(filePath);
+	const fileName = "js/app.js";
+	const filePath = path.join(basedir, fileName);
+	const code = fs.readFileSync(filePath);
 
 	this.sandbox = {
 		module: {},
@@ -41,7 +41,7 @@ after(function () {
 });
 
 describe("'global.root_path' set in js/app.js", function () {
-	var expectedSubPaths = ["modules", "serveronly", "js", "js/app.js", "js/main.js", "js/electron.js", "config"];
+	const expectedSubPaths = ["modules", "serveronly", "js", "js/app.js", "js/main.js", "js/electron.js", "config"];
 
 	expectedSubPaths.forEach((subpath) => {
 		it(`contains a file/folder "${subpath}"`, function () {

--- a/vendor/vendor.js
+++ b/vendor/vendor.js
@@ -4,7 +4,7 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-var vendor = {
+const vendor = {
 	"moment.js": "node_modules/moment/min/moment-with-locales.js",
 	"moment-timezone.js": "node_modules/moment-timezone/builds/moment-timezone-with-data.js",
 	"weather-icons.css": "node_modules/weathericons/css/weather-icons.css",


### PR DESCRIPTION
This PR
- converts 99% of the var-uages into let/const
- removes `var self=this`code 
- cleans up for-loops

so that my inner es6 fanatic is a little more satisfied

The remaining var usages would require more rework since they contain variables that are passed in the global scope (like module and translation)

Also, the deprecated weather modules were not converted, sometimes I am lazy too :-)