### PR TITLE
fix update notification

### DIFF
--- a/.github/workflows/node-ci.js.yml
+++ b/.github/workflows/node-ci.js.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.8]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node-ci.js.yml
+++ b/.github/workflows/node-ci.js.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: |
+        node -v
         Xvfb :99 -screen 0 1024x768x16 &
         export DISPLAY=:99
         npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _This release is scheduled to be released on 2021-10-01._
 - Fix undefined error with ignoreToday option in weather module (#2620).
 - Fix time zone correction in calendar module when the date hour is equal to the time zone correction value (#2632).
 - Fix black cursor on startup when using electron.
+- Fix update notification not working for own repository (#2644).
 
 ## [2.16.0] - 2021-07-01
 

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -1,0 +1,132 @@
+const util = require("util");
+const exec = util.promisify(require("child_process").exec);
+const fs = require("fs");
+const path = require("path");
+const Log = require("logger");
+
+class gitHelper {
+	constructor(){
+		this.gitRepos = [];
+		this.baseDir = path.normalize(__dirname + "/../../../");
+	}
+
+	async execShell(command) {
+		let res = { stdout: "", stderr: "" };
+		const { stdout, stderr } = await exec(command);
+
+		res.stdout = stdout;
+		res.stderr = stderr;
+		return res;
+	}
+
+	async isGitRepo(moduleFolder) {
+		let res = await this.execShell("cd " + moduleFolder + " && git remote -v");
+		if (res.stderr) {
+			Log.error("Failed to fetch git data for " + moduleFolder + ": " + res.stderr);
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	add(moduleName) {
+		let moduleFolder = this.baseDir;
+		if (moduleName !== "default") {
+			moduleFolder = moduleFolder + 'modules/' + moduleName;
+		}
+		try {
+			Log.info("Checking git for module: " + moduleName);
+			// Throws error if file doesn't exist
+			fs.statSync(path.join(moduleFolder, ".git"));
+			// Fetch the git or throw error if no remotes
+			if (this.isGitRepo(moduleFolder)) {
+				// Folder has .git and has at least one git remote, watch this folder
+				this.gitRepos.unshift({ module: moduleName, folder: moduleFolder });
+			}
+		} catch (err) {
+			// Error when directory .git doesn't exist or doesn't have any remotes
+			// This module is not managed with git, skip
+		}
+
+	}
+
+	async getRepoInfo(repo) {
+		let gitInfo = {
+			module: repo.module,
+			// commits behind:
+			behind: 0,
+			// branch name:
+			current: "",
+			// current hash:
+			hash: "",
+			// remote branch:
+			tracking: ""
+		};
+		let res;
+		if (repo.module === "default") {
+			// the hash is only needed for the mm repo
+			res = await this.execShell("cd " + repo.folder + " && git rev-parse HEAD");
+			if (res.stderr) {
+				Log.error("Failed to get current commit hash for " + repo.module + ": " + res.stderr);
+			}
+			gitInfo.hash = res.stdout;
+		}
+		res = await this.execShell("cd " + repo.folder + " && git status -sb");
+		if (res.stderr) {
+			Log.error("Failed to get git status for " + repo.module + ": " + res.stderr);
+			// exit without git status info
+			return;
+		}
+		// only the first line of stdout is evaluated
+		let status = res.stdout.split("\n")[0];
+		// examples for status:
+		// ## develop...origin/develop
+		// ## master...origin/master [behind 8]
+		status = status.match(/(?![.#])([^.]*)/g);
+		// examples for status:
+		// [ ' develop', 'origin/develop', '' ]
+		// [ ' master', 'origin/master [behind 8]', '' ]
+		gitInfo.current = status[0].trim();
+		status = status[1].split(" ");
+		// examples for status:
+		// [ 'origin/develop' ]
+		// [ 'origin/master', '[behind', '8]' ]
+		gitInfo.tracking = status[0].trim();
+		if (status[2]) {
+			// git fetch was already called before so `git status -sb` delivers already the behind number
+			gitInfo.behind = parseInt(status[2].substring(0, status[2].length - 1));
+			return gitInfo;
+		}
+		res = await this.execShell("cd " + repo.folder + " && git fetch --dry-run");
+		// example output:
+		// From https://github.com/MichMich/MagicMirror
+		//    e40ddd4..06389e3  develop    -> origin/develop
+		// here the result is in stderr (this is a git default, don't ask why ...)
+		if (res.stderr === "") return;
+		let refs = res.stderr.match(/s*([a-z,0-9]+[.][.][a-z,0-9]+)s*/g)[0];
+		if (refs === "") {
+			// if match fails set behind to a number greater 0 and return
+			gitInfo.behind = 1;
+			return gitInfo;
+		}
+		// get behind with refs
+		res = await this.execShell("cd " + repo.folder + " && git rev-list --ancestry-path --count " + refs);
+		gitInfo.behind = parseInt(res.stdout);
+		return gitInfo;
+	}
+
+	async getRepos() {
+		const gitResultList = [];
+		for (let repo of this.gitRepos) {
+			const gitInfo = await this.getRepoInfo(repo);
+			if (gitInfo) {
+				gitResultList.unshift(gitInfo);
+			}
+		}
+
+		return gitResultList;
+	}
+
+};
+
+module.exports.gitHelper = gitHelper;

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -2,12 +2,21 @@ const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 const fs = require("fs");
 const path = require("path");
-const Log = require("logger");
 
 class gitHelper {
-	constructor(){
+	constructor() {
 		this.gitRepos = [];
 		this.baseDir = path.normalize(__dirname + "/../../../");
+		if (process.env.JEST_WORKER_ID === undefined) {
+			this.Log = require("logger");
+		} else {
+			// if we are running with jest
+			this.Log = require("../../../tests/unit/mocks/logger.js");
+		}
+	}
+
+	getRefRegex(branch) {
+		return new RegExp("s*([a-z,0-9]+[.][.][a-z,0-9]+)  " + branch, "g");
 	}
 
 	async execShell(command) {
@@ -22,7 +31,7 @@ class gitHelper {
 	async isGitRepo(moduleFolder) {
 		let res = await this.execShell("cd " + moduleFolder + " && git remote -v");
 		if (res.stderr) {
-			Log.error("Failed to fetch git data for " + moduleFolder + ": " + res.stderr);
+			this.Log.error("Failed to fetch git data for " + moduleFolder + ": " + res.stderr);
 			return false;
 		} else {
 			return true;
@@ -32,10 +41,10 @@ class gitHelper {
 	add(moduleName) {
 		let moduleFolder = this.baseDir;
 		if (moduleName !== "default") {
-			moduleFolder = moduleFolder + 'modules/' + moduleName;
+			moduleFolder = moduleFolder + "modules/" + moduleName;
 		}
 		try {
-			Log.info("Checking git for module: " + moduleName);
+			this.Log.info("Checking git for module: " + moduleName);
 			// Throws error if file doesn't exist
 			fs.statSync(path.join(moduleFolder, ".git"));
 			// Fetch the git or throw error if no remotes
@@ -47,10 +56,9 @@ class gitHelper {
 			// Error when directory .git doesn't exist or doesn't have any remotes
 			// This module is not managed with git, skip
 		}
-
 	}
 
-	async getRepoInfo(repo) {
+	async getStatusInfo(repo) {
 		let gitInfo = {
 			module: repo.module,
 			// commits behind:
@@ -60,20 +68,21 @@ class gitHelper {
 			// current hash:
 			hash: "",
 			// remote branch:
-			tracking: ""
+			tracking: "",
+			isBehindInStatus: false
 		};
 		let res;
 		if (repo.module === "default") {
 			// the hash is only needed for the mm repo
 			res = await this.execShell("cd " + repo.folder + " && git rev-parse HEAD");
 			if (res.stderr) {
-				Log.error("Failed to get current commit hash for " + repo.module + ": " + res.stderr);
+				this.Log.error("Failed to get current commit hash for " + repo.module + ": " + res.stderr);
 			}
 			gitInfo.hash = res.stdout;
 		}
 		res = await this.execShell("cd " + repo.folder + " && git status -sb");
 		if (res.stderr) {
-			Log.error("Failed to get git status for " + repo.module + ": " + res.stderr);
+			this.Log.error("Failed to get git status for " + repo.module + ": " + res.stderr);
 			// exit without git status info
 			return;
 		}
@@ -95,24 +104,45 @@ class gitHelper {
 		if (status[2]) {
 			// git fetch was already called before so `git status -sb` delivers already the behind number
 			gitInfo.behind = parseInt(status[2].substring(0, status[2].length - 1));
+			gitInfo.isBehindInStatus = true;
+		}
+		return gitInfo;
+	}
+
+	async getRepoInfo(repo) {
+		let gitInfo = await this.getStatusInfo(repo);
+		if (!gitInfo) {
+			return;
+		}
+		if (gitInfo.isBehindInStatus) {
 			return gitInfo;
 		}
-		res = await this.execShell("cd " + repo.folder + " && git fetch --dry-run");
+		let res = await this.execShell("cd " + repo.folder + " && git fetch --dry-run");
 		// example output:
 		// From https://github.com/MichMich/MagicMirror
 		//    e40ddd4..06389e3  develop    -> origin/develop
 		// here the result is in stderr (this is a git default, don't ask why ...)
-		if (res.stderr === "") return;
-		let refs = res.stderr.match(/s*([a-z,0-9]+[.][.][a-z,0-9]+)s*/g)[0];
-		if (refs === "") {
-			// if match fails set behind to a number greater 0 and return
-			gitInfo.behind = 1;
-			return gitInfo;
+		const matches = res.stderr.match(this.getRefRegex(gitInfo.current));
+		if (!matches || !matches[0]) {
+			// no refs found, nothing to do
+			return;
 		}
 		// get behind with refs
-		res = await this.execShell("cd " + repo.folder + " && git rev-list --ancestry-path --count " + refs);
+		res = await this.execShell("cd " + repo.folder + " && git rev-list --ancestry-path --count " + matches[0]);
 		gitInfo.behind = parseInt(res.stdout);
 		return gitInfo;
+	}
+
+	async getStatus() {
+		const gitResultList = [];
+		for (let repo of this.gitRepos) {
+			const gitInfo = await this.getStatusInfo(repo);
+			if (gitInfo) {
+				gitResultList.unshift(gitInfo);
+			}
+		}
+
+		return gitResultList;
 	}
 
 	async getRepos() {
@@ -126,7 +156,6 @@ class gitHelper {
 
 		return gitResultList;
 	}
-
-};
+}
 
 module.exports.gitHelper = gitHelper;

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -8,7 +8,7 @@ module.exports = NodeHelper.create({
 	updateTimer: null,
 	updateProcessStarted: false,
 
-	gitHelper:  new git_Helper.gitHelper(),
+	gitHelper: new git_Helper.gitHelper(),
 
 	start: function () {},
 

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -1,4 +1,4 @@
-const git_Helper = require(__dirname + "/git_helper.js");
+const GitHelper = require(__dirname + "/git_helper.js");
 const defaultModules = require(__dirname + "/../defaultmodules.js");
 const NodeHelper = require("node_helper");
 
@@ -8,7 +8,7 @@ module.exports = NodeHelper.create({
 	updateTimer: null,
 	updateProcessStarted: false,
 
-	gitHelper: new git_Helper.gitHelper(),
+	gitHelper: new GitHelper.gitHelper(),
 
 	start: function () {},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,11 +28,11 @@
 			"devDependencies": {
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-jest": "^24.4.0",
-				"eslint-plugin-jsdoc": "^36.0.8",
+				"eslint-plugin-jsdoc": "^36.1.0",
 				"eslint-plugin-prettier": "^4.0.0",
 				"express-basic-auth": "^1.2.0",
 				"husky": "^7.0.2",
-				"jest": "^27.1.0",
+				"jest": "^27.1.1",
 				"jsdom": "^17.0.0",
 				"lodash": "^4.17.21",
 				"nyc": "^15.1.0",
@@ -788,16 +788,16 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
-			"integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.1.tgz",
+			"integrity": "sha512-VpQJRsWSeAem0zpBjeRtDbcD6DlbNoK11dNYt+PSQ+DDORh9q2/xyEpErfwgnLjWX0EKkSZmTGx/iH9Inzs6vQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-message-util": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -805,35 +805,35 @@
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
-			"integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.1.tgz",
+			"integrity": "sha512-oCkKeTgI0emznKcLoq5OCD0PhxCijA4l7ejDnWW3d5bgSi+zfVaLybVqa+EQOxpNejQWtTna7tmsAXjMN9N43Q==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^27.1.0",
-				"@jest/reporters": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/reporters": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"emittery": "^0.8.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^27.1.0",
-				"jest-config": "^27.1.0",
-				"jest-haste-map": "^27.1.0",
-				"jest-message-util": "^27.1.0",
+				"jest-changed-files": "^27.1.1",
+				"jest-config": "^27.1.1",
+				"jest-haste-map": "^27.1.1",
+				"jest-message-util": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-resolve-dependencies": "^27.1.0",
-				"jest-runner": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
-				"jest-watcher": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-resolve-dependencies": "^27.1.1",
+				"jest-runner": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
+				"jest-watcher": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"p-each-series": "^2.1.0",
 				"rimraf": "^3.0.0",
@@ -853,62 +853,62 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
-			"integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.1.tgz",
+			"integrity": "sha512-+y882/ZdxhyqF5RzxIrNIANjHj991WH7jifdcplzMDosDUOyCACFYUyVTBGbSTocbU+s1cesroRzkwi8hZ9SHg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0"
+				"jest-mock": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
-			"integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.1.tgz",
+			"integrity": "sha512-u8TJ5VlsVYTsGFatoyIae2l25pku4Bu15QCPTx2Gs5z+R//Ee3tHN85462Vc9yGVcdDvgADbqNkhOLxbEwPjMQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@sinonjs/fake-timers": "^7.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^27.1.0",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0"
+				"jest-message-util": "^27.1.1",
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
-			"integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.1.tgz",
+			"integrity": "sha512-Q3JcTPmY+DAEHnr4MpnBV3mwy50EGrTC6oSDTNnW7FNGGacTJAfpWNk02D7xv422T1OzK2A2BKx+26xJOvHkyw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^27.1.0",
-				"@jest/types": "^27.1.0",
-				"expect": "^27.1.0"
+				"@jest/environment": "^27.1.1",
+				"@jest/types": "^27.1.1",
+				"expect": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
-			"integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.1.tgz",
+			"integrity": "sha512-cEERs62n1P4Pqox9HWyNOEkP57G95aK2mBjB6D8Ruz1Yc98fKH53b58rlVEnsY5nLmkLNZk65fxNi9C0Yds/8w==",
 			"dev": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
@@ -919,10 +919,10 @@
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^4.0.1",
@@ -956,13 +956,13 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
-			"integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.1.tgz",
+			"integrity": "sha512-8vy75A0Jtfz9DqXFUkjC5Co/wRla+D7qRFdShUY8SbPqBS3GBx3tpba7sGKFos8mQrdbe39n+c1zgVKtarfy6A==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			},
@@ -971,36 +971,36 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
-			"integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.1.tgz",
+			"integrity": "sha512-l8zD3EdeixvwmLNlJoMX3hhj8iIze95okj4sqmBzOq/zW8gZLElUveH4bpKEMuR+Nweazjlwc7L6g4C26M/y6Q==",
 			"dev": true,
 			"dependencies": {
-				"@jest/test-result": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
-				"jest-runtime": "^27.1.0"
+				"jest-haste-map": "^27.1.1",
+				"jest-runtime": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
-			"integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.1.tgz",
+			"integrity": "sha512-qM19Eu75U6Jc5zosXXVnq900Nl9JDpoGaZ4Mg6wZs7oqbu3heYSMOZS19DlwjlhWdfNRjF4UeAgkrCJCK3fEXg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-util": "^27.1.0",
+				"jest-util": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -1012,9 +1012,9 @@
 			}
 		},
 		"node_modules/@jest/types": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-			"integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
+			"integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
 			"dev": true,
 			"dependencies": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -1155,9 +1155,9 @@
 			}
 		},
 		"node_modules/@types/babel__core": {
-			"version": "7.1.15",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-			"integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+			"version": "7.1.16",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+			"integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.1.0",
@@ -1924,13 +1924,13 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
-			"integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.1.tgz",
+			"integrity": "sha512-JA+dzJl4n2RBvWQEnph6HJaTHrsIPiXGQYatt/D8nR4UpX9UG4GaDzykVVPQBbrdTebZREkRb6SOxyIXJRab6Q==",
 			"dev": true,
 			"dependencies": {
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/babel__core": "^7.1.14",
 				"babel-plugin-istanbul": "^6.0.0",
 				"babel-preset-jest": "^27.0.6",
@@ -3633,9 +3633,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "36.0.8",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
-			"integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
+			"version": "36.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.0.tgz",
+			"integrity": "sha512-Qpied2AJCQcScxfzTObLKRiP5QgLXjMU/ITjBagEV5p2Q/HpumD1EQtazdRYdjDSwPmXhwOl2yquwOGQ4HOJNw==",
 			"dev": true,
 			"dependencies": {
 				"@es-joy/jsdoccomment": "0.10.8",
@@ -3908,16 +3908,16 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
-			"integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-27.1.1.tgz",
+			"integrity": "sha512-JQAzp0CJoFFHF1RnOtrMUNMdsfx/Tl0+FhRzVl8q0fa23N+JyWdPXwb3T5rkHCvyo9uttnK7lVdKCBl1b/9EDw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"ansi-styles": "^5.0.0",
 				"jest-get-type": "^27.0.6",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
 				"jest-regex-util": "^27.0.6"
 			},
 			"engines": {
@@ -5328,14 +5328,14 @@
 			}
 		},
 		"node_modules/jest": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
-			"integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-27.1.1.tgz",
+			"integrity": "sha512-LFTEZOhoZNR/2DQM3OCaK5xC6c55c1OWhYh0njRsoHX0qd6x4nkcgenkSH0JKjsAGMTmmJAoL7/oqYHMfwhruA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/core": "^27.1.0",
+				"@jest/core": "^27.1.1",
 				"import-local": "^3.0.2",
-				"jest-cli": "^27.1.0"
+				"jest-cli": "^27.1.1"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -5353,12 +5353,12 @@
 			}
 		},
 		"node_modules/jest-changed-files": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
-			"integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.1.tgz",
+			"integrity": "sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"execa": "^5.0.0",
 				"throat": "^6.0.1"
 			},
@@ -5367,27 +5367,27 @@
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
-			"integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.1.tgz",
+			"integrity": "sha512-Xed1ApiMFu/yzqGMBToHr8sp2gkX/ARZf4nXoGrHJrXrTUdVIWiVYheayfcOaPdQvQEE/uyBLgW7I7YBLIrAXQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
 				"dedent": "^0.7.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0",
+				"jest-each": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3",
 				"throat": "^6.0.1"
@@ -5397,21 +5397,21 @@
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
-			"integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.1.tgz",
+			"integrity": "sha512-LCjfEYp9D3bcOeVUUpEol9Y1ijZYMWVqflSmtw/wX+6Fb7zP4IlO14/6s9v1pxsoM4Pn46+M2zABgKuQjyDpTw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/core": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/core": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
 				"import-local": "^3.0.2",
-				"jest-config": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-config": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"prompts": "^2.0.1",
 				"yargs": "^16.0.3"
 			},
@@ -5431,32 +5431,32 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
-			"integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.1.tgz",
+			"integrity": "sha512-2iSd5zoJV4MsWPcLCGwUVUY/j6pZXm4Qd3rnbCtrd9EHNTg458iHw8PZztPQXfxKBKJxLfBk7tbZqYF8MGtxJA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^27.1.0",
-				"@jest/types": "^27.1.0",
-				"babel-jest": "^27.1.0",
+				"@jest/test-sequencer": "^27.1.1",
+				"@jest/types": "^27.1.1",
+				"babel-jest": "^27.1.1",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
 				"is-ci": "^3.0.0",
-				"jest-circus": "^27.1.0",
-				"jest-environment-jsdom": "^27.1.0",
-				"jest-environment-node": "^27.1.0",
+				"jest-circus": "^27.1.1",
+				"jest-environment-jsdom": "^27.1.1",
+				"jest-environment-node": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"jest-jasmine2": "^27.1.0",
+				"jest-jasmine2": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-runner": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-runner": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -5471,15 +5471,15 @@
 			}
 		},
 		"node_modules/jest-diff": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-			"integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.1.tgz",
+			"integrity": "sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
 				"diff-sequences": "^27.0.6",
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -5498,33 +5498,33 @@
 			}
 		},
 		"node_modules/jest-each": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
-			"integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.1.tgz",
+			"integrity": "sha512-r6hOsTLavUBb1xN0uDa89jdDeBmJ+K49fWpbyxeGRA2pLY46PlC4z551/cWNQzrj+IUa5/gSRsCIV/01HdNPug==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^27.0.6",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0"
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
-			"integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.1.tgz",
+			"integrity": "sha512-6vOnoZ6IaExuw7FvnuJhA1qFYv1DDSnN0sQowzolNwxQp7bG1YhLxj2YU1sVXAYA3IR3MbH2mbnJUsLUWfyfzw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"jsdom": "^16.6.0"
 			},
 			"engines": {
@@ -5532,9 +5532,9 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/acorn": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-			"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+			"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -5638,17 +5638,17 @@
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
-			"integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.1.tgz",
+			"integrity": "sha512-OEGeZh0PwzngNIYWYgWrvTcLygopV8OJbC9HNb0j70VBKgEIsdZkYhwcFnaURX83OHACMqf1pa9Tv5Pw5jemrg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0"
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -5664,12 +5664,12 @@
 			}
 		},
 		"node_modules/jest-haste-map": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
-			"integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.1.tgz",
+			"integrity": "sha512-NGLYVAdh5C8Ezg5QBFzrNeYsfxptDBPlhvZNaicLiZX77F/rS27a9M6u9ripWAaaD54xnWdZNZpEkdjD5Eo5aQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -5677,8 +5677,8 @@
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^27.0.6",
 				"jest-serializer": "^27.0.6",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.7"
 			},
@@ -5690,28 +5690,28 @@
 			}
 		},
 		"node_modules/jest-jasmine2": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
-			"integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.1.tgz",
+			"integrity": "sha512-0LAzUmcmvQwjIdJt0cXUVX4G5qjVXE8ELt6nbMNDzv2yAs2hYCCUtQq+Eje70GwAysWCGcS64QeYj5VPHYVxPg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^27.1.0",
+				"@jest/environment": "^27.1.1",
 				"@jest/source-map": "^27.0.6",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0",
+				"jest-each": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1",
 				"throat": "^6.0.1"
 			},
 			"engines": {
@@ -5719,46 +5719,46 @@
 			}
 		},
 		"node_modules/jest-leak-detector": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
-			"integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.1.tgz",
+			"integrity": "sha512-gwSgzmqShoeEsEVpgObymQPrM9P6557jt1EsFW5aCeJ46Cme0EdjYU7xr6llQZ5GpWDl56eOstUaPXiZOfiTKw==",
 			"dev": true,
 			"dependencies": {
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
-			"integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.1.tgz",
+			"integrity": "sha512-Q1a10w9Y4sh0wegkdP6reQOa/Dtz7nAvDqBgrat1ItZAUvk4jzXAqyhXPu/ZuEtDaXaNKpdRPRQA8bvkOh2Eaw==",
 			"dev": true,
 			"dependencies": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^27.1.0",
+				"jest-diff": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/jest-message-util": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
-			"integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.1.tgz",
+			"integrity": "sha512-b697BOJV93+AVGvzLRtVZ0cTVRbd59OaWnbB2D75GRaIMc4I+Z9W0wHxbfjW01JWO+TqqW4yevT0aN7Fd0XWng==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^27.1.0",
+				"pretty-format": "^27.1.1",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
@@ -5779,12 +5779,12 @@
 			}
 		},
 		"node_modules/jest-mock": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
-			"integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.1.tgz",
+			"integrity": "sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*"
 			},
 			"engines": {
@@ -5818,19 +5818,19 @@
 			}
 		},
 		"node_modules/jest-resolve": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
-			"integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.1.tgz",
+			"integrity": "sha512-M41YFmWhvDVstwe7XuV21zynOiBLJB5Sk0GrIsYYgTkjfEWNLVXDjAyq1W7PHseaYNOxIc0nOGq/r5iwcZNC1A==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"escalade": "^3.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"resolve": "^1.20.0",
 				"slash": "^3.0.0"
 			},
@@ -5839,45 +5839,45 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
-			"integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.1.tgz",
+			"integrity": "sha512-sYZR+uBjFDCo4VhYeazZf/T+ryYItvdLKu9vHatqkUqHGjDMrdEPOykiqC2iEpaCFTS+3iL/21CYiJuKdRbniw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-snapshot": "^27.1.0"
+				"jest-snapshot": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
-			"integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.1.tgz",
+			"integrity": "sha512-lP3MBNQhg75/sQtVkC8dsAQZumvy3lHK/YIwYPfEyqGIX1qEcnYIRxP89q0ZgC5ngvi1vN2P5UFHszQxguWdng==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^27.1.0",
-				"@jest/environment": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/environment": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.8.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-docblock": "^27.0.6",
-				"jest-environment-jsdom": "^27.1.0",
-				"jest-environment-node": "^27.1.0",
-				"jest-haste-map": "^27.1.0",
-				"jest-leak-detector": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-environment-jsdom": "^27.1.1",
+				"jest-environment-node": "^27.1.1",
+				"jest-haste-map": "^27.1.1",
+				"jest-leak-detector": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^6.0.1"
 			},
@@ -5886,19 +5886,19 @@
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
-			"integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.1.tgz",
+			"integrity": "sha512-FEwy+tSzmsvuKaQpyYsUyk31KG5vMmA2r2BSTHgv0yNfcooQdm2Ke91LM9Ud8D3xz8CLDHJWAI24haMFTwrsPg==",
 			"dev": true,
 			"dependencies": {
-				"@jest/console": "^27.1.0",
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/globals": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/globals": "^27.1.1",
 				"@jest/source-map": "^27.0.6",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/yargs": "^16.0.0",
 				"chalk": "^4.0.0",
 				"cjs-module-lexer": "^1.0.0",
@@ -5907,14 +5907,14 @@
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-mock": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-mock": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
 				"yargs": "^16.0.3"
@@ -5937,9 +5937,9 @@
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
-			"integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.1.tgz",
+			"integrity": "sha512-Wi3QGiuRFo3lU+EbQmZnBOks0CJyAMPHvYoG7iJk00Do10jeOyuOEO0Jfoaoun8+8TDv+Nzl7Aswir/IK9+1jg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.7.2",
@@ -5948,23 +5948,23 @@
 				"@babel/plugin-syntax-typescript": "^7.7.2",
 				"@babel/traverse": "^7.7.2",
 				"@babel/types": "^7.0.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/babel__traverse": "^7.0.4",
 				"@types/prettier": "^2.1.5",
 				"babel-preset-current-node-syntax": "^1.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-diff": "^27.1.0",
+				"jest-diff": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"jest-haste-map": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^27.1.0",
+				"pretty-format": "^27.1.1",
 				"semver": "^7.3.2"
 			},
 			"engines": {
@@ -5987,12 +5987,12 @@
 			}
 		},
 		"node_modules/jest-util": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
-			"integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.1.tgz",
+			"integrity": "sha512-zf9nEbrASWn2mC/L91nNb0K+GkhFvi4MP6XJG2HqnHzHvLYcs7ou/In68xYU1i1dSkJlrWcYfWXQE8nVR+nbOA==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -6004,17 +6004,17 @@
 			}
 		},
 		"node_modules/jest-validate": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
