### PR TITLE
improved and speedup e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ _This release is scheduled to be released on 2022-04-01._
 
 ### Fixed
 
+- improved and speedup e2e tests, artificial wait after mm start removed.
+
 ## [2.18.0] - 2022-01-01
 
 Special thanks to the following contributors: @AmpioRosso, @eouia, @fewieden, @jupadin, @khassel, @kolbyjack, @KristjanESPERANTO, @MariusVaice, @rejas, @rico24 and @sdetweil.

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -25,8 +25,9 @@ describe("App environment", function () {
 	});
 
 	it("should show the title MagicMirror²", function () {
-		const elem = document.querySelector("title");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toBe("MagicMirror²");
+		helpers.waitForElement("title").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toBe("MagicMirror²");
+		});
 	});
 });

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -23,14 +23,36 @@ exports.stopApplication = function () {
 };
 
 exports.getDocument = function (callback, ms) {
+	if (!ms || ms < 1000) ms = 1000;
 	const url = "http://" + (config.address || "localhost") + ":" + (config.port || "8080");
 	jsdom.JSDOM.fromURL(url, { resources: "usable", runScripts: "dangerously" }).then((dom) => {
 		dom.window.name = "jsdom";
 		dom.window.onload = function () {
+			global.MutationObserver = dom.window.MutationObserver;
 			global.document = dom.window.document;
 			setTimeout(() => {
 				callback();
 			}, ms);
 		};
+	});
+};
+
+exports.waitForElement = function(selector) {
+	return new Promise(resolve => {
+			if (document.querySelector(selector)) {
+					return resolve(document.querySelector(selector));
+			}
+
+			const observer = new MutationObserver(() => {
+					if (document.querySelector(selector)) {
+							resolve(document.querySelector(selector));
+							observer.disconnect();
+					}
+			});
+
+			observer.observe(document.body, {
+					childList: true,
+					subtree: true
+			});
 	});
 };

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -22,16 +22,14 @@ exports.stopApplication = function () {
 	}
 };
 
