### PR TITLE
Newsfeed module: Add option to display title as url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _This release is scheduled to be released on 2022-04-01._
 - Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
 - Added test for new weather forecast absoluteDates porperty.
 - The modules get a class hidden added/removed if they get hidden/shown
+- Added new config option `showTitleAsUrl` to newsfeed module. If set, the diplayed title is a link to the article which is useful when running in a browser and you want to read this article.
 
 ### Updated
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -20,6 +20,7 @@ Module.register("newsfeed", {
 		broadcastNewsFeeds: true,
 		broadcastNewsUpdates: true,
 		showDescription: false,
+		showTitleAsUrl: false,
 		wrapTitle: true,
 		wrapDescription: true,
 		truncDescription: true,
@@ -141,6 +142,7 @@ Module.register("newsfeed", {
 			sourceTitle: item.sourceTitle,
 			publishDate: moment(new Date(item.pubdate)).fromNow(),
 			title: item.title,
+			url: item.url,
 			description: item.description,
 			items: items
 		};

--- a/modules/default/newsfeed/newsfeed.njk
+++ b/modules/default/newsfeed/newsfeed.njk
@@ -6,6 +6,22 @@
   {% endif %}
 {% endmacro %}
 
+{% macro escapeTitle(title, url, dangerouslyDisableAutoEscaping=false, showTitleAsUrl=false) %}
+  {% if dangerouslyDisableAutoEscaping %}
+    {% if showTitleAsUrl %}
+      <a href="{{ url }}" style="text-decoration:none;color:#ffffff" target="_blank">{{ title | safe }}</a>
+    {% else %}
+      {{ title | safe}}
+    {% endif %}
+  {% else %}
+    {% if showTitleAsUrl %}
+      <a href="{{ url }}" style="text-decoration:none;color:#ffffff" target="_blank">{{ title }}</a>
+    {% else %}
+      {{ title }}
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
 {% if loaded %}
     {% if config.showAsList %}
         <ul class="newsfeed-list">
@@ -22,7 +38,7 @@
                         </div>
                     {% endif %}
                     <div class="newsfeed-title bright medium light{{ ' no-wrap' if not config.wrapTitle }}">
-                        {{ escapeText(item.title, config.dangerouslyDisableAutoEscaping) }}
+                        {{ escapeTitle(item.title, item.url, config.dangerouslyDisableAutoEscaping, config.showTitleAsUrl) }}
                     </div>
                     {% if config.showDescription %}
                         <div class="newsfeed-desc small light{{ ' no-wrap' if not config.wrapDescription }}">
@@ -49,7 +65,7 @@
                 </div>
             {% endif %}
             <div class="newsfeed-title bright medium light{{ ' no-wrap' if not config.wrapTitle }}">
-                {{ escapeText(title, config.dangerouslyDisableAutoEscaping) }}
+                {{ escapeTitle(title, url, config.dangerouslyDisableAutoEscaping, config.showTitleAsUrl) }}
             </div>
             {% if config.showDescription %}
                 <div class="newsfeed-desc small light{{ ' no-wrap' if not config.wrapDescription }}">


### PR DESCRIPTION
Added new config option `showTitleAsUrl` to newsfeed module.

If set, the displayed title is a link to the article which is useful when running in a browser. If you now want to read the displayed article you can just click on it and it will open in a new browser tab/window.

There are no optical changes, except when `showTitleAsUrl` is set a mouse curser is displayed when moving over the title so you can click.

Will update documentation if this is accepted and merged here.