-			"integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.1.tgz",
+			"integrity": "sha512-N5Er5FKav/8m2dJwn7BGnZwnoD1BSc8jx5T+diG2OvyeugvZDhPeAt5DrNaGkkaKCrSUvuE7A5E4uHyT7Vj0Mw==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"camelcase": "^6.2.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^27.0.6",
 				"leven": "^3.1.0",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"engines": {
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -6033,17 +6033,17 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
-			"integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.1.tgz",
+			"integrity": "sha512-XQzyHbxziDe+lZM6Dzs40fEt4q9akOGwitJnxQasJ9WG0bv3JGiRlsBgjw13znGapeMtFaEsyhL0Cl04IbaoWQ==",
 			"dev": true,
 			"dependencies": {
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^27.1.0",
+				"jest-util": "^27.1.1",
 				"string-length": "^4.0.1"
 			},
 			"engines": {
@@ -6051,9 +6051,9 @@
 			}
 		},
 		"node_modules/jest-worker": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-			"integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.1.tgz",
+			"integrity": "sha512-XJKCL7tu+362IUYTWvw8+3S75U7qMiYiRU6u5yqscB48bTvzwN6i8L/7wVTXiFLwkRsxARNM7TISnTvcgv9hxA==",
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -7765,12 +7765,12 @@
 			}
 		},
 		"node_modules/pretty-format": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-			"integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.1.tgz",
