### PR TITLE
Add custom switches for electron mainWindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _This release is scheduled to be released on 2021-10-01._
 ### Added
 
 - Added showTime parameter to clock module for enabling/disabling time display in analog clock
+- Added custom electron switches from user config (`config.electronSwitches`)
 
 ### Updated
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -19,7 +19,8 @@ let mainWindow;
  *
  */
 function createWindow() {
-	app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
+	let electronSwitchesDefaults = ["autoplay-policy", "no-user-gesture-required"];
+	app.commandLine.appendSwitch(...new Set(electronSwitchesDefaults, config.electronSwitches));
 	let electronOptionsDefaults = {
 		width: 800,
 		height: 600,


### PR DESCRIPTION
I need some custom electron switches for my purpose. (e.g., Desktop background playing)

This feature enables adding custom switches on Electron starts by a user.

You can add switches in `config.js` like;
```js
electronSwitches: ['enable-transparent-visuals'],
```
