### PR TITLE
hotfix logger.js after jest changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Special thanks to the following contributors: @B1gG, @codac, @ezeholz, @khassel,
 - Fix config check failing when encountering let syntax ("Parsing error: Unexpected token config")
 - Fix calendar debug check
 - Really run prettier over all files
+- Fix logger.js after jest changes
 
 ## [2.15.0] - 2021-04-01
 

--- a/js/logger.js
+++ b/js/logger.js
@@ -36,8 +36,8 @@
 	};
 
 	// the timeStamp instruction fails when running the tests so it is not added in test environment
-	if (process.env.NODE_ENV.trim() !== "test") {
-		logLevel.push({ timeStamp: Function.prototype.bind.call(console.timeStamp, console) });
+	if (typeof process === "object" && process.env.NODE_ENV.trim() !== "test") {
+		logLevel = Object.assign(logLevel, { timeStamp: Function.prototype.bind.call(console.timeStamp, console) });
 	}
 
 	logLevel.setLogLevel = function (newLevel) {


### PR DESCRIPTION
My changes concerning jest have broken logger.js in MM which is fixed by this PR.