+			"integrity": "sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==",
 			"dev": true,
 			"dependencies": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^17.0.1"
@@ -9518,9 +9518,9 @@
 			"dev": true
 		},
 		"node_modules/tmpl": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
 		},
 		"node_modules/to-fast-properties": {
@@ -11093,49 +11093,49 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.0.tgz",
-			"integrity": "sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-27.1.1.tgz",
+			"integrity": "sha512-VpQJRsWSeAem0zpBjeRtDbcD6DlbNoK11dNYt+PSQ+DDORh9q2/xyEpErfwgnLjWX0EKkSZmTGx/iH9Inzs6vQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
-				"jest-message-util": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-message-util": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/core": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.0.tgz",
-			"integrity": "sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-27.1.1.tgz",
+			"integrity": "sha512-oCkKeTgI0emznKcLoq5OCD0PhxCijA4l7ejDnWW3d5bgSi+zfVaLybVqa+EQOxpNejQWtTna7tmsAXjMN9N43Q==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^27.1.0",
-				"@jest/reporters": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/reporters": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
 				"emittery": "^0.8.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
-				"jest-changed-files": "^27.1.0",
-				"jest-config": "^27.1.0",
-				"jest-haste-map": "^27.1.0",
-				"jest-message-util": "^27.1.0",
+				"jest-changed-files": "^27.1.1",
+				"jest-config": "^27.1.1",
+				"jest-haste-map": "^27.1.1",
+				"jest-message-util": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-resolve-dependencies": "^27.1.0",
-				"jest-runner": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
-				"jest-watcher": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-resolve-dependencies": "^27.1.1",
+				"jest-runner": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
+				"jest-watcher": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"p-each-series": "^2.1.0",
 				"rimraf": "^3.0.0",
@@ -11144,53 +11144,53 @@
 			}
 		},
 		"@jest/environment": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.0.tgz",
