### PR TITLE
missing modules will be cloned (and installed) on start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Special thanks to the following contributors: @B1gG, @codac, @ezeholz, @khassel,
 - Added custom-properties for colors and fonts for improved styling experience, see `custom.css.sample` file
 - Added custom-properties for gaps around body and between modules
 - Added test case for recurring calendar events
+- If (new) param `url` is provided in module config a missing module will be cloned (and installed) on start
 
 ### Updated
 

--- a/js/app.js
+++ b/js/app.js
@@ -206,7 +206,7 @@ function App() {
 	 *
 	 * @param {string} url The git url of the module.
 	 */
-	 function checkInstalled(url) {
+	function checkInstalled(url) {
 		if (!url || url === "undefined") {
 			return;
 		}
@@ -215,15 +215,15 @@ function App() {
 			return;
 		}
 		folder = `${__dirname}/../modules/` + path.resolve(folder);
-		if (! fs.existsSync(folder)) {
+		if (!fs.existsSync(folder)) {
 			Log.log("Cloning missing module " + url);
-			child_process.execSync("git clone " + url + " " + folder, {stdio:[0,1,2], timeout: 30000});
+			child_process.execSync("git clone " + url + " " + folder, { stdio: [0, 1, 2], timeout: 30000 });
 			if (fs.existsSync(folder + "/package.json")) {
 				Log.log("Installing module " + url);
-				child_process.execSync("npm install " + folder, {stdio:[0,1,2], timeout: 30000});
+				child_process.execSync("npm install " + folder, { stdio: [0, 1, 2], timeout: 30000 });
 			}
 		}
-	 }
+	}
 
 	/**
 	 * Start the core app.


### PR DESCRIPTION
I thought about simplifying the module installation.

The only piece missing in `config.js` is the url of the git repo.

So what about introducing a new param `url` in the module section of the `config.js`, e.g.

```js
        {
                module: "MMM-RepoStats",
                position: "top_left",
                url: "https://gitlab.com/khassel/MMM-RepoStats.git",
                config: {
                        ...
                }
        },
```

If the `url` is set mm checks on start if the directory under `modules` exists and if not it will clone the repo. If there is a `package.json` after cloning it will also run `npm install` (or may better `npm install --only=prod`).

This is a small and backward compatibel change which would simplify module installation.

I provided this PR as draft to discuss if such a change is wanted.