### PR TITLE
removed duplicate "weather" entry in config.sample.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Fixed wrong file `kr.json` to `ko.json`. Use language code 'ko' instead of 'kr' for Korean language.
 - Fixed `feels_like` data from openweathermaps current weather being ignored (#2678).
 - Fixed chaotic newsfeed display after network connection loss thanks to @jalibu (#2638).
+- Removed duplicate "weather" entry in `config.sample.js`
 
 ## [2.17.1] - 2021-10-01
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -78,18 +78,6 @@ let config = {
 			}
 		},
 		{
-			module: "weather",
-			position: "top_right",
-			header: "Weather Forecast",
-			config: {
-				weatherProvider: "openweathermap",
-				type: "forecast",
-				location: "New York",
-				locationID: "5128581", //ID from http://bulk.openweathermap.org/sample/city.list.json.gz; unzip the gz file and find your city
-				apiKey: "YOUR_OPENWEATHER_API_KEY"
-			}
-		},
-		{
 			module: "newsfeed",
 			position: "bottom_bar",
 			config: {


### PR DESCRIPTION
Removed the duplicate "weather" entry in config.sample.js. According to the documentation for the new "weather" module, there should only be one entry. 

This pull request was primarily created to solve a issue on the MagicMirror Package Manager repo.

https://docs.magicmirror.builders/modules/weather.html#usage