-exports.getDocument = function (callback, ms) {
+exports.getDocument = function (callback) {
 	const url = "http://" + (config.address || "localhost") + ":" + (config.port || "8080");
 	jsdom.JSDOM.fromURL(url, { resources: "usable", runScripts: "dangerously" }).then((dom) => {
 		dom.window.name = "jsdom";
 		dom.window.onload = function () {
 			global.MutationObserver = dom.window.MutationObserver;
 			global.document = dom.window.document;
-			setTimeout(() => {
-				callback();
-			}, ms);
+			callback();
 		};
 	});
 };

--- a/tests/e2e/global-setup.js
+++ b/tests/e2e/global-setup.js
@@ -23,7 +23,6 @@ exports.stopApplication = function () {
 };
 
 exports.getDocument = function (callback, ms) {
-	if (!ms || ms < 1000) ms = 1000;
 	const url = "http://" + (config.address || "localhost") + ":" + (config.port || "8080");
 	jsdom.JSDOM.fromURL(url, { resources: "usable", runScripts: "dangerously" }).then((dom) => {
 		dom.window.name = "jsdom";
@@ -37,22 +36,22 @@ exports.getDocument = function (callback, ms) {
 	});
 };
 
-exports.waitForElement = function(selector) {
-	return new Promise(resolve => {
-			if (document.querySelector(selector)) {
-					return resolve(document.querySelector(selector));
+exports.waitForElement = function (selector) {
+	return new Promise((resolve) => {
+		if (document.querySelector(selector) && document.querySelector(selector).value !== undefined) {
+			return resolve(document.querySelector(selector));
+		}
+
+		const observer = new MutationObserver(() => {
+			if (document.querySelector(selector) && document.querySelector(selector).value !== undefined) {
+				resolve(document.querySelector(selector));
+				observer.disconnect();
 			}
+		});
 
-			const observer = new MutationObserver(() => {
-					if (document.querySelector(selector)) {
-							resolve(document.querySelector(selector));
-							observer.disconnect();
-					}
-			});
-
-			observer.observe(document.body, {
-					childList: true,
-					subtree: true
-			});
+		observer.observe(document.body, {
+			childList: true,
+			subtree: true
+		});
 	});
 };

--- a/tests/e2e/modules/alert_spec.js
+++ b/tests/e2e/modules/alert_spec.js
@@ -3,15 +3,16 @@ const helpers = require("../global-setup");
 describe("Alert module", function () {
 	beforeAll(function (done) {
 		helpers.startApplication("tests/configs/modules/alert/default.js");
-		helpers.getDocument(done, 3000);
+		helpers.getDocument(done);
 	});
 	afterAll(function () {
 		helpers.stopApplication();
 	});
 
 	it("should show the welcome message", function () {
-		const elem = document.querySelector(".ns-box .ns-box-inner .light.bright.small");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toContain("Welcome, start was successful!");
+		helpers.waitForElement(".ns-box .ns-box-inner .light.bright.small").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain("Welcome, start was successful!");
+		});
 	});
 });

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -1,6 +1,5 @@
 const helpers = require("../global-setup");
 const serverBasicAuth = require("./basic-auth.js");
-const testDelay = 4000;
 
 describe("Calendar module", function () {
 	/**
@@ -16,14 +15,15 @@ describe("Calendar module", function () {
 			} else {
 				expect(elem.length).toBe(result);
 			}
-		})
+		});
 	}
 
 	const testTextContain = function (element, text) {
-		const elem = document.querySelector(".calendar");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toContain(text);
-	}
+		helpers.waitForElement(element).then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain(text);
+		});
+	};
 
 	afterAll(function () {
 		helpers.stopApplication();
@@ -86,7 +86,7 @@ describe("Calendar module", function () {
 					return i * 60;
 				};
 				helpers.startApplication("tests/configs/modules/calendar/recurring.js");
-				helpers.getDocument(done, testDelay);
+				helpers.getDocument(done);
 			});
 
 			it('should contain text "Mar 25th" in timezone UTC ' + -i, () => {
@@ -148,7 +148,7 @@ describe("Calendar module", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/fail-basic-auth.js");
 			serverBasicAuth.listen(8020);
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		afterAll(function (done) {

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -9,13 +9,20 @@ describe("Calendar module", function () {
 	 * @param {string} not reverse result
 	 */
 	function testElementLength(element, result, not) {
-		const elem = document.querySelectorAll(element);
+		helpers.waitForElement(element).then((elem) => {
+			expect(elem).not.toBe(null);
+			if (not === "not") {
+				expect(elem.length).not.toBe(result);
+			} else {
+				expect(elem.length).toBe(result);
+			}
+		})
+	}
+
+	const testTextContain = function (element, text) {
+		const elem = document.querySelector(".calendar");
 		expect(elem).not.toBe(null);
-		if (not === "not") {
-			expect(elem.length).not.toBe(result);
-		} else {
-			expect(elem.length).toBe(result);
-		}
+		expect(elem.textContent).toContain(text);
 	}
 
 	afterAll(function () {
@@ -25,7 +32,7 @@ describe("Calendar module", function () {
 	describe("Default configuration", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/default.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show the default maximumEntries of 10", () => {
@@ -40,7 +47,7 @@ describe("Calendar module", function () {
 	describe("Custom configuration", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/custom.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show the custom maximumEntries of 4", () => {
@@ -63,7 +70,7 @@ describe("Calendar module", function () {
 	describe("Recurring event", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/recurring.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show the recurring birthday event 6 times", () => {
@@ -83,9 +90,7 @@ describe("Calendar module", function () {
 			});
 
 			it('should contain text "Mar 25th" in timezone UTC ' + -i, () => {
-				const elem = document.querySelector(".calendar");
-				expect(elem).not.toBe(null);
-				expect(elem.textContent).toContain("Mar 25th");
+				testTextContain(".calendar", "Mar 25th");
 			});
 		});
 	}
@@ -94,7 +99,7 @@ describe("Calendar module", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/changed-port.js");
 			serverBasicAuth.listen(8010);
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		afterAll(function (done) {
@@ -109,7 +114,7 @@ describe("Calendar module", function () {
 	describe("Basic auth", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/basic-auth.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should return TestEvents", function () {
@@ -120,7 +125,7 @@ describe("Calendar module", function () {
 	describe("Basic auth by default", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/auth-default.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should return TestEvents", function () {
@@ -131,7 +136,7 @@ describe("Calendar module", function () {
 	describe("Basic auth backward compatibility configuration: DEPRECATED", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/calendar/old-basic-auth.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should return TestEvents", function () {
@@ -151,9 +156,7 @@ describe("Calendar module", function () {
 		});
 
 		it("should show Unauthorized error", function () {
-			const elem = document.querySelector(".calendar");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Error in the calendar module. Authorization failed");
+			testTextContain(".calendar", "Error in the calendar module. Authorization failed");
 		});
 	});
 });

--- a/tests/e2e/modules/clock_es_spec.js
+++ b/tests/e2e/modules/clock_es_spec.js
@@ -6,15 +6,16 @@ describe("Clock set to spanish language module", function () {
 	});
 
 	const testMatch = function (element, regex) {
-		const elem = document.querySelector(element);
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toMatch(regex);
+		helpers.waitForElement(element).then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toMatch(regex);
+		});
 	};
 
 	describe("with default 24hr clock config", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/es/clock_24hr.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("shows date with correct format", function () {
@@ -31,7 +32,7 @@ describe("Clock set to spanish language module", function () {
 	describe("with default 12hr clock config", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/es/clock_12hr.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("shows date with correct format", function () {
@@ -48,7 +49,7 @@ describe("Clock set to spanish language module", function () {
 	describe("with showPeriodUpper config enabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/es/clock_showPeriodUpper.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("shows 12hr time with upper case AM/PM", function () {
@@ -60,7 +61,7 @@ describe("Clock set to spanish language module", function () {
 	describe("with showWeek config enabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/es/clock_showWeek.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("shows week with correct format", function () {

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -15,7 +15,7 @@ describe("Clock module", function () {
 	describe("with default 24hr clock config", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_24hr.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show the date in the correct format", function () {
@@ -32,7 +32,7 @@ describe("Clock module", function () {
 	describe("with default 12hr clock config", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_12hr.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show the date in the correct format", function () {
@@ -49,7 +49,7 @@ describe("Clock module", function () {
 	describe("with showPeriodUpper config enabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_showPeriodUpper.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show 12hr time with upper case AM/PM", function () {
@@ -61,7 +61,7 @@ describe("Clock module", function () {
 	describe("with displaySeconds config disabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_displaySeconds_false.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show 12hr time without seconds am/pm", function () {
@@ -73,7 +73,7 @@ describe("Clock module", function () {
 	describe("with showTime config disabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_showTime.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show not show the time when digital clock is shown", function () {
@@ -85,7 +85,7 @@ describe("Clock module", function () {
 	describe("with showWeek config enabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_showWeek.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show the week in the correct format", function () {
@@ -105,7 +105,7 @@ describe("Clock module", function () {
 	describe("with analog clock face enabled", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/clock/clock_analog.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("should show the analog clock face", () => {

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -7,9 +7,10 @@ describe("Clock module", function () {
 	});
 
 	const testMatch = function (element, regex) {
-		const elem = document.querySelector(element);
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toMatch(regex);
+		helpers.waitForElement(element).then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toMatch(regex);
+		});
 	};
 
 	describe("with default 24hr clock config", function () {
@@ -77,8 +78,9 @@ describe("Clock module", function () {
 		});
 
 		it("should show not show the time when digital clock is shown", function () {
-			const elem = document.querySelector(".clock .digital .time");
-			expect(elem).toBe(null);
+			helpers.waitForElement(".clock .digital .time").then((elem) => {
+				expect(elem).toBe(null);
+			});
 		});
 	});
 
@@ -96,9 +98,10 @@ describe("Clock module", function () {
 		it("should show the week with the correct number of week of year", function () {
 			const currentWeekNumber = moment().week();
 			const weekToShow = "Week " + currentWeekNumber;
-			const elem = document.querySelector(".clock .week");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toBe(weekToShow);
+			helpers.waitForElement(".clock .week").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toBe(weekToShow);
+			});
 		});
 	});
 
@@ -109,8 +112,9 @@ describe("Clock module", function () {
 		});
 
 		it("should show the analog clock face", () => {
-			const elem = document.querySelector(".clockCircle");
-			expect(elem).not.toBe(null);
+			helpers.waitForElement(".clockCircle").then((elem) => {
+				expect(elem).not.toBe(null);
+			});
 		});
 	});
 });

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -6,11 +6,13 @@ const helpers = require("../global-setup");
  * @param {Array} complimentsArray The array of compliments.
  */
 function doTest(complimentsArray) {
-	let elem = document.querySelector(".compliments");
-	expect(elem).not.toBe(null);
-	elem = document.querySelector(".module-content");
-	expect(elem).not.toBe(null);
-	expect(complimentsArray).toContain(elem.textContent);
+	helpers.waitForElement(".compliments").then((elem) => {
+		expect(elem).not.toBe(null);
+		helpers.waitForElement(".module-content").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(complimentsArray).toContain(elem.textContent);
+		});
+	});
 }
 
 describe("Compliments module", function () {
@@ -21,7 +23,7 @@ describe("Compliments module", function () {
 	describe("parts of days", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("if Morning compliments for that part of day", function () {
@@ -53,7 +55,7 @@ describe("Compliments module", function () {
 		describe("Set anytime and empty compliments for morning, evening and afternoon ", function () {
 			beforeAll(function (done) {
 				helpers.startApplication("tests/configs/modules/compliments/compliments_anytime.js");
-				helpers.getDocument(done, 1000);
+				helpers.getDocument(done);
 			});
 
 			it("Show anytime because if configure empty parts of day compliments and set anytime compliments", function () {
@@ -64,7 +66,7 @@ describe("Compliments module", function () {
 		describe("Only anytime present in configuration compliments", function () {
 			beforeAll(function (done) {
 				helpers.startApplication("tests/configs/modules/compliments/compliments_only_anytime.js");
-				helpers.getDocument(done, 1000);
+				helpers.getDocument(done);
 			});
 
 			it("Show anytime compliments", function () {
@@ -77,7 +79,7 @@ describe("Compliments module", function () {
 		describe("Set date and empty compliments for anytime, morning, evening and afternoon", function () {
 			beforeAll(function (done) {
 				helpers.startApplication("tests/configs/modules/compliments/compliments_date.js");
-				helpers.getDocument(done, 1000);
+				helpers.getDocument(done);
 			});
 
 			it("Show happy new year compliment on new years day", function () {

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -8,26 +8,28 @@ describe("Test helloworld module", function () {
 	describe("helloworld set config text", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/helloworld/helloworld.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("Test message helloworld module", function () {
-			const elem = document.querySelector(".helloworld");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Test HelloWorld Module");
+			helpers.waitForElement(".helloworld").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Test HelloWorld Module");
+			});
 		});
 	});
 
 	describe("helloworld default config text", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/helloworld/helloworld_default.js");
-			helpers.getDocument(done, 1000);
+			helpers.getDocument(done);
 		});
 
 		it("Test message helloworld module", function () {
-			const elem = document.querySelector(".helloworld");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Hello World!");
+			helpers.waitForElement(".helloworld").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Hello World!");
+			});
 		});
 	});
 });

--- a/tests/e2e/modules/newsfeed_spec.js
+++ b/tests/e2e/modules/newsfeed_spec.js
@@ -1,5 +1,4 @@
 const helpers = require("../global-setup");
-const testDelay = 4000;
 
 describe("Newsfeed module", function () {
 	afterAll(function () {
@@ -9,69 +8,76 @@ describe("Newsfeed module", function () {
 	describe("Default configuration", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/newsfeed/default.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show the newsfeed title", function () {
-			const elem = document.querySelector(".newsfeed .newsfeed-source");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Rodrigo Ramirez Blog");
+			helpers.waitForElement(".newsfeed .newsfeed-source").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Rodrigo Ramirez Blog");
+			});
 		});
 
 		it("should show the newsfeed article", function () {
-			const elem = document.querySelector(".newsfeed .newsfeed-title");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("QPanel");
+			helpers.waitForElement(".newsfeed .newsfeed-title").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("QPanel");
+			});
 		});
 
 		it("should NOT show the newsfeed description", () => {
-			const elem = document.querySelector(".newsfeed .newsfeed-desc");
-			expect(elem).toBe(null);
+			helpers.waitForElement(".newsfeed .newsfeed-desc").then((elem) => {
+				expect(elem).toBe(null);
+			});
 		});
 	});
 
 	describe("Custom configuration", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/newsfeed/prohibited_words.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should not show articles with prohibited words", function () {
-			const elem = document.querySelector(".newsfeed .newsfeed-title");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Problema VirtualBox");
+			helpers.waitForElement(".newsfeed .newsfeed-title").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Problema VirtualBox");
+			});
 		});
 
 		it("should show the newsfeed description", () => {
-			const elem = document.querySelector(".newsfeed .newsfeed-desc");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent.length).not.toBe(0);
+			helpers.waitForElement(".newsfeed .newsfeed-desc").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent.length).not.toBe(0);
+			});
 		});
 	});
 
 	describe("Invalid configuration", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/newsfeed/incorrect_url.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show malformed url warning", function () {
-			const elem = document.querySelector(".newsfeed .small");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Error in the Newsfeed module. Malformed url.");
+			helpers.waitForElement(".newsfeed .small").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Error in the Newsfeed module. Malformed url.");
+			});
 		});
 	});
 
 	describe("Ignore items", function () {
 		beforeAll(function (done) {
 			helpers.startApplication("tests/configs/modules/newsfeed/ignore_items.js");
-			helpers.getDocument(done, testDelay);
+			helpers.getDocument(done);
 		});
 
 		it("should show empty items info message", function () {
-			const elem = document.querySelector(".newsfeed .small");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("No news at the moment.");
+			helpers.waitForElement(".newsfeed .small").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("No news at the moment.");
+			});
 		});
 	});
 });

--- a/tests/e2e/modules/weather_spec.js
+++ b/tests/e2e/modules/weather_spec.js
@@ -233,8 +233,8 @@ describe("Weather module", function () {
 			});
 
 			it("should render colored rows", function () {
-				helpers.waitForElement(".weather table.myTableClass").then((elem) => {
-					expect(elem).not.toBe(null);
+				helpers.waitForElement(".weather table.myTableClass").then((table) => {
+					expect(table).not.toBe(null);
 					expect(table.rows).not.toBe(null);
 					expect(table.rows.length).toBe(5);
 				});

--- a/tests/e2e/modules/weather_spec.js
+++ b/tests/e2e/modules/weather_spec.js
@@ -6,28 +6,19 @@ const { generateWeather, generateWeatherForecast } = require("./mocks");
 
 describe("Weather module", function () {
 	/**
-	 *
-	 * @param {string} element css selector
-	 * @returns {Promise<Element>} Promise with the element once it is rendered
-	 */
-	function getElement(element) {
-		const elem = document.querySelector(element);
-		expect(elem).not.toBe(null);
-		return elem;
-	}
-
-	/**
 	 * @param {string} element css selector
 	 * @param {string} result Expected text in given selector
 	 */
 	function getText(element, result) {
-		const elem = getElement(element);
-		expect(
-			elem.textContent
-				.trim()
-				.replace(/(\r\n|\n|\r)/gm, "")
-				.replace(/[ ]+/g, " ")
-		).toBe(result);
+		helpers.waitForElement(element).then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(
+				elem.textContent
+					.trim()
+					.replace(/(\r\n|\n|\r)/gm, "")
+					.replace(/[ ]+/g, " ")
+			).toBe(result);
+		});
 	}
 
 	/**
@@ -46,7 +37,7 @@ describe("Weather module", function () {
 		content = content.replace("#####WEATHERDATA#####", mockWeather);
 		fs.writeFileSync(path.resolve(__dirname + "../../../../config/config.js"), content);
 		helpers.startApplication("");
-		helpers.getDocument(callback, 3000);
+		helpers.getDocument(callback);
 	}
 
 	afterAll(function () {
@@ -117,8 +108,10 @@ describe("Weather module", function () {
 		});
 
 		it("should render showWindDirectionAsArrow = true", function () {
-			const elem = getElement(".weather .normal.medium sup i.fa-long-arrow-alt-up");
-			expect(elem.outerHTML).toContain("transform:rotate(250deg);");
+			helpers.waitForElement(".weather .normal.medium sup i.fa-long-arrow-alt-up").then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.outerHTML).toContain("transform:rotate(250deg);");
+			});
 		});
 
 		it("should render showHumidity = true", function () {
@@ -180,7 +173,9 @@ describe("Weather module", function () {
 				const icons = ["day-cloudy", "rain", "day-sunny", "day-sunny", "day-sunny"];
 
 				for (const [index, icon] of icons.entries()) {
-					getElement(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`);
+					helpers.waitForElement(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`).then((elem) => {
+						expect(elem).not.toBe(null);
+					});
 				}
 			});
 
@@ -204,8 +199,10 @@ describe("Weather module", function () {
 				const opacities = [1, 1, 0.8, 0.5333333333333333, 0.2666666666666667];
 
 				for (const [index, opacity] of opacities.entries()) {
-					const elem = getElement(`.weather table.small tr:nth-child(${index + 1})`);
-					expect(elem.outerHTML).toContain(`<tr style="opacity: ${opacity};">`);
+					helpers.waitForElement(`.weather table.small tr:nth-child(${index + 1})`).then((elem) => {
+						expect(elem).not.toBe(null);
+						expect(elem.outerHTML).toContain(`<tr style="opacity: ${opacity};">`);
+					});
 				}
 			});
 		});
@@ -230,13 +227,17 @@ describe("Weather module", function () {
 			});
 
 			it("should render custom table class", function () {
-				getElement(".weather table.myTableClass");
+				helpers.waitForElement(".weather table.myTableClass").then((elem) => {
+					expect(elem).not.toBe(null);
+				});
 			});
 
 			it("should render colored rows", function () {
-				const table = getElement(".weather table.myTableClass");
-				expect(table.rows).not.toBe(null);
-				expect(table.rows.length).toBe(5);
+				helpers.waitForElement(".weather table.myTableClass").then((elem) => {
+					expect(elem).not.toBe(null);
+					expect(table.rows).not.toBe(null);
+					expect(table.rows.length).toBe(5);
+				});
 			});
 		});
 

--- a/tests/e2e/modules_display_spec.js
+++ b/tests/e2e/modules_display_spec.js
@@ -3,22 +3,24 @@ const helpers = require("./global-setup");
 describe("Display of modules", function () {
 	beforeAll(function (done) {
 		helpers.startApplication("tests/configs/modules/display.js");
-		helpers.getDocument(done, 3000);
+		helpers.getDocument(done);
 	});
 	afterAll(function () {
 		helpers.stopApplication();
 	});
 
 	it("should show the test header", function () {
-		const elem = document.querySelector("#module_0_helloworld .module-header");
-		expect(elem).not.toBe(null);
-		// textContent gibt hier lowercase zurück, das uppercase wird durch css realisiert, was daher nicht in textContent landet
-		expect(elem.textContent).toBe("test_header");
+		helpers.waitForElement("#module_0_helloworld .module-header").then((elem) => {
+			expect(elem).not.toBe(null);
+			// textContent gibt hier lowercase zurück, das uppercase wird durch css realisiert, was daher nicht in textContent landet
+			expect(elem.textContent).toBe("test_header");
+		});
 	});
 
 	it("should show no header if no header text is specified", function () {
-		const elem = document.querySelector("#module_1_helloworld .module-header");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toBe("undefined");
+		helpers.waitForElement("#module_1_helloworld .module-header").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toBe("undefined");
+		});
 	});
 });

--- a/tests/e2e/modules_position_spec.js
+++ b/tests/e2e/modules_position_spec.js
@@ -3,7 +3,7 @@ const helpers = require("./global-setup");
 describe("Position of modules", function () {
 	beforeAll(function (done) {
 		helpers.startApplication("tests/configs/modules/positions.js");
-		helpers.getDocument(done, 3000);
+		helpers.getDocument(done);
 	});
 	afterAll(function () {
 		helpers.stopApplication();
@@ -14,9 +14,10 @@ describe("Position of modules", function () {
 	for (const position of positions) {
 		const className = position.replace("_", ".");
 		it("should show text in " + position, function () {
-			const elem = document.querySelector("." + className);
-			expect(elem).not.toBe(null);
-			expect(elem.textContent).toContain("Text in " + position);
+			helpers.waitForElement("." + className).then((elem) => {
+				expect(elem).not.toBe(null);
+				expect(elem.textContent).toContain("Text in " + position);
+			});
 		});
 	}
 });

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -3,7 +3,7 @@ const helpers = require("./global-setup");
 describe("Check configuration without modules", function () {
 	beforeAll(function (done) {
 		helpers.startApplication("tests/configs/without_modules.js");
-		helpers.getDocument(done, 1000);
+		helpers.getDocument(done);
 	});
 	afterAll(function () {
 		helpers.stopApplication();

--- a/tests/e2e/without_modules.js
+++ b/tests/e2e/without_modules.js
@@ -10,14 +10,16 @@ describe("Check configuration without modules", function () {
 	});
 
 	it("Show the message MagicMirror title", function () {
-		const elem = document.querySelector("#module_1_helloworld .module-content");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toContain("Magic Mirror2");
+		helpers.waitForElement("#module_1_helloworld .module-content").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain("Magic Mirror2");
+		});
 	});
 
 	it("Show the text Michael's website", function () {
-		const elem = document.querySelector("#module_5_helloworld .module-content");
-		expect(elem).not.toBe(null);
-		expect(elem.textContent).toContain("www.michaelteeuw.nl");
+		helpers.waitForElement("#module_5_helloworld .module-content").then((elem) => {
+			expect(elem).not.toBe(null);
+			expect(elem.textContent).toContain("www.michaelteeuw.nl");
+		});
 	});
 });


### PR DESCRIPTION
In the e2e tests I used an artifical wait after mm start because the elements where loaded in jsdom but still undefined when accessing them. Now I managed to wait for the element so I could remove this artifical wait. So now the e2e tests are faster and hopefully there are no fails anymore (in the past most fails were because the artifical wait was to low).