### PR TITLE
Fix undefined error with ignoreToday option in weather module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ _This release is scheduled to be released on 2021-10-01._
 
 ### Fixed
 
+- Fix undefined error with ignoreToday option in weather module (#2620).
+
 ## [2.16.0] - 2021-07-01
 
 Special thanks to the following contributors: @210954, @B1gG, @codac, @Crazylegstoo, @daniel, @earlman, @ezeholz, @FrancoisRmn, @jupadin, @khassel, @KristjanESPERANTO, @njwilliams, @oemel09, @r3wald, @rejas, @rico24, Faizan Ahmed.

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -2,6 +2,9 @@
     {% set numSteps = forecast | calcNumSteps %}
     {% set currentStep = 0 %}
     <table class="{{ config.tableClass }}">
+        {% if config.ignoreToday %}
+            {% set forecast = forecast.splice(1) %}
+        {% endif %}
         {% set forecast = forecast.slice(0, numSteps) %}
         {% for f in forecast %}
             <tr {% if config.colored %}class="colored"{% endif %} {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
@@ -20,10 +23,10 @@
                     {{ f.minTemperature | roundValue | unit("temperature") | decimalSymbol }}
                 </td>
                 {% if config.showPrecipitationAmount %}
-                    {% if f.precipitationUnits %}	
+                    {% if f.precipitationUnits %}
                         <td class="align-right bright precipitation">
                             {{ f.precipitation }}{{ f.precipitationUnits }}
-                        </td>			
+                        </td>
 		                {% else %}
                         <td class="align-right bright precipitation">
                             {{ f.precipitation | unit("precip") }}

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -89,7 +89,7 @@ WeatherProvider.register("openweathermap", {
 	/**
 	 * Overrides method for setting config to check if endpoint is correct for hourly
 	 *
-	 * @param config
+	 * @param {object} config The configuration object
 	 */
 	setConfig(config) {
 		this.config = config;

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -56,7 +56,7 @@ WeatherProvider.register("smhi", {
 	/**
 	 * Overrides method for setting config with checks for the precipitationValue being unset or invalid
 	 *
-	 * @param config
+	 * @param {object} config The configuration object
 	 */
 	setConfig(config) {
 		this.config = config;
@@ -69,8 +69,8 @@ WeatherProvider.register("smhi", {
 	/**
 	 * Of all the times returned find out which one is closest to the current time, should be the first if the data isn't old.
 	 *
-	 * @param times
-	 * @returns {undefined}
+	 * @param {object[]} times Array of time objects
+	 * @returns {object} The weatherdata closest to the current time
 	 */
 	getClosestToCurrentTime(times) {
 		let now = moment();
@@ -87,7 +87,7 @@ WeatherProvider.register("smhi", {
 	/**
 	 * Get the forecast url for the configured coordinates
 	 *
-	 * @returns {string}
+	 * @returns {string} the url for the specified coordinates
 	 */
 	getURL() {
 		let lon = this.config.lon;
@@ -100,8 +100,8 @@ WeatherProvider.register("smhi", {
 	 * The returned units is always in metric system.
 	 * Requires coordinates to determine if its daytime or nighttime to know which icon to use and also to set sunrise and sunset.
 	 *
-	 * @param weatherData
-	 * @param coordinates
+	 * @param {object} weatherData Weatherdata to convert
+	 * @param {object} coordinates Coordinates of the locations of the weather
 	 * @returns {WeatherObject}
 	 */
 	convertWeatherDataToObject(weatherData, coordinates) {
@@ -146,7 +146,7 @@ WeatherProvider.register("smhi", {
 	 * Takes all of the data points and converts it to one WeatherObject per day.
 	 *
 	 * @param allWeatherData
-	 * @param coordinates
+	 * @param {object} coordinates
 	 * @returns {*[]}
 	 */
 	convertWeatherDataGroupedByDay(allWeatherData, coordinates) {
@@ -194,8 +194,8 @@ WeatherProvider.register("smhi", {
 	/**
 	 * Resolve coordinates from the response data (probably preferably to use this if it's not matching the config values exactly)
 	 *
-	 * @param data
-	 * @returns {{lon, lat}}
+	 * @param {object} data Response data from the weather service
+	 * @returns {{lon, lat}} the lat/long coordinates of the data
 	 */
 	resolveCoordinates(data) {
 		return { lat: data.geometry.coordinates[0][1], lon: data.geometry.coordinates[0][0] };
@@ -215,8 +215,8 @@ WeatherProvider.register("smhi", {
 	 * The distance between the data points is increasing in the data the more distant the prediction is.
 	 * Find these gaps and fill them with the previous hours data to make the data returned a complete set.
 	 *
-	 * @param data
-	 * @returns {*[]}
+	 * @param {object[]} data Response data from the weather service
+	 * @returns {object[]} Given data with filled gaps
 	 */
 	fillInGaps(data) {
 		let result = [];
@@ -238,8 +238,8 @@ WeatherProvider.register("smhi", {
 	 * Helper method to fetch a property from the returned data set.
 	 * The returned values is an array with always one value in it.
 	 *
-	 * @param currentWeatherData
-	 * @param name
+	 * @param {object} weatherData Weatherdata to fetch from
+	 * @param {string} name The name of the property
 	 * @returns {unknown}
 	 */
 	paramValue(currentWeatherData, name) {

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -132,10 +132,6 @@ Module.register("weather", {
 	getTemplateData: function () {
 		const forecast = this.weatherProvider.weatherForecast();
 
-		if (this.config.ignoreToday) {
-			forecast.splice(0, 1);
-		}
-
 		return {
 			config: this.config,
 			current: this.weatherProvider.currentWeather(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"colors": "^1.4.0",
 				"console-stamp": "^3.0.3",
 				"digest-fetch": "^1.2.0",
-				"eslint": "^7.30.0",
+				"eslint": "^7.32.0",
 				"express": "^4.17.1",
 				"express-ipfilter": "^1.2.0",
 				"feedme": "^2.0.2",
@@ -23,13 +23,13 @@
 				"moment": "^2.29.1",
 				"node-fetch": "^2.6.1",
 				"node-ical": "^0.13.0",
-				"simple-git": "^2.41.1",
+				"simple-git": "^2.42.0",
 				"socket.io": "^4.1.3"
 			},
 			"devDependencies": {
 				"eslint-config-prettier": "^8.3.0",
-				"eslint-plugin-jest": "^24.3.6",
-				"eslint-plugin-jsdoc": "^35.4.3",
+				"eslint-plugin-jest": "^24.4.0",
+				"eslint-plugin-jsdoc": "^36.0.6",
 				"eslint-plugin-prettier": "^3.4.0",
 				"express-basic-auth": "^1.2.0",
 				"husky": "^7.0.1",
@@ -39,7 +39,7 @@
 				"nyc": "^15.1.0",
 				"prettier": "^2.3.2",
 				"pretty-quick": "^3.1.1",
-				"sinon": "^11.1.1",
+				"sinon": "^11.1.2",
 				"spectron": "^15.0.0",
 				"stylelint": "^13.13.1",
 				"stylelint-config-prettier": "^8.0.2",
@@ -50,7 +50,7 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"electron": "^13.1.6"
+				"electron": "^13.1.7"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -703,23 +703,23 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.9.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.9.0-alpha.1.tgz",
-			"integrity": "sha512-Clxxc0PwpISoYYBibA+1L2qFJ7gvFVhI2Hos87S06K+Q0cXdOhZQJNKWuaQGPAeHjZEuUB/YoWOfwjuF2wirqA==",
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.7.tgz",
+			"integrity": "sha512-aNKZEoMESDzOBjKxCWrFuG50mcpMeKVBnBNko4+IZZ5t9zXYs8GT1KB0ZaOq1YUsKumDRc6YII/TQm309MJ0KQ==",
 			"dev": true,
 			"dependencies": {
-				"comment-parser": "1.1.6-beta.0",
+				"comment-parser": "1.2.3",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "1.0.4"
+				"jsdoc-type-pratt-parser": "1.1.1"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^12.20 || ^14.14.0 || ^16"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+			"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
@@ -1636,9 +1636,9 @@
 			}
 		},
 		"node_modules/acorn-jsx": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -2600,12 +2600,12 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.1.6-beta.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.6-beta.0.tgz",
-			"integrity": "sha512-q3cA8TSMyqW7wcPSYWzbO/rMahnXgzs4SLG/UIWXdEsnXTFPZkEkWAdNgPiHig2OzxgpPLOh4WwsmClDxndwHw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.3.tgz",
+			"integrity": "sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==",
 			"dev": true,
 			"engines": {
-				"node": ">= 10.0.0"
+				"node": "^12.20 || ^14.14.0 || ^16"
 			}
 		},
 		"node_modules/commondir": {
@@ -3243,12 +3243,11 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron": {
-			"version": "13.1.6",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-13.1.6.tgz",
-			"integrity": "sha512-XiB55/JTaQpDFQrD9pulYnOGwaWeMyRIub5ispvoE2bWBvM5zVMLptwMLb0m3KTMrfSkzhedZvOu7fwYvR7L7Q==",
+			"version": "13.1.7",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.1.7.tgz",
+			"integrity": "sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==",
 			"devOptional": true,
 			"hasInstallScript": true,
-			"license": "MIT",
 			"dependencies": {
 				"@electron/get": "^1.0.1",
 				"@types/node": "^14.6.2",
@@ -3558,12 +3557,12 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
 			"dependencies": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.2",
+				"@eslint/eslintrc": "^0.4.3",
 				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -3626,9 +3625,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "24.3.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
-			"integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
+			"integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
 			"dev": true,
 			"dependencies": {
 				"@typescript-eslint/experimental-utils": "^4.0.1"
@@ -3647,23 +3646,23 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "35.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
-			"integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+			"version": "36.0.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.6.tgz",
+			"integrity": "sha512-vOm27rI2SMfi1bOAYmzzGkanMCD/boquKwvN5ECi8EF9ASsXJwlnCzYtiOYpsDpbC2+6JXEHAmWMkqYNA3BWRw==",
 			"dev": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "^0.9.0-alpha.1",
-				"comment-parser": "1.1.6-beta.0",
+				"@es-joy/jsdoccomment": "0.10.7",
+				"comment-parser": "1.2.3",
 				"debug": "^4.3.2",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "^1.0.4",
+				"jsdoc-type-pratt-parser": "^1.1.1",
 				"lodash": "^4.17.21",
 				"regextras": "^0.8.0",
 				"semver": "^7.3.5",
 				"spdx-expression-parse": "^3.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": "^12.20 || ^14.14.0 || ^16"
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0"
@@ -4537,9 +4536,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-			"integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -6004,9 +6003,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.0.4.tgz",
-			"integrity": "sha512-jzmW9gokeq9+bHPDR1nCeidMyFUikdZlbOhKzh9+/nJqB75XhpNKec1/UuxW5c4+O+Pi31Gc/dCboyfSm/pSpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
+			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
@@ -8580,9 +8579,9 @@
 			"dev": true
 		},
 		"node_modules/simple-git": {
-			"version": "2.41.1",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.41.1.tgz",
-			"integrity": "sha512-n1STz1tfnemvYndzWakgKa0JB4s/LrUG4btXMetWB9N9ZoIAJQd0ZtWj9sBwWxIZ/X/tYdA/tq+KHfFNAGzZhQ==",
+			"version": "2.42.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.42.0.tgz",
+			"integrity": "sha512-illpUX0bcrdB3AyvBGLz0ToRVP7lXNJOGVybGVuVk7PpivPNK5YKJx2aagKdKbveaMtt0DCLK4/jfjDb6b2M2g==",
 			"dependencies": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -8590,13 +8589,13 @@
 			}
 		},
 		"node_modules/sinon": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-			"integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+			"integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
 			"dev": true,
 			"dependencies": {
 				"@sinonjs/commons": "^1.8.3",
-				"@sinonjs/fake-timers": "^7.1.0",
+				"@sinonjs/fake-timers": "^7.1.2",
 				"@sinonjs/samsam": "^6.0.2",
 				"diff": "^5.0.0",
 				"nise": "^5.1.0",
@@ -10915,20 +10914,20 @@
 			"requires": {}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.9.0-alpha.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.9.0-alpha.1.tgz",
-			"integrity": "sha512-Clxxc0PwpISoYYBibA+1L2qFJ7gvFVhI2Hos87S06K+Q0cXdOhZQJNKWuaQGPAeHjZEuUB/YoWOfwjuF2wirqA==",
+			"version": "0.10.7",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.10.7.tgz",
+			"integrity": "sha512-aNKZEoMESDzOBjKxCWrFuG50mcpMeKVBnBNko4+IZZ5t9zXYs8GT1KB0ZaOq1YUsKumDRc6YII/TQm309MJ0KQ==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "1.1.6-beta.0",
+				"comment-parser": "1.2.3",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "1.0.4"
+				"jsdoc-type-pratt-parser": "1.1.1"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.2.tgz",
-			"integrity": "sha512-8nmGq/4ycLpIwzvhI4tNDmQztZ8sp+hI7cyG8i1nQDhkAbRzHpXPidRAHlNvCZQpJTKw5ItIpMw9RSToGF00mg==",
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+			"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.1.1",
@@ -11679,9 +11678,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-			"integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"requires": {}
 		},
 		"acorn-walk": {
@@ -12398,9 +12397,9 @@
 			}
 		},
 		"comment-parser": {
-			"version": "1.1.6-beta.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.6-beta.0.tgz",
-			"integrity": "sha512-q3cA8TSMyqW7wcPSYWzbO/rMahnXgzs4SLG/UIWXdEsnXTFPZkEkWAdNgPiHig2OzxgpPLOh4WwsmClDxndwHw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.3.tgz",
+			"integrity": "sha512-vnqDwBSXSsdAkGS5NjwMIPelE47q+UkEgWKHvCDNhVIIaQSUFY6sNnEYGzdoPGMdpV+7KR3ZkRd7oyWIjtuvJg==",
 			"dev": true
 		},
 		"commondir": {
@@ -12917,9 +12916,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron": {
-			"version": "13.1.6",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-13.1.6.tgz",
-			"integrity": "sha512-XiB55/JTaQpDFQrD9pulYnOGwaWeMyRIub5ispvoE2bWBvM5zVMLptwMLb0m3KTMrfSkzhedZvOu7fwYvR7L7Q==",
+			"version": "13.1.7",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.1.7.tgz",
+			"integrity": "sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==",
 			"devOptional": true,
 			"requires": {
 				"@electron/get": "^1.0.1",
@@ -13138,12 +13137,12 @@
 			}
 		},
 		"eslint": {
-			"version": "7.30.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
-			"integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
 			"requires": {
 				"@babel/code-frame": "7.12.11",
-				"@eslint/eslintrc": "^0.4.2",
+				"@eslint/eslintrc": "^0.4.3",
 				"@humanwhocodes/config-array": "^0.5.0",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -13202,25 +13201,25 @@
 			"requires": {}
 		},
 		"eslint-plugin-jest": {
-			"version": "24.3.6",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.3.6.tgz",
-			"integrity": "sha512-WOVH4TIaBLIeCX576rLcOgjNXqP+jNlCiEmRgFTfQtJ52DpwnIQKAVGlGPAN7CZ33bW6eNfHD6s8ZbEUTQubJg==",
+			"version": "24.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz",
+			"integrity": "sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==",
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/experimental-utils": "^4.0.1"
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "35.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-35.4.3.tgz",
-			"integrity": "sha512-hBEn+VNjVX0IKoZ2OdZs0Z1fU8CqZkBSzLqD8ZpwZEamrdi2TUgKvujvETe8gXYQ/67hpRtbR5iPFTgmWpRevw==",
+			"version": "36.0.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.6.tgz",
+			"integrity": "sha512-vOm27rI2SMfi1bOAYmzzGkanMCD/boquKwvN5ECi8EF9ASsXJwlnCzYtiOYpsDpbC2+6JXEHAmWMkqYNA3BWRw==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "^0.9.0-alpha.1",
-				"comment-parser": "1.1.6-beta.0",
+				"@es-joy/jsdoccomment": "0.10.7",
+				"comment-parser": "1.2.3",
 				"debug": "^4.3.2",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "^1.0.4",
+				"jsdoc-type-pratt-parser": "^1.1.1",
 				"lodash": "^4.17.21",
 				"regextras": "^0.8.0",
 				"semver": "^7.3.5",
@@ -13882,9 +13881,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.9.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
-			"integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+			"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
@@ -14989,9 +14988,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.0.4.tgz",
-			"integrity": "sha512-jzmW9gokeq9+bHPDR1nCeidMyFUikdZlbOhKzh9+/nJqB75XhpNKec1/UuxW5c4+O+Pi31Gc/dCboyfSm/pSpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-1.1.1.tgz",
+			"integrity": "sha512-uelRmpghNwPBuZScwgBG/OzodaFk5RbO5xaivBdsAY70icWfShwZ7PCMO0x1zSkOa8T1FzHThmrdoyg/0AwV5g==",
 			"dev": true
 		},
 		"jsdom": {
@@ -16983,9 +16982,9 @@
 			"dev": true
 		},
 		"simple-git": {
-			"version": "2.41.1",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.41.1.tgz",
-			"integrity": "sha512-n1STz1tfnemvYndzWakgKa0JB4s/LrUG4btXMetWB9N9ZoIAJQd0ZtWj9sBwWxIZ/X/tYdA/tq+KHfFNAGzZhQ==",
+			"version": "2.42.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.42.0.tgz",
+			"integrity": "sha512-illpUX0bcrdB3AyvBGLz0ToRVP7lXNJOGVybGVuVk7PpivPNK5YKJx2aagKdKbveaMtt0DCLK4/jfjDb6b2M2g==",
 			"requires": {
 				"@kwsites/file-exists": "^1.1.1",
 				"@kwsites/promise-deferred": "^1.1.1",
@@ -16993,13 +16992,13 @@
 			}
 		},
 		"sinon": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-			"integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+			"integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.8.3",
-				"@sinonjs/fake-timers": "^7.1.0",
+				"@sinonjs/fake-timers": "^7.1.2",
 				"@sinonjs/samsam": "^6.0.2",
 				"diff": "^5.0.0",
 				"nise": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
 	"homepage": "https://magicmirror.builders",
 	"devDependencies": {
 		"eslint-config-prettier": "^8.3.0",
-		"eslint-plugin-jest": "^24.3.6",
-		"eslint-plugin-jsdoc": "^35.4.3",
+		"eslint-plugin-jest": "^24.4.0",
+		"eslint-plugin-jsdoc": "^36.0.6",
 		"eslint-plugin-prettier": "^3.4.0",
 		"express-basic-auth": "^1.2.0",
 		"husky": "^7.0.1",
@@ -57,7 +57,7 @@
 		"nyc": "^15.1.0",
 		"prettier": "^2.3.2",
 		"pretty-quick": "^3.1.1",
-		"sinon": "^11.1.1",
+		"sinon": "^11.1.2",
 		"spectron": "^15.0.0",
 		"stylelint": "^13.13.1",
 		"stylelint-config-prettier": "^8.0.2",
@@ -65,13 +65,13 @@
 		"stylelint-prettier": "^1.2.0"
 	},
 	"optionalDependencies": {
-		"electron": "^13.1.6"
+		"electron": "^13.1.7"
 	},
 	"dependencies": {
 		"colors": "^1.4.0",
 		"console-stamp": "^3.0.3",
 		"digest-fetch": "^1.2.0",
-		"eslint": "^7.30.0",
+		"eslint": "^7.32.0",
 		"express": "^4.17.1",
 		"express-ipfilter": "^1.2.0",
 		"feedme": "^2.0.2",
@@ -81,7 +81,7 @@
 		"moment": "^2.29.1",
 		"node-fetch": "^2.6.1",
 		"node-ical": "^0.13.0",
-		"simple-git": "^2.41.1",
+		"simple-git": "^2.42.0",
 		"socket.io": "^4.1.3"
 	},
 	"_moduleAliases": {

--- a/tests/e2e/modules/mocks/weather_current.js
+++ b/tests/e2e/modules/mocks/weather_current.js
@@ -1,7 +1,8 @@
 const _ = require("lodash");
 
 /**
- * @param extendedData
+ * @param {object} extendedData extra data to add to the default mock data
+ * @returns {string} mocked current weather data
  */
 function generateWeather(extendedData = {}) {
 	return JSON.stringify(

--- a/tests/e2e/modules/mocks/weather_forecast.js
+++ b/tests/e2e/modules/mocks/weather_forecast.js
@@ -1,7 +1,8 @@
 const _ = require("lodash");
 
 /**
- * @param extendedData
+ * @param {object} extendedData extra data to add to the default mock data
+ * @returns {string} mocked forecast weather data
  */
 function generateWeatherForecast(extendedData = {}) {
 	return JSON.stringify(

--- a/tests/e2e/modules/weather_spec.js
+++ b/tests/e2e/modules/weather_spec.js
@@ -13,7 +13,9 @@ describe("Weather module", function () {
 	helpers.setupTimeout(this);
 
 	/**
-	 * @param responses
+	 *
+	 * @param {object} responses mocked data to be returned
+	 * @returns {Promise} Resolved once the electron app is started
 	 */
 	async function setup(responses) {
 		app = await helpers.startApplication({
@@ -27,15 +29,18 @@ describe("Weather module", function () {
 	}
 
 	/**
-	 * @param element
+	 *
+	 * @param {string} element css selector
+	 * @returns {Promise<Element>} Promise with the element once it is rendered
 	 */
 	async function getElement(element) {
 		return await app.client.$(element);
 	}
 
 	/**
-	 * @param element
-	 * @param result
+	 * @param {string} element css selector
+	 * @param {string} result Expected text in given selector
+	 * @returns {Promise<boolean>} Promise with True if the text matches
 	 */
 	async function getText(element, result) {
 		const elem = await getElement(element);


### PR DESCRIPTION
Move logic for handling splicing forecast data when ignoreToday is set in weathermodule to template.

Otherwise we get an undefined error since the forecast data isnt available on the first getTemplateData call.

Fixes #2620