### PR TITLE
Fix broken link in README to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Contributions of all kinds are welcome, not only in the form of code but also wi
 - documentation
 - translations
 
-For the full contribution guidelines, check out: [https://docs.magicmirror.builders/getting-started/contributing.html](https://docs.magicmirror.builders/getting-started/contributing.html)
+For the full contribution guidelines, check out: [https://docs.magicmirror.builders/about/contributing.html](https://docs.magicmirror.builders/about/contributing.html)
 
 ## Enjoying MagicMirror? Consider a donation!
 


### PR DESCRIPTION
I was about to report a bug and when looking for contribution guidelines I noticed the link in the README was broken. So now I'm doing things a bit backwards :P 