-			"integrity": "sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.1.1.tgz",
+			"integrity": "sha512-+y882/ZdxhyqF5RzxIrNIANjHj991WH7jifdcplzMDosDUOyCACFYUyVTBGbSTocbU+s1cesroRzkwi8hZ9SHg==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0"
+				"jest-mock": "^27.1.1"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.0.tgz",
-			"integrity": "sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.1.1.tgz",
+			"integrity": "sha512-u8TJ5VlsVYTsGFatoyIae2l25pku4Bu15QCPTx2Gs5z+R//Ee3tHN85462Vc9yGVcdDvgADbqNkhOLxbEwPjMQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@sinonjs/fake-timers": "^7.0.2",
 				"@types/node": "*",
-				"jest-message-util": "^27.1.0",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0"
+				"jest-message-util": "^27.1.1",
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1"
 			}
 		},
 		"@jest/globals": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.0.tgz",
-			"integrity": "sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.1.1.tgz",
+			"integrity": "sha512-Q3JcTPmY+DAEHnr4MpnBV3mwy50EGrTC6oSDTNnW7FNGGacTJAfpWNk02D7xv422T1OzK2A2BKx+26xJOvHkyw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^27.1.0",
-				"@jest/types": "^27.1.0",
-				"expect": "^27.1.0"
+				"@jest/environment": "^27.1.1",
+				"@jest/types": "^27.1.1",
+				"expect": "^27.1.1"
 			}
 		},
 		"@jest/reporters": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.0.tgz",
-			"integrity": "sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.1.1.tgz",
+			"integrity": "sha512-cEERs62n1P4Pqox9HWyNOEkP57G95aK2mBjB6D8Ruz1Yc98fKH53b58rlVEnsY5nLmkLNZk65fxNi9C0Yds/8w==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"collect-v8-coverage": "^1.0.0",
 				"exit": "^0.1.2",
@@ -11201,10 +11201,10 @@
 				"istanbul-lib-report": "^3.0.0",
 				"istanbul-lib-source-maps": "^4.0.0",
 				"istanbul-reports": "^3.0.2",
