### PR TITLE
Add absolute dates to weather forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2022-04-01._
 
 ### Added
 
+- Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
+
 ### Updated
 
 ### Fixed

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -8,9 +8,9 @@
         {% set forecast = forecast.slice(0, numSteps) %}
         {% for f in forecast %}
             <tr {% if config.colored %}class="colored"{% endif %} {% if config.fade %}style="opacity: {{ currentStep | opacity(numSteps) }};"{% endif %}>
-                {% if (currentStep == 0) and config.ignoreToday == false %}
+                {% if (currentStep == 0) and config.ignoreToday == false and config.absoluteDates == false %}
                     <td class="day">{{ "TODAY" | translate }}</td>
-                {% elif (currentStep == 1) and config.ignoreToday == false %}
+                {% elif (currentStep == 1) and config.ignoreToday == false and config.absoluteDates == false %}
                     <td class="day">{{ "TOMORROW" | translate }}</td>
                 {% else %}
                     <td class="day">{{ f.date.format('ddd') }}</td>

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -43,7 +43,8 @@ Module.register("weather", {
 		onlyTemp: false,
 		showPrecipitationAmount: false,
 		colored: false,
-		showFeelsLike: true
+		showFeelsLike: true,
+		absoluteDates: false
 	},
 
 	// Module properties.


### PR DESCRIPTION
- Does the pull request solve a **related** issue?
No

-  If so, can you reference the issue like this `Fixes #<issue_number>`? 
N/A

- What does the pull request accomplish? Use a list if needed.
Add a Boolean configuration option `absoluteDates` to `modules/default/weather` to allow weather forecast dates to be formatted as absolute (MON, TUE) or relative (TODAY, TOMORROW).

- If it includes major visual changes please add screenshots.
N/A
