### PR TITLE
Relative full day events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - Fixed error when accessing letsencrypt certificates
+- Fixed Calendar module enhancement: displaying full events without time (#2424)
 
 ## [2.17.0] - 2021-10-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -370,7 +370,7 @@ Module.register("calendar", {
 					// Show relative times
 					if (event.startDate >= now) {
 						// Use relative  time
-						if (!this.config.hideTime) {
+						if ((!this.config.hideTime) && (!event.fullDayEvent)) {
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar(null, { sameElse: this.config.dateFormat }));
 						} else {
 							timeWrapper.innerHTML = this.capFirst(
@@ -378,13 +378,24 @@ Module.register("calendar", {
 									sameDay: "[" + this.translate("TODAY") + "]",
 									nextDay: "[" + this.translate("TOMORROW") + "]",
 									nextWeek: "dddd",
-									sameElse: this.config.dateFormat
+									sameElse: (event.fullDayEvent ? this.config.fullDayEventDateFormat : this.config.dateFormat)
 								})
 							);
 						}
 						if (event.startDate - now < this.config.getRelative * oneHour) {
 							// If event is within getRelative  hours, display 'in xxx' time format or moment.fromNow()
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
+						} else if (event.fullDayEvent) {
+							// Full days events within the next two days
+							if (event.today) {
+								timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
+							} else if (event.startDate - now < oneDay && event.startDate - now > 0) {
+								timeWrapper.innerHTML = this.capFirst(this.translate("TOMORROW"));
+							} else if (event.startDate - now < 2 * oneDay && event.startDate - now > 0) {
+								if (this.translate("DAYAFTERTOMORROW") !== "DAYAFTERTOMORROW") {
+									timeWrapper.innerHTML = this.capFirst(this.translate("DAYAFTERTOMORROW"));
+								}
+							}
 						}
 					} else {
 						// Ongoing event

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -368,7 +368,7 @@ Module.register("calendar", {
 					}
 				} else {
 					// Show relative times
-					if (event.startDate >= now) {
+					if ((event.startDate >= now) || (event.fullDayEvent && event.today)) {
 						// Use relative  time
 						if ((!this.config.hideTime) && (!event.fullDayEvent)) {
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar(null, { sameElse: this.config.dateFormat }));
@@ -382,10 +382,7 @@ Module.register("calendar", {
 								})
 							);
 						}
-						if (event.startDate - now < this.config.getRelative * oneHour) {
-							// If event is within getRelative  hours, display 'in xxx' time format or moment.fromNow()
-							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
-						} else if (event.fullDayEvent) {
+						if (event.fullDayEvent) {
 							// Full days events within the next two days
 							if (event.today) {
 								timeWrapper.innerHTML = this.capFirst(this.translate("TODAY"));
@@ -396,8 +393,10 @@ Module.register("calendar", {
 									timeWrapper.innerHTML = this.capFirst(this.translate("DAYAFTERTOMORROW"));
 								}
 							}
-						}
-					} else {
+						} else if (event.startDate - now < this.config.getRelative * oneHour) {
+							// If event is within getRelative  hours, display 'in xxx' time format or moment.fromNow()
+							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").fromNow());
+						}					} else {
 						// Ongoing event
 						timeWrapper.innerHTML = this.capFirst(
 							this.translate("RUNNING", {


### PR DESCRIPTION
Fixes #2424
- Don't display start time of full date events when using relative dates.
- Use the fullDateEventDateFormat when showing full day events more than a week out
