### PR TITLE
Add fix for chaotic newsfeed display after network connection loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2022-01-01._
 
 - Fixed wrong file `kr.json` to `ko.json`. Use language code 'ko' instead of 'kr' for Korean language.
 - Fixed `feels_like` data from openweathermaps current weather being ignored (#2678).
+- Fixed chaotic newsfeed display after network connection loss (#2638).
 
 ## [2.17.1] - 2021-10-01
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -295,6 +295,9 @@ Module.register("newsfeed", {
 			this.sendNotification("NEWS_FEED", { items: this.newsItems });
 		}
 
+		// #2638 Clear timer if it already exists
+		if (this.timer) clearInterval(this.timer);
+
 		this.timer = setInterval(() => {
 			this.activeItem++;
 			this.updateDom(this.config.animationSpeed);


### PR DESCRIPTION
The refresh timer wasnt reset before opening a new one on the browser part of the module. This happened after the network connection was lost and reestablished. So we make sure the timer is cleared before opening a new one

Fixes #2638