### PR TITLE
update weathergov provider to try fetching not just current but also …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _This release is scheduled to be released on 2021-10-01._
 - Updated github templates.
 - Actually test all js and css files when lint script is run.
 - Update jsdocs and print warnings during testing too
+- Update weathergov provider to try fetching not just current, but also foreacst, when API URLs available.
 
 ### Fixed
 

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -21,7 +21,7 @@ WeatherProvider.register("weathergov", {
 
 	// Set the default config properties that is specific to this provider
 	defaults: {
-		apiBase: "https://api.weatherbit.io/v2.0",
+		apiBase: "https://api.weather.gov/points/",
 		weatherEndpoint: "/forecast",
 		lat: 0,
 		lon: 0
@@ -129,7 +129,12 @@ WeatherProvider.register("weathergov", {
 			.finally(() => {
 				// excellent, let's fetch some actual wx data
 				this.configURLs = true;
-				this.fetchCurrentWeather();
+				// handle 'forecast' config, fall back to 'current'
+				if (config.type == "forecast") {
+					this.fetchWeatherForecast();
+				} else {
+					this.fetchCurrentWeather();
+				}
 			});
 	},
 


### PR DESCRIPTION
…forecast when API URLs available

Trying to address seeming shortcoming I reported in issue #2630 

It seems that configuring the "initialLoadDelay" to a high enough number also can solve the issue where API data might take a while, but the code already tries to handle this by executing current weather fetch once the API URLs are ready. Seems to make a lot of sense to me to try to load the forecast here instead if that's what user has configured.

default apiBase url was also incorrect.
