### PR TITLE
fix parsing of feels like for weathergov

### DIFF
--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -156,8 +156,13 @@ WeatherProvider.register("weathergov", {
 		currentWeather.rain = null;
 		currentWeather.snow = null;
 		currentWeather.precipitation = this.convertLength(currentWeatherData.precipitationLastHour.value);
-		currentWeather.feelsLikeTemp = this.convertTemp(currentWeatherData.heatIndex.value);
-
+		if (currentWeatherData.heatIndex.value !== null) {
+			currentWeather.feelsLikeTemp = this.convertTemp(currentWeatherData.heatIndex.value);
+		} else if (currentWeatherData.windChill.value !== null) {
+			currentWeather.feelsLikeTemp = this.convertTemp(currentWeatherData.windChill.value);
+		} else {
+			currentWeather.feelsLikeTemp = this.convertTemp(currentWeatherData.temperature.value);
+		}
 		// determine the sunrise/sunset times - not supplied in weather.gov data
 		currentWeather.updateSunTime(this.config.lat, this.config.lon);
 


### PR DESCRIPTION
weather.gov API does not seem to consistently provide a feels like value. The [API specs](https://weather-gov.github.io/api/gridpoints) mention an `apparentTemperature` value, which seems to not be provided most of the time in responses. There is a consistent value of `windChill` and `heatIndex`, which according to docs, only has a value when the value falls within a certain threshold.

Before this fix, feels like would only be read from `heatIndex` and it would be coerced to 0 if the value was `null`, thus showing a consistent feels like temp of 0 celsius/ 32 fahrenheit.

This pull request uses either `windChill` or `heatIndex` for feels like temp if one of them is available. If none are available, it will fall back to the current actual temperature.