### PR TITLE
Show info message if newsfeed is empty 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Updated github actions.
 - Replace spectron with playwright, update dependencies including electron update to v16.
 - Added lithuanian language to translations.js
+- Show info message if newsfeed is empty (fixes #2731)
 
 ### Fixed
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -121,7 +121,7 @@ Module.register("newsfeed", {
 		}
 		if (this.newsItems.length === 0) {
 			return {
-				loaded: false
+				empty: true
 			};
 		}
 		if (this.activeItem >= this.newsItems.length) {
@@ -184,6 +184,7 @@ Module.register("newsfeed", {
 			const dateB = new Date(b.pubdate);
 			return dateB - dateA;
 		});
+
 		if (this.config.maxNewsItems > 0) {
 			newsItems = newsItems.slice(0, this.config.maxNewsItems);
 		}
@@ -219,7 +220,6 @@ Module.register("newsfeed", {
 			}
 
 			//Remove selected tags from the end of rss feed items (title or description)
-
 			if (this.config.removeEndTags) {
 				for (let endTag of this.config.endTags) {
 					if (item.title.slice(-endTag.length) === endTag) {

--- a/modules/default/newsfeed/newsfeed.njk
+++ b/modules/default/newsfeed/newsfeed.njk
@@ -54,6 +54,10 @@
             {% endif %}
         </div>
     {% endif %}
+{% elseif empty %}
+    <div class="small dimmed">
+        {{ "NEWSFEED_NO_ITEMS" | translate | safe }}
+    </div>
 {% elseif error %}
     <div class="small dimmed">
         {{ "MODULE_CONFIG_ERROR" | translate({MODULE_NAME: "Newsfeed", ERROR: error}) | safe }}

--- a/tests/configs/modules/newsfeed/ignore_items.js
+++ b/tests/configs/modules/newsfeed/ignore_items.js
@@ -1,0 +1,28 @@
+/* Magic Mirror Test config newsfeed module
+ *
+ * MIT Licensed.
+ */
+let config = {
+	timeFormat: 12,
+
+	modules: [
+		{
+			module: "newsfeed",
+			position: "bottom_bar",
+			config: {
+				feeds: [
+					{
+						title: "Rodrigo Ramirez Blog",
+						url: "http://localhost:8080/tests/configs/data/feed_test_rodrigoramirez.xml"
+					}
+				],
+				ignoreOldItems: true
+			}
+		}
+	]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+	module.exports = config;
+}

--- a/tests/e2e/modules/newsfeed_spec.js
+++ b/tests/e2e/modules/newsfeed_spec.js
@@ -60,4 +60,17 @@ describe("Newsfeed module", function () {
 			expect(elem.textContent).toContain("Error in the Newsfeed module. Malformed url.");
 		});
 	});
+
+	describe("Ignore items", function () {
+		beforeAll(function (done) {
+			helpers.startApplication("tests/configs/modules/newsfeed/ignore_items.js");
+			helpers.getDocument(done, 3000);
+		});
+
+		it("should show empty items info message", function () {
+			const elem = document.querySelector(".newsfeed .small");
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain("No news at the moment.");
+		});
+	});
 });

--- a/translations/de.json
+++ b/translations/de.json
@@ -31,6 +31,8 @@
 	"MODULE_CONFIG_CHANGED": "Die Konfigurationsoptionen für das {MODULE_NAME} Modul haben sich geändert. \nBitte überprüfen Sie die Dokumentation.",
 	"MODULE_CONFIG_ERROR": "Fehler im {MODULE_NAME} Modul. {ERROR}",
 
+	"NEWSFEED_NO_ITEMS": "Keine Neuigkeiten momentan.",
+
 	"UPDATE_NOTIFICATION": "Aktualisierung für MagicMirror² verfügbar.",
 	"UPDATE_NOTIFICATION_MODULE": "Aktualisierung für das {MODULE_NAME} Modul verfügbar.",
 	"UPDATE_INFO_SINGLE": "Die aktuelle Installation ist {COMMIT_COUNT} Commit hinter dem {BRANCH_NAME} Branch.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -35,6 +35,8 @@
 	"MODULE_ERROR_UNAUTHORIZED": "Authorization failed.",
 	"MODULE_ERROR_UNSPECIFIED": "Check logs for more details.",
 
+	"NEWSFEED_NO_ITEMS": "No news at the moment.",
+
 	"UPDATE_NOTIFICATION": "MagicMirror² update available.",
 	"UPDATE_NOTIFICATION_MODULE": "Update available for {MODULE_NAME} module.",
 	"UPDATE_INFO_SINGLE": "The current installation is {COMMIT_COUNT} commit behind on the {BRANCH_NAME} branch.",


### PR DESCRIPTION
Fixes #2731 

If ignoreOldItems is set, it can happen that no items are to be displayed. Currently the module stays in the "loading" screen which isnt very helpful. So why not show a little info?