-				"jest-haste-map": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^4.0.1",
@@ -11224,45 +11224,45 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.0.tgz",
-			"integrity": "sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.1.1.tgz",
+			"integrity": "sha512-8vy75A0Jtfz9DqXFUkjC5Co/wRla+D7qRFdShUY8SbPqBS3GBx3tpba7sGKFos8mQrdbe39n+c1zgVKtarfy6A==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/istanbul-lib-coverage": "^2.0.0",
 				"collect-v8-coverage": "^1.0.0"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz",
-			"integrity": "sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.1.1.tgz",
+			"integrity": "sha512-l8zD3EdeixvwmLNlJoMX3hhj8iIze95okj4sqmBzOq/zW8gZLElUveH4bpKEMuR+Nweazjlwc7L6g4C26M/y6Q==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
-				"jest-runtime": "^27.1.0"
+				"jest-haste-map": "^27.1.1",
+				"jest-runtime": "^27.1.1"
 			}
 		},
 		"@jest/transform": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.0.tgz",
-			"integrity": "sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.1.1.tgz",
+			"integrity": "sha512-qM19Eu75U6Jc5zosXXVnq900Nl9JDpoGaZ4Mg6wZs7oqbu3heYSMOZS19DlwjlhWdfNRjF4UeAgkrCJCK3fEXg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"babel-plugin-istanbul": "^6.0.0",
 				"chalk": "^4.0.0",
 				"convert-source-map": "^1.4.0",
 				"fast-json-stable-stringify": "^2.0.0",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-util": "^27.1.0",
+				"jest-util": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"pirates": "^4.0.1",
 				"slash": "^3.0.0",
@@ -11271,9 +11271,9 @@
 			}
 		},
 		"@jest/types": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.0.tgz",
-			"integrity": "sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
+			"integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-coverage": "^2.0.0",
@@ -11385,9 +11385,9 @@
 			"dev": true
 		},
 		"@types/babel__core": {
-			"version": "7.1.15",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-			"integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+			"version": "7.1.16",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.16.tgz",
+			"integrity": "sha512-EAEHtisTMM+KaKwfWdC3oyllIqswlznXCIVCt7/oRNrh+DhgT4UEBNC/jlADNjvw7UnfbcdkGQcPVZ1xYiLcrQ==",
 			"dev": true,
 			"requires": {
 				"@babel/parser": "^7.1.0",
@@ -11998,13 +11998,13 @@
 			}
 		},
 		"babel-jest": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.0.tgz",
-			"integrity": "sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.1.1.tgz",
+			"integrity": "sha512-JA+dzJl4n2RBvWQEnph6HJaTHrsIPiXGQYatt/D8nR4UpX9UG4GaDzykVVPQBbrdTebZREkRb6SOxyIXJRab6Q==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/babel__core": "^7.1.14",
 				"babel-plugin-istanbul": "^6.0.0",
 				"babel-preset-jest": "^27.0.6",
@@ -13307,9 +13307,9 @@
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "36.0.8",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.0.8.tgz",
-			"integrity": "sha512-brNjHvRuBy5CaV01mSp6WljrO/T8fHNj0DXG38odOGDnhI7HdcbLKX7DpSvg2Rfcifwh8GlnNFzx13sI05t3bg==",
+			"version": "36.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-36.1.0.tgz",
+			"integrity": "sha512-Qpied2AJCQcScxfzTObLKRiP5QgLXjMU/ITjBagEV5p2Q/HpumD1EQtazdRYdjDSwPmXhwOl2yquwOGQ4HOJNw==",
 			"dev": true,
 			"requires": {
 				"@es-joy/jsdoccomment": "0.10.8",
@@ -13486,16 +13486,16 @@
 			"dev": true
 		},
 		"expect": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-27.1.0.tgz",
-			"integrity": "sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-27.1.1.tgz",
+			"integrity": "sha512-JQAzp0CJoFFHF1RnOtrMUNMdsfx/Tl0+FhRzVl8q0fa23N+JyWdPXwb3T5rkHCvyo9uttnK7lVdKCBl1b/9EDw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"ansi-styles": "^5.0.0",
 				"jest-get-type": "^27.0.6",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
 				"jest-regex-util": "^27.0.6"
 			},
 			"dependencies": {
@@ -14566,113 +14566,113 @@
 			}
 		},
 		"jest": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-27.1.0.tgz",
-			"integrity": "sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-27.1.1.tgz",
+			"integrity": "sha512-LFTEZOhoZNR/2DQM3OCaK5xC6c55c1OWhYh0njRsoHX0qd6x4nkcgenkSH0JKjsAGMTmmJAoL7/oqYHMfwhruA==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^27.1.0",
+				"@jest/core": "^27.1.1",
 				"import-local": "^3.0.2",
-				"jest-cli": "^27.1.0"
+				"jest-cli": "^27.1.1"
 			}
 		},
 		"jest-changed-files": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.0.tgz",
-			"integrity": "sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.1.1.tgz",
+			"integrity": "sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"execa": "^5.0.0",
 				"throat": "^6.0.1"
 			}
 		},
 		"jest-circus": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.0.tgz",
-			"integrity": "sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.1.1.tgz",
+			"integrity": "sha512-Xed1ApiMFu/yzqGMBToHr8sp2gkX/ARZf4nXoGrHJrXrTUdVIWiVYheayfcOaPdQvQEE/uyBLgW7I7YBLIrAXQ==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
 				"dedent": "^0.7.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0",
+				"jest-each": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3",
 				"throat": "^6.0.1"
 			}
 		},
 		"jest-cli": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.0.tgz",
-			"integrity": "sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.1.1.tgz",
+			"integrity": "sha512-LCjfEYp9D3bcOeVUUpEol9Y1ijZYMWVqflSmtw/wX+6Fb7zP4IlO14/6s9v1pxsoM4Pn46+M2zABgKuQjyDpTw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/core": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
 				"import-local": "^3.0.2",
-				"jest-config": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-config": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"prompts": "^2.0.1",
 				"yargs": "^16.0.3"
 			}
 		},
 		"jest-config": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.0.tgz",
-			"integrity": "sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.1.1.tgz",
+			"integrity": "sha512-2iSd5zoJV4MsWPcLCGwUVUY/j6pZXm4Qd3rnbCtrd9EHNTg458iHw8PZztPQXfxKBKJxLfBk7tbZqYF8MGtxJA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.1.0",
-				"@jest/test-sequencer": "^27.1.0",
-				"@jest/types": "^27.1.0",
-				"babel-jest": "^27.1.0",
+				"@jest/test-sequencer": "^27.1.1",
+				"@jest/types": "^27.1.1",
+				"babel-jest": "^27.1.1",
 				"chalk": "^4.0.0",
 				"deepmerge": "^4.2.2",
 				"glob": "^7.1.1",
 				"graceful-fs": "^4.2.4",
 				"is-ci": "^3.0.0",
-				"jest-circus": "^27.1.0",
-				"jest-environment-jsdom": "^27.1.0",
-				"jest-environment-node": "^27.1.0",
+				"jest-circus": "^27.1.1",
+				"jest-environment-jsdom": "^27.1.1",
+				"jest-environment-node": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"jest-jasmine2": "^27.1.0",
+				"jest-jasmine2": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-runner": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-runner": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			}
 		},
 		"jest-diff": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.0.tgz",
-			"integrity": "sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.1.tgz",
+			"integrity": "sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
 				"diff-sequences": "^27.0.6",
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			}
 		},
 		"jest-docblock": {
@@ -14685,37 +14685,37 @@
 			}
 		},
 		"jest-each": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.0.tgz",
-			"integrity": "sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.1.1.tgz",
+			"integrity": "sha512-r6hOsTLavUBb1xN0uDa89jdDeBmJ+K49fWpbyxeGRA2pLY46PlC4z551/cWNQzrj+IUa5/gSRsCIV/01HdNPug==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^27.0.6",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0"
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1"
 			}
 		},
 		"jest-environment-jsdom": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz",
