### PR TITLE
added test for calendar recurring event with checks the correct date displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2022-01-01._
 
 ### Added
 
+- Added test for calendar recurring event with checks the correct date displayed (related to #2752).
+
 ### Updated
 
 - ESLint version supports now ECMAScript 2018

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -68,13 +68,26 @@ describe("Calendar module", function () {
 		it("should show the recurring birthday event 6 times", () => {
 			testElementLength(".calendar .event", 6);
 		});
-
-		it('should contain text "Mar 25th"', () => {
-			const elem = document.querySelector(".calendar");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Mar 25th");
-		});
 	});
+
+	process.setMaxListeners(0);
+	for (let i = -12; i < 12; i++) {
+		describe("Recurring event per timezone", function () {
+			beforeAll(function (done) {
+				Date.prototype.getTimezoneOffset = function () {
+					return i * 60;
+				};
+				helpers.startApplication("tests/configs/modules/calendar/recurring.js");
+				helpers.getDocument(done, 3000);
+			});
+
+			it('should contain text "Mar 25th" in timezone UTC ' + -i, () => {
+				const elem = document.querySelector(".calendar");
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Mar 25th");
+			});
+		});
+	}
 
 	describe("Changed port", function () {
 		beforeAll(function (done) {

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -68,6 +68,12 @@ describe("Calendar module", function () {
 		it("should show the recurring birthday event 6 times", () => {
 			testElementLength(".calendar .event", 6);
 		});
+
+		it('should contain text "Mar 25th"', () => {
+			const elem = document.querySelector(".calendar");
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain("Mar 25th");
+		});
 	});
 
 	describe("Changed port", function () {


### PR DESCRIPTION
related to #2752

This additional test checks if the event date is correctly displayed.

The new test will fail at the moment because the current `develop` branch is broken with https://github.com/MichMich/MagicMirror/pull/2748.

So may merging should be delayed until #2752 is fixed with a new PR.