### PR TITLE
Revert node ical update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Fixed chaotic newsfeed display after network connection loss thanks to @jalibu (#2638).
 - Fixed incorrect time zone correction of recurring full day events (#2632 and #2634).
 - Fixed e2e tests by increasing testTimeout.
+- Revert node-ical update due to missing luxon package.
 
 ## [2.17.1] - 2021-10-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"module-alias": "^2.2.2",
 				"moment": "^2.29.1",
 				"node-fetch": "^2.6.6",
-				"node-ical": "^0.14.1",
+				"node-ical": "^0.13.0",
 				"socket.io": "^4.4.0"
 			},
 			"devDependencies": {
@@ -1666,14 +1666,6 @@
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
-		},
-		"node_modules/axios": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-			"integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-			"dependencies": {
-				"follow-redirects": "^1.14.4"
-			}
 		},
 		"node_modules/babel-jest": {
 			"version": "27.3.1",
@@ -3566,25 +3558,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
 			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.14.5",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-			"integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/foreground-child": {
 			"version": "2.0.0",
@@ -6047,13 +6020,13 @@
 			}
 		},
 		"node_modules/node-ical": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.14.1.tgz",
-			"integrity": "sha512-EUlbAWK0iaKFqimtGCyKOnldtvBNyzLqk9NCTAO6TiVby8vsEcAOlIrkUjZKM0Wrvh3YBCbeWbW+xA2cw5BdDw==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.13.0.tgz",
+			"integrity": "sha512-hfV7HsY0oTehirXLtkKgAdVomSv6/zjSw66z/RTkKfEp9MwwIz1asyE/g9x4ZKWE2YqGnr81Se5zSRcligPY5Q==",
 			"dependencies": {
-				"axios": "^0.24.0",
 				"moment-timezone": "^0.5.31",
-				"rrule": "2.6.4",
+				"node-fetch": "^2.6.1",
+				"rrule": "2.6.8",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -7374,9 +7347,9 @@
 			}
 		},
 		"node_modules/rrule": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
-			"integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.8.tgz",
+			"integrity": "sha512-cUaXuUPrz9d1wdyzHsBfT1hptKlGgABeCINFXFvulEPqh9Np9BnF3C3lrv9uO54IIr8VDb58tsSF3LhsW+4VRw==",
 			"dependencies": {
 				"tslib": "^1.10.0"
 			},
@@ -9969,14 +9942,6 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
-		"axios": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-			"integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-			"requires": {
-				"follow-redirects": "^1.14.4"
-			}
-		},
 		"babel-jest": {
 			"version": "27.3.1",
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.3.1.tgz",
@@ -11431,11 +11396,6 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
 			"integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw=="
-		},
-		"follow-redirects": {
-			"version": "1.14.5",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
-			"integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
 		},
 		"foreground-child": {
 			"version": "2.0.0",
@@ -13320,13 +13280,13 @@
 			}
 		},
 		"node-ical": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.14.1.tgz",
-			"integrity": "sha512-EUlbAWK0iaKFqimtGCyKOnldtvBNyzLqk9NCTAO6TiVby8vsEcAOlIrkUjZKM0Wrvh3YBCbeWbW+xA2cw5BdDw==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.13.0.tgz",
+			"integrity": "sha512-hfV7HsY0oTehirXLtkKgAdVomSv6/zjSw66z/RTkKfEp9MwwIz1asyE/g9x4ZKWE2YqGnr81Se5zSRcligPY5Q==",
 			"requires": {
-				"axios": "^0.24.0",
 				"moment-timezone": "^0.5.31",
-				"rrule": "2.6.4",
+				"node-fetch": "^2.6.1",
+				"rrule": "2.6.8",
 				"uuid": "^8.3.1"
 			}
 		},
@@ -14310,9 +14270,9 @@
 			}
 		},
 		"rrule": {
-			"version": "2.6.4",
-			"resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.4.tgz",
-			"integrity": "sha512-sLdnh4lmjUqq8liFiOUXD5kWp/FcnbDLPwq5YAc/RrN6120XOPb86Ae5zxF7ttBVq8O3LxjjORMEit1baluahA==",
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/rrule/-/rrule-2.6.8.tgz",
+			"integrity": "sha512-cUaXuUPrz9d1wdyzHsBfT1hptKlGgABeCINFXFvulEPqh9Np9BnF3C3lrv9uO54IIr8VDb58tsSF3LhsW+4VRw==",
 			"requires": {
 				"luxon": "^1.21.3",
 				"tslib": "^1.10.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"module-alias": "^2.2.2",
 		"moment": "^2.29.1",
 		"node-fetch": "^2.6.6",
-		"node-ical": "^0.14.1",
+		"node-ical": "^0.13.0",
 		"socket.io": "^4.4.0"
 	},
 	"_moduleAliases": {


### PR DESCRIPTION
With my last dependency update node-ical was updated from 0.13.0 to 0.14.1.

Starting mm with the calendar module results now in `module luxon not found` when using `npm install --no-optional`.

So reverting this, must be solved on the node-ical side.