-			"integrity": "sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.1.1.tgz",
+			"integrity": "sha512-6vOnoZ6IaExuw7FvnuJhA1qFYv1DDSnN0sQowzolNwxQp7bG1YhLxj2YU1sVXAYA3IR3MbH2mbnJUsLUWfyfzw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"jsdom": "^16.6.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.4.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-					"integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+					"version": "8.5.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+					"integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
 					"dev": true
 				},
 				"cssom": {
@@ -14795,17 +14795,17 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.0.tgz",
-			"integrity": "sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.1.1.tgz",
+			"integrity": "sha512-OEGeZh0PwzngNIYWYgWrvTcLygopV8OJbC9HNb0j70VBKgEIsdZkYhwcFnaURX83OHACMqf1pa9Tv5Pw5jemrg==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
-				"jest-mock": "^27.1.0",
-				"jest-util": "^27.1.0"
+				"jest-mock": "^27.1.1",
+				"jest-util": "^27.1.1"
 			}
 		},
 		"jest-get-type": {
@@ -14815,12 +14815,12 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.0.tgz",
-			"integrity": "sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.1.1.tgz",
+			"integrity": "sha512-NGLYVAdh5C8Ezg5QBFzrNeYsfxptDBPlhvZNaicLiZX77F/rS27a9M6u9ripWAaaD54xnWdZNZpEkdjD5Eo5aQ==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/graceful-fs": "^4.1.2",
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
@@ -14829,73 +14829,73 @@
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^27.0.6",
 				"jest-serializer": "^27.0.6",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"micromatch": "^4.0.4",
 				"walker": "^1.0.7"
 			}
 		},
 		"jest-jasmine2": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz",
-			"integrity": "sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.1.1.tgz",
+			"integrity": "sha512-0LAzUmcmvQwjIdJt0cXUVX4G5qjVXE8ELt6nbMNDzv2yAs2hYCCUtQq+Eje70GwAysWCGcS64QeYj5VPHYVxPg==",
 			"dev": true,
 			"requires": {
 				"@babel/traverse": "^7.1.0",
-				"@jest/environment": "^27.1.0",
+				"@jest/environment": "^27.1.1",
 				"@jest/source-map": "^27.0.6",
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"co": "^4.6.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"is-generator-fn": "^2.0.0",
-				"jest-each": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"pretty-format": "^27.1.0",
+				"jest-each": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"pretty-format": "^27.1.1",
 				"throat": "^6.0.1"
 			}
 		},
 		"jest-leak-detector": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz",
-			"integrity": "sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.1.1.tgz",
+			"integrity": "sha512-gwSgzmqShoeEsEVpgObymQPrM9P6557jt1EsFW5aCeJ46Cme0EdjYU7xr6llQZ5GpWDl56eOstUaPXiZOfiTKw==",
 			"dev": true,
 			"requires": {
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz",
-			"integrity": "sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.1.1.tgz",
+			"integrity": "sha512-Q1a10w9Y4sh0wegkdP6reQOa/Dtz7nAvDqBgrat1ItZAUvk4jzXAqyhXPu/ZuEtDaXaNKpdRPRQA8bvkOh2Eaw==",
 			"dev": true,
 			"requires": {
 				"chalk": "^4.0.0",
-				"jest-diff": "^27.1.0",
+				"jest-diff": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			}
 		},
 		"jest-message-util": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.0.tgz",
-			"integrity": "sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.1.1.tgz",
+			"integrity": "sha512-b697BOJV93+AVGvzLRtVZ0cTVRbd59OaWnbB2D75GRaIMc4I+Z9W0wHxbfjW01JWO+TqqW4yevT0aN7Fd0XWng==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/stack-utils": "^2.0.0",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
 				"micromatch": "^4.0.4",
-				"pretty-format": "^27.1.0",
+				"pretty-format": "^27.1.1",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
 			},
@@ -14912,12 +14912,12 @@
 			}
 		},
 		"jest-mock": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.0.tgz",
-			"integrity": "sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.1.1.tgz",
+			"integrity": "sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*"
 			}
 		},
@@ -14935,78 +14935,78 @@
 			"dev": true
 		},
 		"jest-resolve": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.0.tgz",
-			"integrity": "sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.1.1.tgz",
+			"integrity": "sha512-M41YFmWhvDVstwe7XuV21zynOiBLJB5Sk0GrIsYYgTkjfEWNLVXDjAyq1W7PHseaYNOxIc0nOGq/r5iwcZNC1A==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"chalk": "^4.0.0",
 				"escalade": "^3.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
 				"jest-pnp-resolver": "^1.2.2",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"resolve": "^1.20.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz",
-			"integrity": "sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.1.tgz",
+			"integrity": "sha512-sYZR+uBjFDCo4VhYeazZf/T+ryYItvdLKu9vHatqkUqHGjDMrdEPOykiqC2iEpaCFTS+3iL/21CYiJuKdRbniw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-snapshot": "^27.1.0"
+				"jest-snapshot": "^27.1.1"
 			}
 		},
 		"jest-runner": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.0.tgz",
-			"integrity": "sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.1.1.tgz",
+			"integrity": "sha512-lP3MBNQhg75/sQtVkC8dsAQZumvy3lHK/YIwYPfEyqGIX1qEcnYIRxP89q0ZgC5ngvi1vN2P5UFHszQxguWdng==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^27.1.0",
-				"@jest/environment": "^27.1.0",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/environment": "^27.1.1",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"emittery": "^0.8.1",
 				"exit": "^0.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-docblock": "^27.0.6",
-				"jest-environment-jsdom": "^27.1.0",
-				"jest-environment-node": "^27.1.0",
-				"jest-haste-map": "^27.1.0",
-				"jest-leak-detector": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-runtime": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-worker": "^27.1.0",
+				"jest-environment-jsdom": "^27.1.1",
+				"jest-environment-node": "^27.1.1",
+				"jest-haste-map": "^27.1.1",
+				"jest-leak-detector": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-runtime": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-worker": "^27.1.1",
 				"source-map-support": "^0.5.6",
 				"throat": "^6.0.1"
 			}
 		},
 		"jest-runtime": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.0.tgz",
-			"integrity": "sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.1.1.tgz",
+			"integrity": "sha512-FEwy+tSzmsvuKaQpyYsUyk31KG5vMmA2r2BSTHgv0yNfcooQdm2Ke91LM9Ud8D3xz8CLDHJWAI24haMFTwrsPg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "^27.1.0",
-				"@jest/environment": "^27.1.0",
-				"@jest/fake-timers": "^27.1.0",
-				"@jest/globals": "^27.1.0",
+				"@jest/console": "^27.1.1",
+				"@jest/environment": "^27.1.1",
+				"@jest/fake-timers": "^27.1.1",
+				"@jest/globals": "^27.1.1",
 				"@jest/source-map": "^27.0.6",
-				"@jest/test-result": "^27.1.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/yargs": "^16.0.0",
 				"chalk": "^4.0.0",
 				"cjs-module-lexer": "^1.0.0",
@@ -15015,14 +15015,14 @@
 				"exit": "^0.1.2",
 				"glob": "^7.1.3",
 				"graceful-fs": "^4.2.4",
-				"jest-haste-map": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-mock": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-mock": "^27.1.1",
 				"jest-regex-util": "^27.0.6",
-				"jest-resolve": "^27.1.0",
-				"jest-snapshot": "^27.1.0",
-				"jest-util": "^27.1.0",
-				"jest-validate": "^27.1.0",
+				"jest-resolve": "^27.1.1",
+				"jest-snapshot": "^27.1.1",
+				"jest-util": "^27.1.1",
+				"jest-validate": "^27.1.1",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0",
 				"yargs": "^16.0.3"
@@ -15039,9 +15039,9 @@
 			}
 		},
 		"jest-snapshot": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.0.tgz",
-			"integrity": "sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.1.1.tgz",
+			"integrity": "sha512-Wi3QGiuRFo3lU+EbQmZnBOks0CJyAMPHvYoG7iJk00Do10jeOyuOEO0Jfoaoun8+8TDv+Nzl7Aswir/IK9+1jg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.7.2",
@@ -15050,23 +15050,23 @@
 				"@babel/plugin-syntax-typescript": "^7.7.2",
 				"@babel/traverse": "^7.7.2",
 				"@babel/types": "^7.0.0",
-				"@jest/transform": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/transform": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/babel__traverse": "^7.0.4",
 				"@types/prettier": "^2.1.5",
 				"babel-preset-current-node-syntax": "^1.0.0",
 				"chalk": "^4.0.0",
-				"expect": "^27.1.0",
+				"expect": "^27.1.1",
 				"graceful-fs": "^4.2.4",
-				"jest-diff": "^27.1.0",
+				"jest-diff": "^27.1.1",
 				"jest-get-type": "^27.0.6",
-				"jest-haste-map": "^27.1.0",
-				"jest-matcher-utils": "^27.1.0",
-				"jest-message-util": "^27.1.0",
-				"jest-resolve": "^27.1.0",
-				"jest-util": "^27.1.0",
+				"jest-haste-map": "^27.1.1",
+				"jest-matcher-utils": "^27.1.1",
+				"jest-message-util": "^27.1.1",
+				"jest-resolve": "^27.1.1",
+				"jest-util": "^27.1.1",
 				"natural-compare": "^1.4.0",
