### PR TITLE
change husky setup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
-npm run lint:staged
+[ -f "$(dirname "$0")/_/husky.sh" ] && . "$(dirname "$0")/_/husky.sh"
+
+if command -v npm &> /dev/null; then
+  npm run lint:staged
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2022-04-01._
 ### Fixed
 
 - improved and speedup e2e tests, artificial wait after mm start removed.
+- improved husky setup not blocking `git commit` if `husky` or `npm` is not installed.
 
 ## [2.18.0] - 2022-01-01
 


### PR DESCRIPTION
This is a convenience PR for developers when working with this git repo (or a fork) without having dependencies installed.

I'm doing this e.g. when adding a changelog entry on my windows machine where I don't want to install the whole node/npm stuff.

So I changed the husky pre-commit to run the commands inside only if they are installed.

Hopefully @rejas can live with this change ...