### PR TITLE
Return full list of events for broadcasting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ _This release is scheduled to be released on 2022-04-01._
 - update `helmet` to v5, use defaults of v4.
 - updates Font Awesome css class to new default style (fixes #2768)
 - replaced deprecated modules `currentweather` and `weatherforecast` with dummy modules only displaying that they have to be replaced.
+- include all calendar events from the configured date range when broadcasting.
 
 ### Fixed
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -477,10 +477,10 @@ Module.register("calendar", {
 	/**
 	 * Creates the sorted list of all events.
 	 *
-	 * @param {boolean} forDisplay Whether to filter returned events for display.
+	 * @param {boolean} limitNumberOfEntries Whether to filter returned events for display.
 	 * @returns {object[]} Array with events.
 	 */
-	createEventList: function (forDisplay) {
+	createEventList: function (limitNumberOfEntries) {
 		const now = new Date();
 		const today = moment().startOf("day");
 		const future = moment().startOf("day").add(this.config.maximumNumberOfDays, "days").toDate();
@@ -491,7 +491,7 @@ Module.register("calendar", {
 			for (const e in calendar) {
 				const event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 
-				if (event.endDate < now && forDisplay) {
+				if (event.endDate < now && limitNumberOfEntries) {
 					continue;
 				}
 				if (this.config.hidePrivate) {
@@ -500,7 +500,7 @@ Module.register("calendar", {
 						continue;
 					}
 				}
-				if (this.config.hideOngoing && forDisplay) {
+				if (this.config.hideOngoing && limitNumberOfEntries) {
 					if (event.startDate < now) {
 						continue;
 					}
@@ -549,7 +549,7 @@ Module.register("calendar", {
 			return a.startDate - b.startDate;
 		});
 
-		if (!forDisplay) {
+		if (!limitNumberOfEntries) {
 			return events;
 		}
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -498,23 +498,7 @@ const CalendarUtils = {
 			return a.startDate - b.startDate;
 		});
 
-		// include up to maximumEntries current or upcoming events
-		// If past events should be included, include all past events
-		const now = moment();
-		let entries = 0;
-		let events = [];
-		for (let ne of newEvents) {
-			if (moment(ne.endDate, "x").isBefore(now)) {
-				if (config.includePastEvents) events.push(ne);
-				continue;
-			}
-			entries++;
-			// If max events has been saved, skip the rest
-			if (entries > config.maximumEntries) break;
-			events.push(ne);
-		}
-
-		return events;
+		return newEvents;
 	},
 
 	/**


### PR DESCRIPTION
I have several modules that provide alternate displays for calendar events, and currently, if I want the calendar module to return all of the future events for the current month (for my MMM-MonthlyCalendar module), then I need to configure maximumEvents to be large enough that the calendar module itself needs to be hidden.  Instead, the configured display limits should only be imposed when generating the list of events to display, not when fetching events from configured calendars.