-				"pretty-format": "^27.1.0",
+				"pretty-format": "^27.1.1",
 				"semver": "^7.3.2"
 			},
 			"dependencies": {
@@ -15082,12 +15082,12 @@
 			}
 		},
 		"jest-util": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.0.tgz",
-			"integrity": "sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.1.1.tgz",
+			"integrity": "sha512-zf9nEbrASWn2mC/L91nNb0K+GkhFvi4MP6XJG2HqnHzHvLYcs7ou/In68xYU1i1dSkJlrWcYfWXQE8nVR+nbOA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"chalk": "^4.0.0",
 				"graceful-fs": "^4.2.4",
@@ -15096,17 +15096,17 @@
 			}
 		},
 		"jest-validate": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.0.tgz",
-			"integrity": "sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.1.1.tgz",
+			"integrity": "sha512-N5Er5FKav/8m2dJwn7BGnZwnoD1BSc8jx5T+diG2OvyeugvZDhPeAt5DrNaGkkaKCrSUvuE7A5E4uHyT7Vj0Mw==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"camelcase": "^6.2.0",
 				"chalk": "^4.0.0",
 				"jest-get-type": "^27.0.6",
 				"leven": "^3.1.0",
-				"pretty-format": "^27.1.0"
+				"pretty-format": "^27.1.1"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -15118,24 +15118,24 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.0.tgz",
-			"integrity": "sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.1.1.tgz",
+			"integrity": "sha512-XQzyHbxziDe+lZM6Dzs40fEt4q9akOGwitJnxQasJ9WG0bv3JGiRlsBgjw13znGapeMtFaEsyhL0Cl04IbaoWQ==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "^27.1.0",
-				"@jest/types": "^27.1.0",
+				"@jest/test-result": "^27.1.1",
+				"@jest/types": "^27.1.1",
 				"@types/node": "*",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.0.0",
-				"jest-util": "^27.1.0",
+				"jest-util": "^27.1.1",
 				"string-length": "^4.0.1"
 			}
 		},
 		"jest-worker": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.0.tgz",
-			"integrity": "sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.1.1.tgz",
+			"integrity": "sha512-XJKCL7tu+362IUYTWvw8+3S75U7qMiYiRU6u5yqscB48bTvzwN6i8L/7wVTXiFLwkRsxARNM7TISnTvcgv9hxA==",
 			"dev": true,
 			"requires": {
 				"@types/node": "*",
@@ -16455,12 +16455,12 @@
 			}
 		},
 		"pretty-format": {
-			"version": "27.1.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.0.tgz",
-			"integrity": "sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==",
+			"version": "27.1.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.1.tgz",
+			"integrity": "sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^27.1.0",
+				"@jest/types": "^27.1.1",
 				"ansi-regex": "^5.0.0",
 				"ansi-styles": "^5.0.0",
 				"react-is": "^17.0.1"
@@ -17816,9 +17816,9 @@
 			"dev": true
 		},
 		"tmpl": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+			"integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
 			"dev": true
 		},
 		"to-fast-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"moment": "^2.29.1",
 				"node-fetch": "^2.6.1",
 				"node-ical": "^0.13.0",
-				"simple-git": "^2.45.0",
 				"socket.io": "^4.1.3"
 			},
 			"devDependencies": {
@@ -8707,16 +8706,6 @@
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
 		},
-		"node_modules/simple-git": {
-			"version": "2.45.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.45.0.tgz",
-			"integrity": "sha512-wu/Ujs9IXn0HuyYm4HyRvne+EKsjJSWKEMkB3wQa3gNHSMHt7y3oeNX9zRQ3UBPk7bRRMLLHAdIZCZfHT9ehPg==",
-			"dependencies": {
-				"@kwsites/file-exists": "^1.1.1",
-				"@kwsites/promise-deferred": "^1.1.1",
-				"debug": "^4.3.1"
-			}
-		},
 		"node_modules/sinon": {
 			"version": "11.1.2",
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
@@ -17205,16 +17194,6 @@
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
 			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
 			"dev": true
-		},
-		"simple-git": {
-			"version": "2.45.0",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.45.0.tgz",
-			"integrity": "sha512-wu/Ujs9IXn0HuyYm4HyRvne+EKsjJSWKEMkB3wQa3gNHSMHt7y3oeNX9zRQ3UBPk7bRRMLLHAdIZCZfHT9ehPg==",
-			"requires": {
-				"@kwsites/file-exists": "^1.1.1",
-				"@kwsites/promise-deferred": "^1.1.1",
-				"debug": "^4.3.1"
-			}
 		},
 		"sinon": {
 			"version": "11.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,13 +23,13 @@
 				"moment": "^2.29.1",
 				"node-fetch": "^2.6.1",
 				"node-ical": "^0.13.0",
-				"socket.io": "^4.1.3"
+				"socket.io": "^4.2.0"
 			},
 			"devDependencies": {
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-jest": "^24.4.0",
 				"eslint-plugin-jsdoc": "^36.0.8",
-				"eslint-plugin-prettier": "^3.4.1",
+				"eslint-plugin-prettier": "^4.0.0",
 				"express-basic-auth": "^1.2.0",
 				"husky": "^7.0.2",
 				"jest": "^27.1.0",
@@ -50,7 +50,7 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"electron": "^13.2.3"
+				"electron": "^13.3.0"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -1027,19 +1027,6 @@
 				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
-		"node_modules/@kwsites/file-exists": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-			"dependencies": {
-				"debug": "^4.1.1"
-			}
-		},
-		"node_modules/@kwsites/promise-deferred": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
-		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1226,14 +1213,14 @@
 			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
 		},
 		"node_modules/@types/cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg=="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
 		},
 		"node_modules/@types/cors": {
-			"version": "2.8.10",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
-			"integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
+			"version": "2.8.12",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
 		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.5",
@@ -3243,9 +3230,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron": {
-			"version": "13.2.3",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-13.2.3.tgz",
-			"integrity": "sha512-FzWhbKHjq7ZTpPQFaYiLPL64erC8/BOsu5NlNN9nQ6f7rIP8ygKlNAlQit3vbOcksQAwItDUCIw4sW0mcaRpCA==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+			"integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3353,9 +3340,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.1.1.tgz",
-			"integrity": "sha512-aMWot7H5aC8L4/T8qMYbLdvKlZOdJTH54FxfdFunTGvhMx1BHkJOntWArsVfgAZVwAO9LC2sryPWRcEeUzCe5w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.2.0.tgz",
+			"integrity": "sha512-d1DexkQx87IFr1FLuV+0f5kAm1Hk1uOVijLOb+D1sDO2QMb7YjE02VHtZtxo7xIXMgcWLb+vl3HRT0rI9tr4jQ==",
 			"dependencies": {
 				"accepts": "~1.3.4",
 				"base64id": "2.0.0",
@@ -3370,9 +3357,9 @@
 			}
 		},
 		"node_modules/engine.io-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
-			"integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
+			"integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
 			"dependencies": {
 				"base64-arraybuffer": "0.1.4"
 			},
@@ -3684,9 +3671,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+			"integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
 			"dev": true,
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -3695,8 +3682,8 @@
 				"node": ">=6.0.0"
 			},
 			"peerDependencies": {
-				"eslint": ">=5.0.0",
-				"prettier": ">=1.13.0"
+				"eslint": ">=7.28.0",
+				"prettier": ">=2.0.0"
 			},
 			"peerDependenciesMeta": {
 				"eslint-config-prettier": {
@@ -8756,18 +8743,18 @@
 			}
 		},
 		"node_modules/socket.io": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.1.3.tgz",
