### PR TITLE
fix helmet, use defaults from v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ _This release is scheduled to be released on 2022-04-01._
 ### Updated
 
 - deprecated roboto fonts package `roboto-fontface-bower` replaced with `fontsource`.
-- update `helmet` to v5.
+- update `helmet` to v5, use defaults of v4.
 - updates Font Awesome css class to new default style (fixes #2768)
 
 ### Fixed

--- a/js/server.js
+++ b/js/server.js
@@ -67,7 +67,7 @@ function Server(config, callback) {
 			res.status(403).send("This device is not allowed to access your mirror. <br> Please check your config.js or config.js.sample to change this.");
 		});
 	});
-	app.use(helmet({ contentSecurityPolicy: false, crossOriginOpenerPolicy: false }));
+	app.use(helmet({ contentSecurityPolicy: false, crossOriginOpenerPolicy: false, crossOriginEmbedderPolicy: false, crossOriginResourcePolicy: false, originAgentCluster: false }));
 
 	app.use("/js", express.static(__dirname));
 


### PR DESCRIPTION
After the helmet upgrade to v5 the MMM-RAIN-MAP module was not working anymore due to cors errors.

Helmet changed some defaults so with this PR the defaults from v4 are set. This solved the above problem.