### PR TITLE
automatically add/remove a hidden/shown class to the module wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _This release is scheduled to be released on 2022-04-01._
 
 - Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
 - Added test for new weather forecast absoluteDates porperty.
+- The modules get a class shown/hidden added/removed if they get shown/hidden
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _This release is scheduled to be released on 2022-04-01._
 
 - Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
 - Added test for new weather forecast absoluteDates porperty.
-- The modules get a class shown/hidden added/removed if they get shown/hidden
+- The modules get a class hidden added/removed if they get hidden/shown
 
 ### Updated
 

--- a/js/main.js
+++ b/js/main.js
@@ -245,7 +245,6 @@ const MM = (function () {
 		if (moduleWrapper !== null) {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			moduleWrapper.style.opacity = 0;
-			moduleWrapper.className = moduleWrapper.className.split(" shown").join("");
 			moduleWrapper.className += " hidden";
 
 			clearTimeout(module.showHideTimer);
@@ -313,7 +312,6 @@ const MM = (function () {
 			// Restore the position. See hideModule() for more info.
 			moduleWrapper.style.position = "static";
 			moduleWrapper.className = moduleWrapper.className.split(" hidden").join("");
-			moduleWrapper.className += " shown";
 
 			updateWrapperStates();
 

--- a/js/main.js
+++ b/js/main.js
@@ -245,6 +245,8 @@ const MM = (function () {
 		if (moduleWrapper !== null) {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			moduleWrapper.style.opacity = 0;
+			moduleWrapper.className = moduleWrapper.className.split(" shown").join("");
+			moduleWrapper.className += " hidden";
 
 			clearTimeout(module.showHideTimer);
 			module.showHideTimer = setTimeout(function () {
@@ -310,6 +312,8 @@ const MM = (function () {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			// Restore the position. See hideModule() for more info.
 			moduleWrapper.style.position = "static";
+			moduleWrapper.className = moduleWrapper.className.split(" hidden").join("");
+			moduleWrapper.className += " shown";
 
 			updateWrapperStates();
 

--- a/js/main.js
+++ b/js/main.js
@@ -245,7 +245,7 @@ const MM = (function () {
 		if (moduleWrapper !== null) {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			moduleWrapper.style.opacity = 0;
-			moduleWrapper.className += " hidden";
+			moduleWrapper.classList.add("hidden");
 
 			clearTimeout(module.showHideTimer);
 			module.showHideTimer = setTimeout(function () {
@@ -311,7 +311,7 @@ const MM = (function () {
 			moduleWrapper.style.transition = "opacity " + speed / 1000 + "s";
 			// Restore the position. See hideModule() for more info.
 			moduleWrapper.style.position = "static";
-			moduleWrapper.className = moduleWrapper.className.split(" hidden").join("");
+			moduleWrapper.classList.remove("hidden");
 
 			updateWrapperStates();
 


### PR DESCRIPTION
Hi,

i need a possibility to change the z-index of modules based on the information if they are hidden or shown currently. In my setup i do have overlapping modules which are hidden/shown based on profiles. The modules are controlled by touch.
I added two small changes to the show/hide function which add/remove the classes shown/hidden to the module wrappers.
This way i can control which modules need to handle the current events by setting different z-index values in my custom.css file.

```
.module.MMM-Bring.shown,
.module.MMM-SynologySurveillance.shown {
  z-index: 1000;
}

.module.MMM-Bring.hidden,
.module.MMM-SynologySurveillance.hidden {
  z-index: -1;
}
```