-			"integrity": "sha512-tLkaY13RcO4nIRh1K2hT5iuotfTaIQw7cVIe0FUykN3SuQi0cm7ALxuyT5/CtDswOMWUzMGTibxYNx/gU7In+Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.2.0.tgz",
+			"integrity": "sha512-sjlGfMmnaWvTRVxGRGWyhd9ctpg4APxWAxu85O/SxekkxHhfxmePWZbaYCkeX5QQX0z1YEnKOlNt6w82E4Nzug==",
 			"dependencies": {
-				"@types/cookie": "^0.4.0",
-				"@types/cors": "^2.8.10",
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
 				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
-				"debug": "~4.3.1",
-				"engine.io": "~5.1.1",
-				"socket.io-adapter": "~2.3.1",
+				"debug": "~4.3.2",
+				"engine.io": "~5.2.0",
+				"socket.io-adapter": "~2.3.2",
 				"socket.io-parser": "~4.0.4"
 			},
 			"engines": {
@@ -8775,9 +8762,9 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.1.tgz",
-			"integrity": "sha512-8cVkRxI8Nt2wadkY6u60Y4rpW3ejA1rxgcK2JuyIhmF+RMNpTy1QRtkHIDUOf3B4HlQwakMsWbKftMv/71VMmw=="
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
+			"integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg=="
 		},
 		"node_modules/socket.io-parser": {
 			"version": "4.0.4",
@@ -11296,19 +11283,6 @@
 				"chalk": "^4.0.0"
 			}
 		},
-		"@kwsites/file-exists": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-			"requires": {
-				"debug": "^4.1.1"
-			}
-		},
-		"@kwsites/promise-deferred": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -11469,14 +11443,14 @@
 			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg=="
 		},
 		"@types/cookie": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
-			"integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg=="
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
 		},
 		"@types/cors": {
-			"version": "2.8.10",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
-			"integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
+			"version": "2.8.12",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
 		},
 		"@types/graceful-fs": {
 			"version": "4.1.5",
@@ -13039,9 +13013,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron": {
-			"version": "13.2.3",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-13.2.3.tgz",
-			"integrity": "sha512-FzWhbKHjq7ZTpPQFaYiLPL64erC8/BOsu5NlNN9nQ6f7rIP8ygKlNAlQit3vbOcksQAwItDUCIw4sW0mcaRpCA==",
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+			"integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
 			"devOptional": true,
 			"requires": {
 				"@electron/get": "^1.0.1",
@@ -13114,9 +13088,9 @@
 			}
 		},
 		"engine.io": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.1.1.tgz",
-			"integrity": "sha512-aMWot7H5aC8L4/T8qMYbLdvKlZOdJTH54FxfdFunTGvhMx1BHkJOntWArsVfgAZVwAO9LC2sryPWRcEeUzCe5w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-5.2.0.tgz",
+			"integrity": "sha512-d1DexkQx87IFr1FLuV+0f5kAm1Hk1uOVijLOb+D1sDO2QMb7YjE02VHtZtxo7xIXMgcWLb+vl3HRT0rI9tr4jQ==",
 			"requires": {
 				"accepts": "~1.3.4",
 				"base64id": "2.0.0",
@@ -13141,9 +13115,9 @@
 			}
 		},
 		"engine.io-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
-			"integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.3.tgz",
+			"integrity": "sha512-xEAAY0msNnESNPc00e19y5heTPX4y/TJ36gr8t1voOaNmTojP9b3oK3BbJLFufW2XFPQaaijpFewm2g2Um3uqA==",
 			"requires": {
 				"base64-arraybuffer": "0.1.4"
 			}
@@ -13361,9 +13335,9 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-			"integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
+			"integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.0"
@@ -17232,25 +17206,25 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.1.3.tgz",
-			"integrity": "sha512-tLkaY13RcO4nIRh1K2hT5iuotfTaIQw7cVIe0FUykN3SuQi0cm7ALxuyT5/CtDswOMWUzMGTibxYNx/gU7In+Q==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.2.0.tgz",
+			"integrity": "sha512-sjlGfMmnaWvTRVxGRGWyhd9ctpg4APxWAxu85O/SxekkxHhfxmePWZbaYCkeX5QQX0z1YEnKOlNt6w82E4Nzug==",
 			"requires": {
-				"@types/cookie": "^0.4.0",
-				"@types/cors": "^2.8.10",
+				"@types/cookie": "^0.4.1",
+				"@types/cors": "^2.8.12",
 				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
-				"debug": "~4.3.1",
-				"engine.io": "~5.1.1",
-				"socket.io-adapter": "~2.3.1",
+				"debug": "~4.3.2",
+				"engine.io": "~5.2.0",
+				"socket.io-adapter": "~2.3.2",
 				"socket.io-parser": "~4.0.4"
 			}
 		},
 		"socket.io-adapter": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.1.tgz",
-			"integrity": "sha512-8cVkRxI8Nt2wadkY6u60Y4rpW3ejA1rxgcK2JuyIhmF+RMNpTy1QRtkHIDUOf3B4HlQwakMsWbKftMv/71VMmw=="
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.2.tgz",
+			"integrity": "sha512-PBZpxUPYjmoogY0aoaTmo1643JelsaS1CiAwNjRVdrI0X9Seuc19Y2Wife8k88avW6haG8cznvwbubAZwH4Mtg=="
 		},
 		"socket.io-parser": {
 			"version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
 	"devDependencies": {
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-jest": "^24.4.0",
-		"eslint-plugin-jsdoc": "^36.0.8",
+		"eslint-plugin-jsdoc": "^36.1.0",
 		"eslint-plugin-prettier": "^4.0.0",
 		"express-basic-auth": "^1.2.0",
 		"husky": "^7.0.2",
-		"jest": "^27.1.0",
+		"jest": "^27.1.1",
 		"jsdom": "^17.0.0",
 		"lodash": "^4.17.21",
 		"nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-jest": "^24.4.0",
 		"eslint-plugin-jsdoc": "^36.0.8",
-		"eslint-plugin-prettier": "^3.4.1",
+		"eslint-plugin-prettier": "^4.0.0",
 		"express-basic-auth": "^1.2.0",
 		"husky": "^7.0.2",
 		"jest": "^27.1.0",
@@ -66,7 +66,7 @@
 		"suncalc": "^1.8.0"
 	},
 	"optionalDependencies": {
-		"electron": "^13.2.3"
+		"electron": "^13.3.0"
 	},
 	"dependencies": {
 		"colors": "^1.4.0",
@@ -82,7 +82,7 @@
 		"moment": "^2.29.1",
 		"node-fetch": "^2.6.1",
 		"node-ical": "^0.13.0",
-		"socket.io": "^4.1.3"
+		"socket.io": "^4.2.0"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"moment": "^2.29.1",
 		"node-fetch": "^2.6.1",
 		"node-ical": "^0.13.0",
-		"simple-git": "^2.45.0",
 		"socket.io": "^4.1.3"
 	},
 	"_moduleAliases": {

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -1,0 +1,31 @@
+const path = require("path");
+const git_Helper = require("../../../modules/default/updatenotification/git_helper.js");
+const gitHelper = new git_Helper.gitHelper();
+gitHelper.add("default");
+let branch = "";
+
+describe("Updatenotification", function () {
+	// it is assumed that we are at the HEAD of a branch when running this tests
+	// and we have no foreign modules installed.
+
+	it("should return 0 for repo count", async function () {
+		const arr = await gitHelper.getRepos();
+		expect(arr.length).toBe(0);
+	}, 15000);
+
+	it("should return valid output for git status", async function () {
+		const arr = await gitHelper.getStatus();
+		expect(arr.length).toBe(1);
+		const gitInfo = arr[0];
+		branch = gitInfo.current;
+		expect(gitInfo.current).not.toBe("");
+		expect(gitInfo.tracking).not.toBe("");
+		expect(gitInfo.hash).not.toBe("");
+	}, 15000);
+
+	it("should return no refs for git fetch", async function () {
+		const baseDir = path.normalize(__dirname + "/../../../");
+		const res = await gitHelper.execShell("cd " + baseDir + " && git fetch --dry-run");
+		expect(res.stderr.match(gitHelper.getRefRegex(branch))).toBe(null);
+	});
+});

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -19,8 +19,6 @@ describe("Updatenotification", function () {
 		const gitInfo = arr[0];
 		branch = gitInfo.current;
 		expect(gitInfo.current).not.toBe("");
-		expect(gitInfo.tracking).not.toBe("");
-		expect(gitInfo.hash).not.toBe("");
 	}, 15000);
 
 	it("should return no refs for git fetch", async function () {


### PR DESCRIPTION
see #2644 

We have to handle several cases which I was not able to get running with the `simple-git` package. So now the git command line is used.

First run `git status -sb`.

If the repo was already fetched (hard, not with dry run) the output contains the `behind` number, so use this.

If not run `git fetch --dry-run` and extract the `from..to` hashes. With this run `git rev-list --ancestry-path --count from..to` to get the `behind` number.