### PR TITLE
electron: disable black cursor on start

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,7 +34,7 @@ When submitting a new issue, please supply the following information:
 
 **Node Version**: Make sure it's version 12 or later (recommended is 14).
 
-**MagicMirror Version**: Please let us now which version of MagicMirror you are running. It can be found in the `package.json` file.
+**MagicMirror Version**: Please let us know which version of MagicMirror you are running. It can be found in the `package.json` file.
 
 **Description**: Provide a detailed description about the issue and include specific details to help us understand the problem. Adding screenshots will help describing the problem.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -34,7 +34,7 @@ When submitting a new issue, please supply the following information:
 
 **Node Version**: Make sure it's version 12 or later (recommended is 14).
 
-**MagicMirror Version**: Please let us now which version of MagicMirror you are running. It can be found in the `package.json` file.
+**MagicMirror Version**: Please let us know which version of MagicMirror you are running. It can be found in the `package.json` file.
 
 **Description**: Provide a detailed description about the issue and include specific details to help us understand the problem. Adding screenshots will help describing the problem.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ _This release is scheduled to be released on 2021-10-01._
 
 - Fix undefined error with ignoreToday option in weather module (#2620).
 - Fix time zone correction in calendar module when the date hour is equal to the time zone correction value (#2632).
+- Fix black cursor on startup when using electron.
 
 ## [2.16.0] - 2021-07-01
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -72,8 +72,8 @@ function createWindow() {
 	}
 
 	// simulate mouse move to hide black cursor on start
-	mainWindow.webContents.on('dom-ready', (event)=> {
-		mainWindow.webContents.sendInputEvent({type: "mouseMove", x: 0, y: 0});
+	mainWindow.webContents.on("dom-ready", (event) => {
+		mainWindow.webContents.sendInputEvent({ type: "mouseMove", x: 0, y: 0 });
 	});
 
 	// Set responders for window events.

--- a/js/electron.js
+++ b/js/electron.js
@@ -71,6 +71,11 @@ function createWindow() {
 		mainWindow.webContents.openDevTools();
 	}
 
+	// simulate mouse move to hide black cursor on start
+	mainWindow.webContents.on('dom-ready', (event)=> {
+		mainWindow.webContents.sendInputEvent({type: "mouseMove", x: 0, y: 0});
+	});
+
 	// Set responders for window events.
 	mainWindow.on("closed", function () {
 		mainWindow = null;


### PR DESCRIPTION
This PR simultes a mouse move to hide the black cursor on electron start.
See [this forum thread](https://forum.magicmirror.builders/topic/15411/cursor-shown-in-v2-16-0).

Additionally 2 typos in the templates are fixed.