### PR TITLE
Don't adjust startDate for full day events if endDate is in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ _This release is scheduled to be released on 2022-04-01._
 - Improved husky setup not blocking `git commit` if `husky` or `npm` is not installed.
 - Using a consistent spelling of MagicMirror².
 - Fix minor console output issue for loading translations (#2814).
+- Don't adjust startDate for full day events if endDate is in the past
 
 ## [2.18.0] - 2022-01-01
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -470,7 +470,7 @@ const CalendarUtils = {
 					}
 
 					// Adjust start date so multiple day events will be displayed as happening today even though they started some days ago already
-					if (fullDayEvent && startDate <= today) {
+					if (fullDayEvent && startDate <= today && endDate > today) {
 						startDate = moment(today);
 					}
 					// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)


### PR DESCRIPTION
When including past events in the event list for broadcast, the adjustment to make multi-day events appear as happening today had the side effect of promoting single-day full-day events from yesterday to today.  Adding a check to ensure that the event hasn't ended before updating the start date fixes my use case, however, I think a proper fix needs to perform the change in calendar.js when building the dom, as it is, multi-day events will still have their start date updated until after they've ended, which could be confusing for CALENDAR_EVENTS consumers.  Alternatively, a second field (`originalStartDate`?) could be added for broadcasting, but that seems like a hack.