### PR TITLE
replace node v10 with v16 in github workflow

### DIFF
--- a/.github/workflows/node-ci.js.yml
+++ b/.github/workflows/node-ci.js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2021-04-01._
 - Bump node-ical to v0.13.0 (now last runtime dependency using deprecated `request` package is removed).
 - Use codecov in informational mode
 - Refactor code into es6 where possible (e.g. var -> let/const)
+- Use node v16 in github workflow (replacing node v10)
 
 ### Removed
 


### PR DESCRIPTION
See #2555
