### PR TITLE
update One Call API results for openweathermap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Special thanks to the following contributors: @B1gG, @codac, @ezeholz, @khassel,
 - Fix calendar start function logging inconsistency.
 - Fix updatenotification start function logging inconsistency.
 - Checks and applies the showDescription setting for the newsfeed module again
+- Fix issue with openweathermap not showing current or forecast info when using onecall API
 - Fix tests in weather module and add one for decimalPoint in forecast
 - Fix decimalSymbol in the forecast part of the new weather module #2530
 - Fix wrong treatment of `appendLocationNameToHeader` when using `ukmetofficedatahub`

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -54,7 +54,7 @@ WeatherProvider.register("openweathermap", {
 					this.setWeatherForecast(weatherData.days);
 					this.setFetchedLocation(`${data.timezone}`);
 				} else {
-					const forecast = this.generateWeatherObjectsFromForecast(data.daily);
+					const forecast = this.generateWeatherObjectsFromForecast(data.list);
 					this.setWeatherForecast(forecast);
 					this.setFetchedLocation(`${data.city.name}, ${data.city.country}`);
 				}

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -30,16 +30,14 @@ WeatherProvider.register("openweathermap", {
 	fetchCurrentWeather() {
 		this.fetchData(this.getUrl())
 			.then((data) => {
-				if (!data || !data.main || typeof data.main.temp === "undefined") {
-					// Did not receive usable new data.
-					// Maybe this needs a better check?
-					return;
+				if (this.config.weatherEndpoint === "/onecall") {
+					const weatherData = this.generateWeatherObjectsFromOnecall(data);
+					this.setCurrentWeather(weatherData.current);
+					this.setFetchedLocation(`${data.timezone}`);
+				} else {
+					const currentWeather = this.generateWeatherObjectFromCurrentWeather(data);
+					this.setCurrentWeather(currentWeather);
 				}
-
-				this.setFetchedLocation(`${data.name}, ${data.sys.country}`);
-
-				const currentWeather = this.generateWeatherObjectFromCurrentWeather(data);
-				this.setCurrentWeather(currentWeather);
 			})
 			.catch(function (request) {
 				Log.error("Could not load data ... ", request);
@@ -51,16 +49,15 @@ WeatherProvider.register("openweathermap", {
 	fetchWeatherForecast() {
 		this.fetchData(this.getUrl())
 			.then((data) => {
-				if (!data || !data.list || !data.list.length) {
-					// Did not receive usable new data.
-					// Maybe this needs a better check?
-					return;
+				if (this.config.weatherEndpoint === "/onecall") {
+					const weatherData = this.generateWeatherObjectsFromOnecall(data);
+					this.setWeatherForecast(weatherData.days);
+					this.setFetchedLocation(`${data.timezone}`);
+				} else {
+					const forecast = this.generateWeatherObjectsFromForecast(data.daily);
+					this.setWeatherForecast(forecast);
+					this.setFetchedLocation(`${data.city.name}, ${data.city.country}`);
 				}
-
-				this.setFetchedLocation(`${data.city.name}, ${data.city.country}`);
-
-				const forecast = this.generateWeatherObjectsFromForecast(data.list);
-				this.setWeatherForecast(forecast);
 			})
 			.catch(function (request) {
 				Log.error("Could not load data ... ", request);


### PR DESCRIPTION
The results from the /onecall endpoint were not
being parsed correctly in current and forecast mode - it was
assuming the current/forecast endpoint API, and the return
datasets are different. The effect was that the module
would simply display "Loading..." when in /onecall mode, since
it has no way of displaying error status (ideally, it should,
but leave that for another day)

Hello and thank you for wanting to contribute to the MagicMirror project

**Please make sure that you have followed these 4 rules before submitting your Pull Request:**

> 1) Base your pull requests against the `develop` branch.
>
>
> 2) Include these infos in the description:
>  * Does the pull request solve a **related** issue?
>  * If so, can you reference the issue like this `Fixes #<issue_number>`?
>  * What does the pull request accomplish? Use a list if needed.
>  * If it includes major visual changes please add screenshots.
>
>
> 3) Please run `npm run lint:prettier` before submitting so that
> style issues are fixed.
>
>
> 4) Don't forget to add an entry about your changes to
> the CHANGELOG.md file.


**Note**: Sometimes the development moves very fast. It is highly
recommended that you update your branch of `develop` before creating a
pull request to send us your changes. This makes everyone's lives
easier (including yours) and helps us out on the development team.

Thanks again and have a nice day!
