### PR TITLE
fix date correction comparison for fulldate, just less than, not less than or equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _This release is scheduled to be released on 2022-01-01._
 - Fixed electron tests with retry.
 - Fixed Calendar recurring cross timezone error (add/subtract a day, not just offset hours) (#2632)
 - Fixed Calendar showEnd and Full Date overlay (#2629)
+- Fixed regression on #2632, #2752
 
 ## [2.17.1] - 2021-10-01
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -332,15 +332,15 @@ const CalendarUtils = {
 							Log.debug("Fullday");
 							// If the offset is negative (east of GMT), where the problem is
 							if (dateoffset < 0) {
-								//if (dh <= Math.abs(dateoffset / 60)) {
-								// reduce the time by the offset
-								// Apply the correction to the date/time to get it UTC relative
-								date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
-								// the duration was calculated way back at the top before we could correct the start time..
-								// fix it for this event entry
-								//duration = 24 * 60 * 60 * 1000;
-								Log.debug("new recurring date1 is " + date);
-								//}
+								if (dh < Math.abs(dateoffset / 60)) {
+									// reduce the time by the offset
+									// Apply the correction to the date/time to get it UTC relative
+									date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
+									// the duration was calculated way back at the top before we could correct the start time..
+									// fix it for this event entry
+									//duration = 24 * 60 * 60 * 1000;
+									Log.debug("new recurring date1 fulldate is " + date);
+								}
 							} else {
 								// if the timezones are the same, correct date if needed
 								//if (event.start.tz === moment.tz.guess()) {
@@ -351,7 +351,7 @@ const CalendarUtils = {
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry
 									//duration = 24 * 60 * 60 * 1000;
-									Log.debug("new recurring date2 is " + date);
+									Log.debug("new recurring date2 fulldate is " + date);
 								}
 								//}
 							}


### PR DESCRIPTION

> - Does the pull request solve a **related** issue?
fixes: #2752 

