### PR TITLE
Broadcast custom symbols in CALENDAR_EVENTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Fixed electron tests with retry.
 - Fixed Calendar recurring cross timezone error (add/subtract a day, not just offset hours) (#2632)
 - Fixed Calendar showEnd and Full Date overlay (#2629)
+- Broadcast custom symbols in CALENDAR_EVENTS
 
 ## [2.17.1] - 2021-10-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -237,18 +237,6 @@ Module.register("calendar", {
 				symbolWrapper.className = "symbol align-right " + symbolClass;
 
 				const symbols = this.symbolsForEvent(event);
-				// If symbols are displayed and custom symbol is set, replace event symbol
-				if (this.config.displaySymbol && this.config.customEvents.length > 0) {
-					for (let ev in this.config.customEvents) {
-						if (typeof this.config.customEvents[ev].symbol !== "undefined" && this.config.customEvents[ev].symbol !== "") {
-							let needle = new RegExp(this.config.customEvents[ev].keyword, "gi");
-							if (needle.test(event.title)) {
-								symbols[0] = this.config.customEvents[ev].symbol;
-								break;
-							}
-						}
-					}
-				}
 				symbols.forEach((s, index) => {
 					const symbol = document.createElement("span");
 					symbol.className = "fa fa-fw fa-" + s;
@@ -638,6 +626,17 @@ Module.register("calendar", {
 
 		if (event.fullDayEvent === true && this.hasCalendarProperty(event.url, "fullDaySymbol")) {
 			symbols = this.mergeUnique(this.getCalendarPropertyAsArray(event.url, "fullDaySymbol", this.config.defaultSymbol), symbols);
+		}
+
+		// If custom symbol is set, replace event symbol
+		for (let ev of this.config.customEvents) {
+			if (typeof ev.symbol !== "undefined" && ev.symbol !== "") {
+				let needle = new RegExp(ev.keyword, "gi");
+				if (needle.test(event.title)) {
+					symbols[0] = ev.symbol;
+					break;
+				}
+			}
 		}
 
 		return symbols;


### PR DESCRIPTION
I added support for displaying event symbols to MMM-MonthlyCalendar, and received a bug report that custom symbols aren't being displayed.  Move the custom event logic into symbolsForEvent so that they are properly set in the CALENDAR_EVENTS message.