### PR TITLE
Add absolute dates to weather forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2022-04-01._
 
 ### Added
 
+- Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
+
 ### Updated
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror²
+❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror².
 
-## [2.18.0] - Unreleased (Develop Branch)
+## [2.18.0] - 2022-01-01
 
-_This release is scheduled to be released on 2022-01-01._
+Special thanks to the following contributors: @AmpioRosso, @eouia, @fewieden, @jupadin, @khassel, @kolbyjack, @KristjanESPERANTO, @MariusVaice, @rejas, @rico24 and @sdetweil.
 
 ### Added
 
@@ -15,18 +15,18 @@ _This release is scheduled to be released on 2022-01-01._
 
 ### Updated
 
-- ESLint version supports now ECMAScript 2018
+- ESLint version supports now ECMAScript 2018.
 - Cleaned up `updatenotification` module and switched to nunjuck template.
 - Moved calendar tests from category `electron` to `e2e`.
-- Update missed translations for Korean language (ko.json)
-- Update missed translations for Dutch language (nl.json)
+- Update missed translations for Korean language (ko.json).
+- Update missed translations for Dutch language (nl.json).
 - Cleaned up `alert` module and switched to nunjuck template.
 - Moved weather tests from category `electron` to `e2e`.
 - Updated github actions.
 - Replace spectron with playwright, update dependencies including electron update to v16.
-- Added lithuanian language to translations.js
-- Show info message if newsfeed is empty (fixes #2731)
-- Added dangerouslyDisableAutoEscaping config option for newsfeed templates (fixes #2712)
+- Added lithuanian language to translations.js.
+- Show info message if newsfeed is empty (fixes #2731).
+- Added dangerouslyDisableAutoEscaping config option for newsfeed templates (fixes #2712).
 - Added missing shebang to `installers/mm.sh`.
 - Node versions in templates and github workflows.
 
@@ -41,10 +41,10 @@ _This release is scheduled to be released on 2022-01-01._
 - Fixed User-Agent-Header for newsfeed and calendar module (#2729).
 - Replace broken shields in Readme and use https for links.
 - Fixed electron tests with retry.
-- Fixed Calendar recurring cross timezone error (add/subtract a day, not just offset hours) (#2632)
-- Fixed Calendar showEnd and Full Date overlay (#2629)
-- Fixed regression on #2632, #2752
-- Broadcast custom symbols in CALENDAR_EVENTS
+- Fixed Calendar recurring cross timezone error (add/subtract a day, not just offset hours) (#2632).
+- Fixed Calendar showEnd and Full Date overlay (#2629).
+- Fixed regression on #2632, #2752.
+- Broadcast custom symbols in CALENDAR_EVENTS.
 
 ## [2.17.1] - 2021-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror².
 
+## [2.19.0] - Unreleased (Develop Branch)
+
+_This release is scheduled to be released on 2022-04-01._
+
+### Added
+
+### Updated
+
+### Fixed
+
 ## [2.18.0] - 2022-01-01
 
 Special thanks to the following contributors: @AmpioRosso, @eouia, @fewieden, @jupadin, @khassel, @kolbyjack, @KristjanESPERANTO, @MariusVaice, @rejas, @rico24 and @sdetweil.

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -8,9 +8,9 @@
         {% set forecast = forecast.slice(0, numSteps) %}
         {% for f in forecast %}
             <tr {% if config.colored %}class="colored"{% endif %} {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
-                {% if (currentStep == 0) and config.ignoreToday == false %}
+                {% if (currentStep == 0) and config.ignoreToday == false and config.absoluteDates == false %}
                     <td class="day">{{ "TODAY" | translate }}</td>
-                {% elif (currentStep == 1) and config.ignoreToday == false %}
+                {% elif (currentStep == 1) and config.ignoreToday == false and config.absoluteDates == false %}
                     <td class="day">{{ "TOMORROW" | translate }}</td>
                 {% else %}
                     <td class="day">{{ f.date.format('ddd') }}</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "magicmirror",
-	"version": "2.18.0",
+	"version": "2.19.0-develop",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magicmirror",
-			"version": "2.18.0",
+			"version": "2.19.0-develop",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "magicmirror",
-	"version": "2.18.0-develop",
+	"version": "2.18.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "magicmirror",
-			"version": "2.18.0-develop",
+			"version": "2.18.0",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "magicmirror",
-	"version": "2.18.0",
+	"version": "2.19.0-develop",
 	"description": "The open source modular smart mirror platform.",
 	"main": "js/electron.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "magicmirror",
-	"version": "2.18.0-develop",
+	"version": "2.18.0",
 	"description": "The open source modular smart mirror platform.",
 	"main": "js/electron.js",
 	"scripts": {


### PR DESCRIPTION
- Does the pull request solve a **related** issue?
No

-  If so, can you reference the issue like this `Fixes #<issue_number>`? 
N/A

- What does the pull request accomplish? Use a list if needed.
Add a Boolean configuration option `absoluteDates` to `modules/default/weather` to allow weather forecast dates to be formatted as absolute (MON, TUE) or relative (TODAY, TOMORROW).

- If it includes major visual changes please add screenshots.
N/A
