### PR TITLE
Add flag that removes today entry in forecast

### DIFF
--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -5,9 +5,9 @@
         {% set forecast = forecast.slice(0, numSteps) %}
         {% for f in forecast %}
             <tr {% if config.colored %}class="colored"{% endif %} {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
-                {% if (currentStep == 0) %}
+                {% if (currentStep == 0) and config.ignoreToday == false %}
                     <td class="day">{{ "TODAY" | translate }}</td>
-                {% elif (currentStep == 1) %}
+                {% elif (currentStep == 1) and config.ignoreToday == false %}
                     <td class="day">{{ "TOMORROW" | translate }}</td>
                 {% else %}
                     <td class="day">{{ f.date.format('ddd') }}</td>

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -33,6 +33,7 @@ Module.register("weather", {
 		showIndoorHumidity: false,
 		maxNumberOfDays: 5,
 		maxEntries: 5,
+    ignoreToday: false,
 		fade: true,
 		fadePoint: 0.25, // Start on 1/4th of the list.
 		initialLoadDelay: 0, // 0 seconds delay
@@ -128,10 +129,16 @@ Module.register("weather", {
 
 	// Add all the data to the template.
 	getTemplateData: function () {
+    const forecast = this.weatherProvider.weatherForecast()
+
+    if (this.config.ignoreToday) {
+      forecast.splice(0, 1)
+    }
+    
 		return {
 			config: this.config,
 			current: this.weatherProvider.currentWeather(),
-			forecast: this.weatherProvider.weatherForecast(),
+			forecast: forecast,
 			hourly: this.weatherProvider.weatherHourly(),
 			indoor: {
 				humidity: this.indoorHumidity,
@@ -260,7 +267,7 @@ Module.register("weather", {
 
 		this.nunjucksEnvironment().addFilter(
 			"calcNumEntries",
-			function (dataArray) {
+			function (dataArray) {       
 				return Math.min(dataArray.length, this.config.maxEntries);
 			}.bind(this)
 		);


### PR DESCRIPTION
Hello!

Just a wee addition to the weather module here.

I added a new config flag - `ignoreToday` - that removes the entry for today in weather forecast mode.  This is so if you have two weather modules, one just for today and one for the forecast, there isn't duplicate data between the two modules.

Thanks!