### PR TITLE
fix updatenotification.js increasing timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`
 - Fix alert not recognizing multiple alerts (#2522)
 - Fix fetch option httpsAgent to agent in calendar module (#466)
+- Fix module updatenotification which did not work for repos with many refs (#1907)
 
 ## [2.15.0] - 2021-04-01
 

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -10,7 +10,7 @@ Module.register("updatenotification", {
 		updateInterval: 10 * 60 * 1000, // every 10 minutes
 		refreshInterval: 24 * 60 * 60 * 1000, // one day
 		ignoreModules: [],
-		timeout: 1000
+		timeout: 5000
 	},
 
 	suspended: false,


### PR DESCRIPTION
The timeout for the updatenotification is to low so the module does not work in most cases, especially when many git refs are fetched.

See #1907 