### PR TITLE
Enhanced translator

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -483,7 +483,7 @@ const MM = (function () {
 
 			Log.setLogLevel(config.logLevel);
 
-			Translator.loadCoreTranslations(config.language);
+			Translator.init(config);
 			Loader.loadModules();
 		},
 

--- a/js/module.js
+++ b/js/module.js
@@ -306,32 +306,7 @@ const Module = Class.extend({
 	 * @param {Function} callback Function called when done.
 	 */
 	loadTranslations(callback) {
-		const translations = this.getTranslations() || {};
-		const language = config.language.toLowerCase();
-
-		const languages = Object.keys(translations);
-		const fallbackLanguage = languages[0];
-
-		if (languages.length === 0) {
-			callback();
-			return;
-		}
-
-		const translationFile = translations[language];
-		const translationsFallbackFile = translations[fallbackLanguage];
-
-		if (!translationFile) {
-			Translator.load(this, translationsFallbackFile, true, callback);
-			return;
-		}
-
-		Translator.load(this, translationFile, false, () => {
-			if (translationFile !== translationsFallbackFile) {
-				Translator.load(this, translationsFallbackFile, true, callback);
-			} else {
-				callback();
-			}
-		});
+		Translator.loadTranslations(this, callback);
 	},
 
 	/**

--- a/js/module.js
+++ b/js/module.js
@@ -304,24 +304,43 @@ const Module = Class.extend({
 	 * Load all translations.
 	 *
 	 * @param {Function} callback Function called when done.
+	 * @returns {Promise<boolean>} return promise.
 	 */
 	loadTranslations(callback) {
-		Translator.loadTranslations(this, callback);
+		return Translator.loadTranslations(this, callback);
 	},
 
 	/**
-	 * Request the translation for a given key with optional variables and default value.
+	 * Request the translation for a given key with optional variables and fallback.
 	 *
-	 * @param {string} key The key of the string to translate
-	 * @param {string|object} [defaultValueOrVariables] The default value or variables for translating.
-	 * @param {string} [defaultValue] The default value with variables.
-	 * @returns {string} the translated key
+	 * @param {string} key The key of the string to translate.
+	 * @param {...*} rest - list of arguments. all arguments are optional and distinguished by type.
+	 * @param {string|object} rest.fallbackOrVariables (optional) The fallback string or object contains variables for translating.
+	 * @param {string} rest.fallback (optional) fallback string.
+	 * @param {boolean} rest.asObject (optional) return result as object
+	 * @returns {string|object} the translated key
 	 */
-	translate: function (key, defaultValueOrVariables, defaultValue) {
-		if (typeof defaultValueOrVariables === "object") {
-			return Translator.translate(this, key, defaultValueOrVariables) || defaultValue || "";
+	translate: function (key, ...rest) {
+		const isBoolean = (val) => "boolean" === typeof val;
+		var fallbackOrVariables,
+			fallback,
+			asObject = false;
+		if (rest.length > 0) {
+			asObject = isBoolean(rest[rest.length - 1]) ? rest[rest.length - 1] : false;
+			if ("object" === typeof rest[0]) {
+				fallbackOrVariables = !isBoolean(rest[0]) ? rest[0] : null;
+				fallback = !isBoolean(rest[1]) ? (rest[1] ? rest[1] : "") : null;
+			} else {
+				fallback = !isBoolean(rest[0]) ? rest[0] : "";
+			}
 		}
-		return Translator.translate(this, key) || defaultValueOrVariables || "";
+		return Translator.translate({
+			moduleName: this.name,
+			key,
+			fallback,
+			asObject,
+			variables: fallbackOrVariables
+		});
 	},
 
 	/**

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"test:js": "eslint 'js/**/*.js' 'modules/default/**/*.js' 'clientonly/*.js' 'serveronly/*.js' 'translations/*.js' 'vendor/*.js' 'tests/**/*.js' 'config/*' --config .eslintrc.json",
 		"test:css": "stylelint 'css/main.css' 'fonts/*.css' 'modules/default/**/*.css' 'vendor/*.css' --config .stylelintrc.json",
 		"test:calendar": "node ./modules/default/calendar/debug.js",
+		"test:translator": "NODE_ENV=test jest tests/unit/classes/translator_spec.js -i --forceExit",
 		"config:check": "node js/check_config.js",
 		"lint:prettier": "prettier . --write",
 		"lint:js": "eslint 'js/**/*.js' 'modules/default/**/*.js' 'clientonly/*.js' 'serveronly/*.js' 'translations/*.js' 'vendor/*.js' 'tests/**/*.js' 'config/*' --config .eslintrc.json --fix",

--- a/tests/unit/classes/translator_spec.js
+++ b/tests/unit/classes/translator_spec.js
@@ -1,287 +1,479 @@
 const path = require("path");
-const helmet = require("helmet");
 const { JSDOM } = require("jsdom");
-const express = require("express");
-const sockets = new Set();
+
+const silence = {
+	log: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {}
+};
+
+const log = silence;
+// const log = console;
+
+const dictionaries = {
+	translations: {
+		"en.json": {
+			TEST: "test(en)",
+			HELLO: "Hello",
+			ONLY_EXIST_CORE_EN: "only exists in core (en)"
+		},
+		"de.json": {
+			TEST: "test(de)",
+			HELLO: "Hallo"
+		},
+		"ko.json": {
+			TEST: "test(ko)",
+			HELLO: "안녕"
+		}
+	},
+	"MMM-Module": {
+		"en.json": {
+			TEST: "test(module/en)",
+			HELLO: "Hello (module)"
+		},
+		"de.json": {
+			TEST: "test(module/de)",
+			HELLO: "Hallo (module)",
+			TEST_VARIABLES: "{number}, {obj.some.thing}, {arr.0}, {arr.1.value}",
+			TEST_PLURALRULES: "{number.0}{number.0@PLURAL_SELECT}, {number.1}{number.1@PLURAL_SELECT}, {number.2}{number.2@PLURAL_SELECT}",
+			TEST_NUMBERFORMAT: "{number@CURRENCY}",
+			TEST_LISTFORMAT: "{arr@LIST}",
+			TEST_DATETIMEFORMAT: "{date@DATE}",
+			TEST_RELATIVEFORMAT: "{target@RELATIVE_DAY}",
+			TEST_AUTOSCALEFORMAT: "{target@AUTOSCALE}",
+			TEST_SELECT: "{condition@GREETING}, {user}!",
+			TEST_CUSTOM: "Temp: {roomTemperature@TEMP_C2F}",
+
+			"@PLURAL_SELECT": {
+				locale: "en-US",
+				format: "PluralRules",
+				options: {
+					type: "ordinal"
+				},
+				rules: {
+					one: "st",
+					two: "nd",
+					few: "rd",
+					other: "th"
+				}
+			},
+			"@CURRENCY": {
+				format: "NumberFormat",
+				options: {
+					style: "currency",
+					currency: "EUR"
+				}
+			},
+			"@LIST": {
+				format: "ListFormat",
+				options: { style: "long", type: "disjunction" }
+			},
+			"@DATE": {
+				format: "DateTimeFormat",
+				options: {
+					dateStyle: "long",
+					timeStyle: "short"
+				}
+			},
+			"@RELATIVE_DAY": {
+				format: "RelativeTimeFormat",
+				unit: "day",
+				options: {
+					numeric: "auto",
+					style: "long"
+				}
+			},
+			"@AUTOSCALE": {
+				format: "AutoScaledRelativeTimeFormat",
+				locale: "en-US",
+				options: {
+					numeric: "auto",
+					style: "long"
+				}
+			},
+			"@GREETING": {
+				format: "Select",
+				locale: "en-US",
+				rules: {
+					morning: "Good morning",
+					afternoon: "Good afternoon",
+					evening: "Good evening",
+					other: "Hi"
+				}
+			},
+			"@TEMP_C2F": {
+				format: "Temperature",
+				options: { unit: "farenheit" }
+			}
+		}
+	}
+};
+
+const fetch = async (url) => {
+	var response = {};
+	let dict = path.parse(url).base;
+	var directory = path.parse(url).dir.split("/")[1];
+
+	if (dictionaries[directory][dict]) {
+		response.ok = true;
+		response.json = () => {
+			return dictionaries[directory][dict];
+		};
+	}
+	return response;
+};
+
+const MM_Module = {
+	name: "MMM-Module",
+	file: (filePath) => {
+		return "/MMM-Module" + "/" + filePath;
+	}
+};
 
 describe("Translator", function () {
-	let server;
-
-	beforeAll(function () {
-		const app = express();
-		app.use(helmet());
-		app.use(function (req, res, next) {
-			res.header("Access-Control-Allow-Origin", "*");
-			next();
+	describe("init", function () {
+		it("initialize without parameter", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				await Translator.init();
+				let locale = Translator.getLocale();
+				let language = Translator.getLanguages();
+				expect(locale).toBe("default");
+				expect(language.toString()).toBe(["en"].toString());
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hello");
+				done();
+			};
 		});
-		app.use("/translations", express.static(path.join(__dirname, "..", "..", "..", "tests", "configs", "data")));
 
-		server = app.listen(3000);
+		it("initialize with only config.language", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { language: "de" };
+				await Translator.init(config);
+				let locale = Translator.getLocale();
+				let language = Translator.getLanguages();
+				expect(locale).toBe("default");
+				expect(language.toString()).toBe(["de", "en"].toString());
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hallo");
+				done();
+			};
+		});
 
-		server.on("connection", (socket) => {
-			sockets.add(socket);
+		it("initialize with only config.languages (array)", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: ["de", "en-US"] };
+				await Translator.init(config);
+				let locale = Translator.getLocale();
+				let language = Translator.getLanguages();
+				expect(locale).toBe("default");
+				expect(language.join(",")).toBe(["de", "en-US", "en"].join(","));
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hallo");
+				done();
+			};
+		});
+
+		it("initialize with only config.languages (string)", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de, en-US" };
+				await Translator.init(config);
+				let locale = Translator.getLocale();
+				let language = Translator.getLanguages();
+				expect(locale).toBe("default");
+				expect(language.join(",")).toBe(["de", "en-US", "en"].join(","));
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hallo");
+				done();
+			};
+		});
+
+		it("initialize with config.languages and config.language together", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: ["en", "nl", "de"], language: "nl" };
+				await Translator.init(config);
+				let locale = Translator.getLocale();
+				let language = Translator.getLanguages();
+				expect(locale).toBe("default");
+				expect(language.join(",")).toBe(["nl", "en", "de"].join(","));
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hello");
+				done();
+			};
+		});
+
+		it("initialize with invalid locale format", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { locale: "en_US" };
+				await Translator.init(config);
+				let locale = Translator.getLocale();
+				expect(locale).toBe("default");
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hello");
+				done();
+			};
 		});
 	});
 
-	afterAll(function () {
-		for (const socket of sockets) {
-			socket.destroy();
+	describe("loadTranslations", function () {
+		it("load core translations and test fallback", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de, en-US" };
+				await Translator.init(config);
+				var text = Translator.translate("core", "HELLO");
+				expect(text).toBe("Hallo");
+				text = Translator.translate("core", "ONLY_EXIST_CORE_EN");
+				expect(text).toBe("only exists in core (en)");
+				done();
+			};
+		});
 
-			sockets.delete(socket);
-		}
-
-		server.close();
+		it("load module translations and test fallback", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				var text = Translator.translate(MM_Module, "HELLO");
+				expect(text).toBe("Hallo (module)");
+				text = Translator.translate(MM_Module, "ONLY_EXIST_CORE_EN");
+				expect(text).toBe("only exists in core (en)");
+				done();
+			};
+		});
 	});
 
 	describe("translate", function () {
-		const translations = {
-			"MMM-Module": {
-				Hello: "Hallo",
-				"Hello {username}": "Hallo {username}"
-			}
-		};
-
-		const coreTranslations = {
-			Hello: "XXX",
-			"Hello {username}": "XXX",
-			FOO: "Foo",
-			"BAR {something}": "Bar {something}"
-		};
-
-		const translationsFallback = {
-			"MMM-Module": {
-				Hello: "XXX",
-				"Hello {username}": "XXX",
-				FOO: "XXX",
-				"BAR {something}": "XXX",
-				"A key": "A translation"
-			}
-		};
-
-		const coreTranslationsFallback = {
-			FOO: "XXX",
-			"BAR {something}": "XXX",
-			Hello: "XXX",
-			"Hello {username}": "XXX",
-			"A key": "XXX",
-			Fallback: "core fallback"
-		};
-
-		/**
-		 * @param {object} Translator the global Translator object
-		 */
-		function setTranslations(Translator) {
-			Translator.translations = translations;
-			Translator.coreTranslations = coreTranslations;
-			Translator.translationsFallback = translationsFallback;
-			Translator.coreTranslationsFallback = coreTranslationsFallback;
-		}
-
-		it("should return custom module translation", function (done) {
+		it("should return 'null' when not found in dictionaries", function (done) {
 			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
 				const { Translator } = dom.window;
-				setTranslations(Translator);
-				let translation = Translator.translate({ name: "MMM-Module" }, "Hello");
-				expect(translation).toBe("Hallo");
-				translation = Translator.translate({ name: "MMM-Module" }, "Hello {username}", { username: "fewieden" });
-				expect(translation).toBe("Hallo fewieden");
+				var config = { languages: "de-DE, en-US" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				var text = Translator.translate(MM_Module, "WEIRD");
+				expect(text).toBe(null);
 				done();
 			};
 		});
 
-		it("should return core translation", function (done) {
+		it("test simple translation without variables.", function (done) {
 			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
 				const { Translator } = dom.window;
-				setTranslations(Translator);
-				let translation = Translator.translate({ name: "MMM-Module" }, "FOO");
-				expect(translation).toBe("Foo");
-				translation = Translator.translate({ name: "MMM-Module" }, "BAR {something}", { something: "Lorem Ipsum" });
-				expect(translation).toBe("Bar Lorem Ipsum");
+				var config = { languages: "de-DE, en-US" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				var text = Translator.translate(MM_Module, "TEST");
+				expect(text).toBe("test(module/de)");
 				done();
 			};
 		});
 
-		it("should return custom module translation fallback", function (done) {
+		it("test translation with variables (scalar variable, nested object property, array)", function (done) {
 			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
 				const { Translator } = dom.window;
-				setTranslations(Translator);
-				const translation = Translator.translate({ name: "MMM-Module" }, "A key");
-				expect(translation).toBe("A translation");
-				done();
-			};
-		});
-
-		it("should return core translation fallback", function (done) {
-			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				setTranslations(Translator);
-				const translation = Translator.translate({ name: "MMM-Module" }, "Fallback");
-				expect(translation).toBe("core fallback");
-				done();
-			};
-		});
-
-		it("should return translation with placeholder for missing variables", function (done) {
-			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				setTranslations(Translator);
-				const translation = Translator.translate({ name: "MMM-Module" }, "Hello {username}");
-				expect(translation).toBe("Hallo {username}");
-				done();
-			};
-		});
-
-		it("should return key if no translation was found", function (done) {
-			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				setTranslations(Translator);
-				const translation = Translator.translate({ name: "MMM-Module" }, "MISSING");
-				expect(translation).toBe("MISSING");
-				done();
-			};
-		});
-	});
-
-	describe("load", function () {
-		const mmm = {
-			name: "TranslationTest",
-			file(file) {
-				return `http://localhost:3000/translations/${file}`;
-			}
-		};
-
-		it("should load translations", function (done) {
-			const dom = new JSDOM(`<script>var Log = {log: function(){}};</script><script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				const file = "TranslationTest.json";
-
-				Translator.load(mmm, file, false, function () {
-					const json = require(path.join(__dirname, "..", "..", "..", "tests", "configs", "data", file));
-					expect(Translator.translations[mmm.name]).toEqual(json);
-					done();
-				});
-			};
-		});
-
-		it("should load translation fallbacks", function (done) {
-			const dom = new JSDOM(`<script>var Log = {log: function(){}};</script><script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				const file = "TranslationTest.json";
-
-				Translator.load(mmm, file, true, function () {
-					const json = require(path.join(__dirname, "..", "..", "..", "tests", "configs", "data", file));
-					expect(Translator.translationsFallback[mmm.name]).toEqual(json);
-					done();
-				});
-			};
-		});
-
-		it("should not load translations, if module fallback exists", function (done) {
-			const dom = new JSDOM(`<script>var Log = {log: function(){}};</script><script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
-			dom.window.onload = function () {
-				const { Translator, XMLHttpRequest } = dom.window;
-				const file = "TranslationTest.json";
-
-				XMLHttpRequest.prototype.send = function () {
-					throw "Shouldn't load files";
+				var config = { languages: "de-DE, en-US" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = {
+					number: 1234,
+					obj: {
+						some: {
+							thing: "something"
+						}
+					},
+					arr: ["index0", { value: "value of index1" }]
 				};
+				var text = Translator.translate(MM_Module, "TEST_VARIABLES", testData);
+				expect(text).toBe("1234, something, index0, value of index1");
+				done();
+			};
+		});
 
-				Translator.translationsFallback[mmm.name] = {
-					Hello: "Hallo"
+		it("test translation formatter(PluralRules) by force-locale in translation(en-US).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = {
+					number: [1, 2, 3]
 				};
+				var text = Translator.translate(MM_Module, "TEST_PLURALRULES", testData);
+				expect(text).toBe("1st, 2nd, 3rd");
+				done();
+			};
+		});
 
-				Translator.load(mmm, file, false, function () {
-					expect(Translator.translations[mmm.name]).toBe(undefined);
-					expect(Translator.translationsFallback[mmm.name]).toEqual({
-						Hello: "Hallo"
-					});
-					done();
+		it("test translation formatter(NumberFormat) by config locale(de-DE).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = { number: 1234567 };
+				var text = Translator.translate(MM_Module, "TEST_NUMBERFORMAT", testData);
+				expect(text).toBe("1.234.567,00 €");
+				done();
+			};
+		});
+
+		it("test translation formatter(ListFormat) by config locale(de-DE).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = { arr: ["Red", "Blue", "Gold", "Silver"] };
+				var text = Translator.translate(MM_Module, "TEST_LISTFORMAT", testData);
+				expect(text).toBe("Red, Blue, Gold oder Silver");
+				done();
+			};
+		});
+
+		it("test translation formatter(DateTimeFormat) by config locale(de-DE).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const date = "2021-08-15 12:34:56";
+				var text = Translator.translate(MM_Module, "TEST_DATETIMEFORMAT", { date });
+				expect(text).toBe("15. August 2021 um 12:34");
+				done();
+			};
+		});
+
+		it("test translation formatter(RelativeTimeFormat) by config locale(de-DE).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = {
+					target: -3
+				};
+				var text = Translator.translate(MM_Module, "TEST_RELATIVEFORMAT", testData);
+				expect(text).toBe("vor 3 Tagen");
+				done();
+			};
+		});
+
+		it("test translation formatter(AutoScaledRelativeTimeFormat) by force-locale(en-US).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = {
+					target: new Date(Date.now() + 60 * 60 * 24 * 10 * 1000)
+				};
+				var text = Translator.translate(MM_Module, "TEST_AUTOSCALEFORMAT", testData);
+				expect(text).toBe("next week");
+				done();
+			};
+		});
+
+		it("test translation formatter(Select) by force-locale(en-US).", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+				const testData = {
+					condition: "afternoon",
+					user: "Tom"
+				};
+				var text = Translator.translate(MM_Module, "TEST_SELECT", testData);
+				expect(text).toBe("Good afternoon, Tom!");
+				done();
+			};
+		});
+	});
+
+	describe("custom formatter", function () {
+		it("register custom formatter and test it.", function (done) {
+			const dom = new JSDOM(`<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`, { runScripts: "dangerously", resources: "usable" });
+			dom.window.onload = async function () {
+				dom.window.fetch = fetch;
+				dom.window.Log = log;
+				const { Translator } = dom.window;
+				var config = { languages: "de-DE, en-US", locale: "de-DE" };
+				await Translator.init(config);
+				await Translator.loadTranslations(MM_Module);
+
+				Translator.registerFormatter("Temperature", function ({ value, options } = {}) {
+					if (isNaN(value)) return value;
+					if (options.unit === "farenheit") return (value * 9) / 5 + 32 + "°F";
+					return value + "°C";
 				});
-			};
-		});
-	});
 
-	describe("loadCoreTranslations", function () {
-		it("should load core translations and fallback", function (done) {
-			const dom = new JSDOM(
-				`<script>var translations = {en: "http://localhost:3000/translations/en.json"}; var Log = {log: function(){}};</script>\
-					<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`,
-				{ runScripts: "dangerously", resources: "usable" }
-			);
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				Translator.loadCoreTranslations("en");
-
-				const en = require(path.join(__dirname, "..", "..", "..", "tests", "configs", "data", "en.json"));
-				setTimeout(function () {
-					expect(Translator.coreTranslations).toEqual(en);
-					expect(Translator.coreTranslationsFallback).toEqual(en);
-					done();
-				}, 500);
-			};
-		});
-
-		it("should load core fallback if language cannot be found", function (done) {
-			const dom = new JSDOM(
-				`<script>var translations = {en: "http://localhost:3000/translations/en.json"}; var Log = {log: function(){}};</script>\
-					<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`,
-				{ runScripts: "dangerously", resources: "usable" }
-			);
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				Translator.loadCoreTranslations("MISSINGLANG");
-
-				const en = require(path.join(__dirname, "..", "..", "..", "tests", "configs", "data", "en.json"));
-				setTimeout(function () {
-					expect(Translator.coreTranslations).toEqual({});
-					expect(Translator.coreTranslationsFallback).toEqual(en);
-					done();
-				}, 500);
-			};
-		});
-	});
-
-	describe("loadCoreTranslationsFallback", function () {
-		it("should load core translations fallback", function (done) {
-			const dom = new JSDOM(
-				`<script>var translations = {en: "http://localhost:3000/translations/en.json"}; var Log = {log: function(){}};</script>\
-					<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`,
-				{ runScripts: "dangerously", resources: "usable" }
-			);
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				Translator.loadCoreTranslationsFallback();
-
-				const en = require(path.join(__dirname, "..", "..", "..", "tests", "configs", "data", "en.json"));
-				setTimeout(function () {
-					expect(Translator.coreTranslationsFallback).toEqual(en);
-					done();
-				}, 500);
-			};
-		});
-
-		it("should load core fallback if language cannot be found", function (done) {
-			const dom = new JSDOM(
-				`<script>var translations = {}; var Log = {log: function(){}};</script>\
-					<script src="file://${path.join(__dirname, "..", "..", "..", "js", "translator.js")}">`,
-				{ runScripts: "dangerously", resources: "usable" }
-			);
-			dom.window.onload = function () {
-				const { Translator } = dom.window;
-				Translator.loadCoreTranslations();
-
-				setTimeout(function () {
-					expect(Translator.coreTranslationsFallback).toEqual({});
-					done();
-				}, 500);
+				const testData = {
+					roomTemperature: 22
+				};
+				var text = Translator.translate(MM_Module, "TEST_CUSTOM", testData);
+				expect(text).toBe("Temp: 71.6°F");
+				done();
 			};
 		});
 	});


### PR DESCRIPTION
# **MagicMirror² Enhanced Translator**

This project is rewriting the internal translator class of MagicMirror to have enhanced features.

- dev repository : https://github.com/MMRIZE/MagicMirror_EnhancedTranslator
- dev branch : https://github.com/MMRIZE/MagicMirror_EnhancedTranslator/tree/enhanced-translator (original based [2.16-develop](https://github.com/MichMich/MagicMirror/tree/develop) of [MicMich/MagicMirror](https://github.com/MichMich/MagicMirror))

## **Motivation**

For several years, the current `translator` class works for L10N/I18N of **MM** successfully. But there is still some lack of features. Especially in the below cases, we need more improvements.

- ### **Maintenance of translation files.**

  Whenever a new translation by the user is added or updated, `translations.js`(core) or `.getTranslations()`(module) should be updated and released officially to prevent the update-conflicts issue.

  By versioning up, some old translation might be obsoleted or needs to be updated for the changes of terms used in MM.

  And also, it is hard to add a light-modified custom dictionary like `de-au.json`. It would probably be copied from the original `de.json`, and even though the difference might be very little, but full `de-au.json` should be published and maintained.

- ### **Locale-aware**

  One `xx.json` cannot hold several locale-specific translations difference. US English and Australian English are noticeably different from each other from vocabulary to grammar. Some Australian users may prefer `"G’day mate"` instead of `"Hello"`. Some British people might not be comfortable with the spelling of `"Color"`.

  English users in Canada(**`en-CA`**) notate dates as `4 September 2021` or `September 4, 2021`, And French in Canada(**`fr-CA`**) notate date as `4 septembre 2021`. and the usual numeric format is `2021-09-04`. But in the US(**`en-US`**), people genrally use `09/04/2021`. And in France(**`fr-FR`**) it is `04/09/21`.

  German people prefer to write a number like `1.234.567,89`, but in the US, it will be `1,234,567.89`. In India, it will be `12,34,567.89`. In China, under 'hanidec' numbering format, it will be `一,二三四,五六七.八九`.

  Generally, MM module developers have tried to solve these issues by providing specific additional L10N converted values by `config` definition. Occasionally it makes another **too-many-config-value** issue.

  And for the date format, we are facing `momentJS` deprecation. (Well, `luxon` might be the excellent alternative, though.)

- ### **For multi-lingual user (too-simple-fallback)**

  Current fallback mechanism - **primary language or 'en'** is not enough. Some people use multi-languages in their country.

  Certain Serbian users can speak Serbian, Croatian, Romanian, Hungarian, Slovak, Czech, etc. Anyway English might not be his prefer language. With luck, some modules might provide `hu.json`. and some modules might provide `hr.json`. But he should select only one language for his Mirror. And whatever he chooses, other modules will display English. Of course, `en` must be the last-final-safe fallback. However, it will be convenient and user-friendly if MM provided more steps before the final solution.

  Also, there could be cases like this; sometimes `fr-CA` user needs `fr-CA` translation at first, then want to use familiar `fr`, then `en-CA` if available, at last reluctantly use standard `en` as final fallback.

- ### **flexibility for natural language process**

  `translator` is not a template engine. However, if it could handle `Object` and `Array` it would provide more abundant natural translation results. In some countries, the first name is preferred to Family name, and in some countries, vice versa. If `translator` can handle `user: {firstName, familyName, gender, title}` together instead of addressing each `userFirstName`, `userFamilyName`, `userGender`, `userTitle`, it could reduce the codes and make meaningful context.

  Customizable value-formatters would be a help for L10N/I18N also. A Module developer supports only general value and format, and then a translation provider could convert that value to another format with those formatter on dictionaries.

  For example; Instead of `"Unread mail: 3"`, more natural sentences `"There is a mail unread."`, `"There are 3 mails unread."` or `"Es gibt eine ungelesene Mail."`, `"Es sind 3 Mails ungelesen"` could be possible with some formatters and language/locale information by translation provider, not by module developer himself.

  Finally, translation could be used as a light template engine with those features. It will give more freedom to the user who wants to customize the MM.

Those are the main reason why this project begins.

## **Improvements**

- Multi-language fallback by prefer order and related-locales
- Translation dictionaries autoload
- Handling Object and Array as replacement variables
- custom value formatting


.... For more details; https://github.com/MMRIZE/MagicMirror_EnhancedTranslator/blob/master/README.md