### PR TITLE
Allow dangerouslyDisablingAutoEscaping in newsfeed items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Replace spectron with playwright, update dependencies including electron update to v16.
 - Added lithuanian language to translations.js
 - Show info message if newsfeed is empty (fixes #2731)
+- Added dangerouslyDisableAutoEscaping config option for newsfeed templates (fixes #2712)
 
 ### Fixed
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -37,7 +37,8 @@ Module.register("newsfeed", {
 		endTags: [],
 		prohibitedWords: [],
 		scrollLength: 500,
-		logFeedWarnings: false
+		logFeedWarnings: false,
+		dangerouslyDisableAutoEscaping: false
 	},
 
 	// Define required scripts.

--- a/modules/default/newsfeed/newsfeed.njk
+++ b/modules/default/newsfeed/newsfeed.njk
@@ -33,7 +33,7 @@
             {% if (config.showSourceTitle and sourceTitle) or config.showPublishDate %}
                 <div class="newsfeed-source light small dimmed">
                     {% if sourceTitle and config.showSourceTitle %}
-                        {{ sourceTitle }}{% if config.showPublishDate %}, {% else %}: {% endif %}
+                        {{ sourceTitle | safe }}{% if config.showPublishDate %}, {% else %}: {% endif %}
                     {% endif %}
                     {% if config.showPublishDate %}
                         {{ publishDate }}:
@@ -46,9 +46,9 @@
             {% if config.showDescription %}
                 <div class="newsfeed-desc small light{{ ' no-wrap' if not config.wrapDescription }}">
                     {% if config.truncDescription %}
-                        {{ description | truncate(config.lengthDescription) }}
+                        {{ description | truncate(config.lengthDescription) | safe }}
                     {% else %}
-                        {{ description }}
+                        {{ description | safe }}
                     {% endif %}
                 </div>
             {% endif %}

--- a/modules/default/newsfeed/newsfeed.njk
+++ b/modules/default/newsfeed/newsfeed.njk
@@ -1,3 +1,11 @@
+{% macro escapeText(text, dangerouslyDisableAutoEscaping=false) %}
+  {% if dangerouslyDisableAutoEscaping %}
+    {{ text | safe}}
+  {% else %}
+    {{ text }}
+  {% endif %}
+{% endmacro %}
+
 {% if loaded %}
     {% if config.showAsList %}
         <ul class="newsfeed-list">
@@ -14,14 +22,14 @@
                         </div>
                     {% endif %}
                     <div class="newsfeed-title bright medium light{{ ' no-wrap' if not config.wrapTitle }}">
-                        {{ item.title }}
+                        {{ escapeText(item.title, config.dangerouslyDisableAutoEscaping) }}
                     </div>
                     {% if config.showDescription %}
                         <div class="newsfeed-desc small light{{ ' no-wrap' if not config.wrapDescription }}">
                             {% if config.truncDescription %}
-                                {{ item.description | truncate(config.lengthDescription) }}
+                                {{ escapeText(item.description | truncate(config.lengthDescription), config.dangerouslyDisableAutoEscaping) }}
                             {% else %}
-                                {{ item.description }}
+                                {{ escapeText(item.description, config.dangerouslyDisableAutoEscaping) }}
                             {% endif %}
                         </div>
                     {% endif %}
@@ -33,7 +41,7 @@
             {% if (config.showSourceTitle and sourceTitle) or config.showPublishDate %}
                 <div class="newsfeed-source light small dimmed">
                     {% if sourceTitle and config.showSourceTitle %}
-                        {{ sourceTitle | safe }}{% if config.showPublishDate %}, {% else %}: {% endif %}
+                        {{ escapeText(sourceTitle, config.dangerouslyDisableAutoEscaping) }}{% if config.showPublishDate %}, {% else %}: {% endif %}
                     {% endif %}
                     {% if config.showPublishDate %}
                         {{ publishDate }}:
@@ -41,14 +49,14 @@
                 </div>
             {% endif %}
             <div class="newsfeed-title bright medium light{{ ' no-wrap' if not config.wrapTitle }}">
-                {{ title }}
+                {{ escapeText(title, config.dangerouslyDisableAutoEscaping) }}
             </div>
             {% if config.showDescription %}
                 <div class="newsfeed-desc small light{{ ' no-wrap' if not config.wrapDescription }}">
                     {% if config.truncDescription %}
-                        {{ description | truncate(config.lengthDescription) | safe }}
+                        {{ escapeText(description | truncate(config.lengthDescription), config.dangerouslyDisableAutoEscaping) }}
                     {% else %}
-                        {{ description | safe }}
+                        {{ escapeText(description, config.dangerouslyDisableAutoEscaping) }}
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
Sometimes the newfeed might encode html tags and such (german umlauts for eaxmple) which the nunjuck templating would escape again so that the text looks like garbage.

This is helpful in preventing malicious code to be send to the mirror but the user might now disable this behaviour with the new config option "dangerouslyDisableAutoEscaping"

Fixes #2712 