### PR TITLE
Fix windspeed conversion in openweathermap provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ _This release is scheduled to be released on 2022-04-01._
 - Using a consistent spelling of MagicMirror².
 - Fix minor console output issue for loading translations (#2814).
 - Don't adjust startDate for full day events if endDate is in the past
+- Fix windspeed conversion error in openweathermap provider. (#2812)
 
 ## [2.18.0] - 2022-01-01
 
@@ -283,7 +284,7 @@ Special thanks to the following contributors: @Alvinger, @AndyPoms, @ashishtank,
 - Rename Greek translation to correct ISO 639-1 alpha-2 code (gr > el). (#2155)
 - Add a space after icons of sunrise and sunset. (#2169)
 - Fix calendar when no DTEND record found in event, startDate overlay when endDate set. (#2177)
-- Fix windspeed convertion error in ukmetoffice weather provider. (#2189)
+- Fix windspeed conversion error in ukmetoffice weather provider. (#2189)
 - Fix console.debug not having timestamps. (#2199)
 - Fix calendar full day event east of UTC start time. (#2200)
 - Fix non-fullday recurring rule processing. (#2216)

--- a/fonts/package-lock.json
+++ b/fonts/package-lock.json
@@ -7,31 +7,31 @@
 			"name": "magicmirror-fonts",
 			"license": "MIT",
 			"dependencies": {
-				"@fontsource/roboto": "^4.5.1",
-				"@fontsource/roboto-condensed": "^4.5.0"
+				"@fontsource/roboto": "^4.5.3",
+				"@fontsource/roboto-condensed": "^4.5.4"
 			}
 		},
 		"node_modules/@fontsource/roboto": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.1.tgz",
-			"integrity": "sha512-3mhfL+eNPG/woMNqwD/OHaW5qMpeGEBsDwzmhFmjB1yUV+M+M9P0NhP/AyHvnGz3DrqkvZ7CPzNMa+UkVLeELg=="
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.3.tgz",
+			"integrity": "sha512-NUvBTj332dFRdiVkLlavXbDGoD2zyyeGYmMyrXOnctg/3e4pq95+rJgNfUP+k4v8UBk2L1aomGw9dDjbRdAmTg=="
 		},
 		"node_modules/@fontsource/roboto-condensed": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-4.5.0.tgz",
-			"integrity": "sha512-P5On1DdWxWvBHC0kfinxGWOHveAS3wEHKpgfBidl6mzJI/nJyzcPxf5p5k0oT6uY0WzUCPPfsfgCmKMMULAXGg=="
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-4.5.4.tgz",
+			"integrity": "sha512-f7/6m4eW8LXmUrx3yxgzWNte4oztZrBH40BuTdgEgDIGU72HzRlM78k1u3BV945SaQwPoA+yv5RDa+FOfzpflA=="
 		}
 	},
 	"dependencies": {
 		"@fontsource/roboto": {
-			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.1.tgz",
-			"integrity": "sha512-3mhfL+eNPG/woMNqwD/OHaW5qMpeGEBsDwzmhFmjB1yUV+M+M9P0NhP/AyHvnGz3DrqkvZ7CPzNMa+UkVLeELg=="
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.3.tgz",
+			"integrity": "sha512-NUvBTj332dFRdiVkLlavXbDGoD2zyyeGYmMyrXOnctg/3e4pq95+rJgNfUP+k4v8UBk2L1aomGw9dDjbRdAmTg=="
 		},
 		"@fontsource/roboto-condensed": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-4.5.0.tgz",
-			"integrity": "sha512-P5On1DdWxWvBHC0kfinxGWOHveAS3wEHKpgfBidl6mzJI/nJyzcPxf5p5k0oT6uY0WzUCPPfsfgCmKMMULAXGg=="
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/@fontsource/roboto-condensed/-/roboto-condensed-4.5.4.tgz",
+			"integrity": "sha512-f7/6m4eW8LXmUrx3yxgzWNte4oztZrBH40BuTdgEgDIGU72HzRlM78k1u3BV945SaQwPoA+yv5RDa+FOfzpflA=="
 		}
 	}
 }

--- a/fonts/package.json
+++ b/fonts/package.json
@@ -10,7 +10,7 @@
 		"url": "https://github.com/MichMich/MagicMirror/issues"
 	},
 	"dependencies": {
-		"@fontsource/roboto": "^4.5.1",
-		"@fontsource/roboto-condensed": "^4.5.0"
+		"@fontsource/roboto": "^4.5.3",
+		"@fontsource/roboto-condensed": "^4.5.4"
 	}
 }

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -128,12 +128,7 @@ WeatherProvider.register("openweathermap", {
 		currentWeather.humidity = currentWeatherData.main.humidity;
 		currentWeather.temperature = currentWeatherData.main.temp;
 		currentWeather.feelsLikeTemp = currentWeatherData.main.feels_like;
-
-		if (this.config.windUnits === "metric") {
-			currentWeather.windSpeed = this.config.useKmh ? currentWeatherData.wind.speed * 3.6 : currentWeatherData.wind.speed;
-		} else {
-			currentWeather.windSpeed = currentWeatherData.wind.speed;
-		}
+		currentWeather.windSpeed = currentWeatherData.wind.speed;
 		currentWeather.windDirection = currentWeatherData.wind.deg;
 		currentWeather.weatherType = this.convertWeatherType(currentWeatherData.weather[0].icon);
 		currentWeather.sunrise = moment(currentWeatherData.sys.sunrise, "X");

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -40,7 +40,8 @@ WeatherProvider.register("weathergov", {
 	// Called to set the config, this config is the same as the weather module's config.
 	setConfig: function (config) {
 		this.config = config;
-		(this.config.apiBase = "https://api.weather.gov"), this.fetchWxGovURLs(this.config);
+		this.config.apiBase = "https://api.weather.gov";
+		this.fetchWxGovURLs(this.config);
 	},
 
 	// Called when the weather provider is about to start.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"colors": "^1.4.0",
 				"console-stamp": "^3.0.4",
 				"digest-fetch": "^1.2.1",
-				"eslint": "^8.10.0",
+				"eslint": "^8.11.0",
 				"express": "^4.17.3",
 				"express-ipfilter": "^1.2.0",
 				"feedme": "^2.0.2",
@@ -26,9 +26,9 @@
 				"socket.io": "^4.4.1"
 			},
 			"devDependencies": {
-				"eslint-config-prettier": "^8.4.0",
-				"eslint-plugin-jest": "^26.1.1",
-				"eslint-plugin-jsdoc": "^37.9.5",
+				"eslint-config-prettier": "^8.5.0",
+				"eslint-plugin-jest": "^26.1.2",
+				"eslint-plugin-jsdoc": "^38.0.6",
 				"eslint-plugin-prettier": "^4.0.0",
 				"express-basic-auth": "^1.2.1",
 				"husky": "^7.0.4",
@@ -36,11 +36,11 @@
 				"jsdom": "^19.0.0",
 				"lodash": "^4.17.21",
 				"nyc": "^15.1.0",
-				"playwright": "^1.19.2",
-				"prettier": "^2.5.1",
+				"playwright": "^1.20.0",
+				"prettier": "^2.6.0",
 				"pretty-quick": "^3.1.3",
 				"sinon": "^13.0.1",
-				"stylelint": "^14.5.3",
+				"stylelint": "^14.6.0",
 				"stylelint-config-prettier": "^9.0.3",
 				"stylelint-config-standard": "^25.0.0",
 				"stylelint-prettier": "^2.0.0",
@@ -50,7 +50,7 @@
 				"node": ">=14"
 			},
 			"optionalDependencies": {
-				"electron": "^17.1.0"
+				"electron": "^17.1.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -648,29 +648,29 @@
 			}
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-			"integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.1.tgz",
+			"integrity": "sha512-/WMkqLYfwCf0waCAMC8Eddt3iAOdghkDF5vmyKEu8pfO66KRFY1L15yks8mfgURiwOAOJpAQ3blvB3Znj6ZwBw==",
 			"dev": true,
 			"dependencies": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.3"
+				"jsdoc-type-pratt-parser": "~2.2.5"
 			},
 			"engines": {
 				"node": "^12 || ^14 || ^16 || ^17"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-			"integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+			"integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.3.1",
 				"globals": "^13.9.0",
-				"ignore": "^4.0.6",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.0.4",
@@ -678,14 +678,6 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/ignore": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
@@ -2201,9 +2193,9 @@
 			}
 		},
 		"node_modules/comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.0.0"
@@ -2432,9 +2424,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dependencies": {
 				"ms": "2.1.2"
 			},
@@ -2657,9 +2649,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"node_modules/electron": {
-			"version": "17.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.0.tgz",
-			"integrity": "sha512-X/qdldmQ8lA15NmeraubWCTtMeTO8K9Ser0wtSCgOXVh53Sr1Ea0VQQ7Q9LuGgWRVz4qtr40cntuEdM8icdmTw==",
+			"version": "17.1.2",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+			"integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -2889,11 +2881,11 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-			"integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
+			"integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
 			"dependencies": {
-				"@eslint/eslintrc": "^1.2.0",
+				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -2940,9 +2932,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
-			"integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"dev": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
@@ -2952,9 +2944,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
-			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.2.tgz",
+			"integrity": "sha512-1bXCoRODPkGN06n9KAMls4Jm0eyS+0Q/LWcIxhqWR2ycV0Z7lnx2c10idk4dtFIJY5xStgiIr5snC6/rxcXpbw==",
 			"dev": true,
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
@@ -2976,14 +2968,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "37.9.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.5.tgz",
-			"integrity": "sha512-g2NHlLauufgQIlJBOxtg8afY+JAFG8lPjq/PGcU+IBpEXvaDs2MLoXJ6uDuv+N85nIt4kYaoZrkce0MANEXLZA==",
+			"version": "38.0.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.0.6.tgz",
+			"integrity": "sha512-Wvh5ERLUL8zt2yLZ8LLgi8RuF2UkjDvD+ri1/i7yMpbfreK2S29B9b5JC7iBIoFR7KDaEWCLnUPHTqgwcXX1Sg==",
 			"dev": true,
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.20.1",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.22.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
 				"regextras": "^0.8.0",
@@ -3795,9 +3787,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "13.12.1",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-			"integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+			"version": "13.13.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+			"integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
 			"dependencies": {
 				"type-fest": "^0.20.2"
 			},
@@ -5302,9 +5294,9 @@
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.3.tgz",
-			"integrity": "sha512-QPyxq62Q8veBSDtDrWmqaEPjSCeknUV9dH/OAGt3q9an8qC8UQDqitQiw1NvoMskIESpoRZ6qzt4H3rlK0xo8A==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0"
@@ -6486,6 +6478,27 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/pixelmatch": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
+			"integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
+			"dev": true,
+			"dependencies": {
+				"pngjs": "^4.0.1"
+			},
+			"bin": {
+				"pixelmatch": "bin/pixelmatch"
+			}
+		},
+		"node_modules/pixelmatch/node_modules/pngjs": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
+			"integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/pkg-dir": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -6499,13 +6512,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.19.2.tgz",
-			"integrity": "sha512-2JmGWr/Iw/Uu27bZULeHgjn8doNrRVxIYdhspMuMlfKNpzwAe/sfm7wH8uey6jiZxnPL4bC5V4ACQcF4dAGWnw==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.20.0.tgz",
+			"integrity": "sha512-YcFXhXttk9yvpc8PMbfvts6KEopXjxdBh47BdOiA7xhjF/gkXeSM0Hs9CSdbL9mp2xtlB5xqE7+D+F2soQOjbA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"playwright-core": "1.19.2"
+				"playwright-core": "1.20.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -6515,17 +6528,19 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.19.2.tgz",
-			"integrity": "sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
+			"integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
 			"dev": true,
 			"dependencies": {
+				"colors": "1.4.0",
 				"commander": "8.3.0",
 				"debug": "4.3.3",
 				"extract-zip": "2.0.1",
 				"https-proxy-agent": "5.0.0",
 				"jpeg-js": "0.4.3",
 				"mime": "3.0.0",
+				"pixelmatch": "5.2.1",
 				"pngjs": "6.0.0",
 				"progress": "2.0.3",
 				"proper-lockfile": "4.1.2",
@@ -6542,6 +6557,23 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/playwright-core/node_modules/debug": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/playwright-core/node_modules/extract-zip": {
@@ -6610,10 +6642,20 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				}
+			],
 			"dependencies": {
 				"nanoid": "^3.3.1",
 				"picocolors": "^1.0.0",
@@ -6621,10 +6663,6 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
 			}
 		},
 		"node_modules/postcss-media-query-parser": {
@@ -6692,15 +6730,18 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-			"integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+			"integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
@@ -7872,9 +7913,9 @@
 			"dev": true
 		},
 		"node_modules/stylelint": {
-			"version": "14.5.3",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
-			"integrity": "sha512-omHETL+kGHR+fCXFK1SkZD/A+emCP9esggAdWEl8GPjTNeyRYj+H6uetRDcU+7E451zwWiUYGVAX+lApsAZgsQ==",
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.6.0.tgz",
+			"integrity": "sha512-Xk2sqXYPi9nXgq70nBiZkbQm/QOOKd83NBTaBE1fXEWAEeRlgHnKC/E7kJFlT6K0SaNDOK5yIvR7GFPGsNLuOg==",
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^2.0.0",
@@ -7902,7 +7943,7 @@
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.6",
+				"postcss": "^8.4.12",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
@@ -9135,37 +9176,30 @@
 			}
 		},
 		"@es-joy/jsdoccomment": {
-			"version": "0.20.1",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.20.1.tgz",
-			"integrity": "sha512-oeJK41dcdqkvdZy/HctKklJNkt/jh+av3PZARrZEl+fs/8HaHeeYoAvEwOV0u5I6bArTF17JEsTZMY359e/nfQ==",
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.22.1.tgz",
+			"integrity": "sha512-/WMkqLYfwCf0waCAMC8Eddt3iAOdghkDF5vmyKEu8pfO66KRFY1L15yks8mfgURiwOAOJpAQ3blvB3Znj6ZwBw==",
 			"dev": true,
 			"requires": {
-				"comment-parser": "1.3.0",
+				"comment-parser": "1.3.1",
 				"esquery": "^1.4.0",
-				"jsdoc-type-pratt-parser": "~2.2.3"
+				"jsdoc-type-pratt-parser": "~2.2.5"
 			}
 		},
 		"@eslint/eslintrc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
-			"integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.1.tgz",
+			"integrity": "sha512-bxvbYnBPN1Gibwyp6NrpnFzA3YtRL3BBAyEAFVIpNTm2Rn4Vy87GA5M4aSn3InRrlsbX5N0GW7XIx+U4SAEKdQ==",
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
 				"espree": "^9.3.1",
 				"globals": "^13.9.0",
-				"ignore": "^4.0.6",
+				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
 				"js-yaml": "^4.1.0",
 				"minimatch": "^3.0.4",
 				"strip-json-comments": "^3.1.1"
-			},
-			"dependencies": {
-				"ignore": {
-					"version": "4.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
-				}
 			}
 		},
 		"@humanwhocodes/config-array": {
@@ -10363,9 +10397,9 @@
 			"dev": true
 		},
 		"comment-parser": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.0.tgz",
-			"integrity": "sha512-hRpmWIKgzd81vn0ydoWoyPoALEOnF4wt8yKD35Ib1D6XC2siLiYaiqfGkYrunuKdsXGwpBpHU3+9r+RVw2NZfA==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.3.1.tgz",
+			"integrity": "sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==",
 			"dev": true
 		},
 		"commondir": {
@@ -10550,9 +10584,9 @@
 			"integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
 		},
 		"debug": {
-			"version": "4.3.3",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"requires": {
 				"ms": "2.1.2"
 			}
@@ -10724,9 +10758,9 @@
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
 		},
 		"electron": {
-			"version": "17.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.0.tgz",
-			"integrity": "sha512-X/qdldmQ8lA15NmeraubWCTtMeTO8K9Ser0wtSCgOXVh53Sr1Ea0VQQ7Q9LuGgWRVz4qtr40cntuEdM8icdmTw==",
+			"version": "17.1.2",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
+			"integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
 			"optional": true,
 			"requires": {
 				"@electron/get": "^1.13.0",
@@ -10891,11 +10925,11 @@
 			}
 		},
 		"eslint": {
-			"version": "8.10.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
-			"integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+			"version": "8.11.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
+			"integrity": "sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==",
 			"requires": {
-				"@eslint/eslintrc": "^1.2.0",
+				"@eslint/eslintrc": "^1.2.1",
 				"@humanwhocodes/config-array": "^0.9.2",
 				"ajv": "^6.10.0",
 				"chalk": "^4.0.0",
@@ -10933,30 +10967,30 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.4.0.tgz",
-			"integrity": "sha512-CFotdUcMY18nGRo5KGsnNxpznzhkopOcOo0InID+sgQssPrzjvsyKZPvOgymTFeHrFuC3Tzdf2YndhXtULK9Iw==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
 			"dev": true,
 			"requires": {}
 		},
 		"eslint-plugin-jest": {
-			"version": "26.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.1.tgz",
-			"integrity": "sha512-HRKOuPi5ADhza4ZBK5ufyNXy28bXXkib87w+pQqdvBhSTsamndh6sIAKPAUl8y0/n9jSWBdTPslrwtKWqkp8dA==",
+			"version": "26.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.1.2.tgz",
+			"integrity": "sha512-1bXCoRODPkGN06n9KAMls4Jm0eyS+0Q/LWcIxhqWR2ycV0Z7lnx2c10idk4dtFIJY5xStgiIr5snC6/rxcXpbw==",
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/utils": "^5.10.0"
 			}
 		},
 		"eslint-plugin-jsdoc": {
-			"version": "37.9.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.5.tgz",
-			"integrity": "sha512-g2NHlLauufgQIlJBOxtg8afY+JAFG8lPjq/PGcU+IBpEXvaDs2MLoXJ6uDuv+N85nIt4kYaoZrkce0MANEXLZA==",
+			"version": "38.0.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-38.0.6.tgz",
+			"integrity": "sha512-Wvh5ERLUL8zt2yLZ8LLgi8RuF2UkjDvD+ri1/i7yMpbfreK2S29B9b5JC7iBIoFR7KDaEWCLnUPHTqgwcXX1Sg==",
 			"dev": true,
 			"requires": {
-				"@es-joy/jsdoccomment": "~0.20.1",
-				"comment-parser": "1.3.0",
-				"debug": "^4.3.3",
+				"@es-joy/jsdoccomment": "~0.22.1",
+				"comment-parser": "1.3.1",
+				"debug": "^4.3.4",
 				"escape-string-regexp": "^4.0.0",
 				"esquery": "^1.4.0",
 				"regextras": "^0.8.0",
@@ -11575,9 +11609,9 @@
 			}
 		},
 		"globals": {
-			"version": "13.12.1",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-			"integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+			"version": "13.13.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
+			"integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
 			"requires": {
 				"type-fest": "^0.20.2"
 			}
@@ -12722,9 +12756,9 @@
 			}
 		},
 		"jsdoc-type-pratt-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.3.tgz",
-			"integrity": "sha512-QPyxq62Q8veBSDtDrWmqaEPjSCeknUV9dH/OAGt3q9an8qC8UQDqitQiw1NvoMskIESpoRZ6qzt4H3rlK0xo8A==",
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
+			"integrity": "sha512-2a6eRxSxp1BW040hFvaJxhsCMI9lT8QB8t14t+NY5tC5rckIR0U9cr2tjOeaFirmEOy6MHvmJnY7zTBHq431Lw==",
 			"dev": true
 		},
 		"jsdom": {
@@ -13640,6 +13674,23 @@
 			"integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
 			"dev": true
 		},
+		"pixelmatch": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
+			"integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
+			"dev": true,
+			"requires": {
+				"pngjs": "^4.0.1"
+			},
+			"dependencies": {
+				"pngjs": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
+					"integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==",
+					"dev": true
+				}
+			}
+		},
 		"pkg-dir": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -13650,26 +13701,28 @@
 			}
 		},
 		"playwright": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.19.2.tgz",
-			"integrity": "sha512-2JmGWr/Iw/Uu27bZULeHgjn8doNrRVxIYdhspMuMlfKNpzwAe/sfm7wH8uey6jiZxnPL4bC5V4ACQcF4dAGWnw==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.20.0.tgz",
+			"integrity": "sha512-YcFXhXttk9yvpc8PMbfvts6KEopXjxdBh47BdOiA7xhjF/gkXeSM0Hs9CSdbL9mp2xtlB5xqE7+D+F2soQOjbA==",
 			"dev": true,
 			"requires": {
-				"playwright-core": "1.19.2"
+				"playwright-core": "1.20.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.19.2.tgz",
-			"integrity": "sha512-OsL3sJZIo1UxKNWSP7zW7sk3FyUGG06YRHxHeBw51eIOxTCQRx5t+hXd0cvXashN2CHnd3hIZTs2aKa/im4hZQ==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.20.0.tgz",
+			"integrity": "sha512-d25IRcdooS278Cijlp8J8A5fLQZ+/aY3dKRJvgX5yjXA69N0huIUdnh3xXSgn+LsQ9DCNmB7Ngof3eY630jgdA==",
 			"dev": true,
 			"requires": {
+				"colors": "1.4.0",
 				"commander": "8.3.0",
 				"debug": "4.3.3",
 				"extract-zip": "2.0.1",
 				"https-proxy-agent": "5.0.0",
 				"jpeg-js": "0.4.3",
 				"mime": "3.0.0",
+				"pixelmatch": "5.2.1",
 				"pngjs": "6.0.0",
 				"progress": "2.0.3",
 				"proper-lockfile": "4.1.2",
@@ -13682,6 +13735,15 @@
 				"yazl": "2.5.1"
 			},
 			"dependencies": {
+				"debug": {
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
 				"extract-zip": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -13719,9 +13781,9 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.7",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
-			"integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
+			"version": "8.4.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.12.tgz",
+			"integrity": "sha512-lg6eITwYe9v6Hr5CncVbK70SoioNQIq81nsaG86ev5hAidQvmOeETBqs7jm43K2F5/Ley3ytDtriImV6TpNiSg==",
 			"dev": true,
 			"requires": {
 				"nanoid": "^3.3.1",
@@ -13776,9 +13838,9 @@
 			"optional": true
 		},
 		"prettier": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-			"integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+			"integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -14675,9 +14737,9 @@
 			"dev": true
 		},
 		"stylelint": {
-			"version": "14.5.3",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.5.3.tgz",
-			"integrity": "sha512-omHETL+kGHR+fCXFK1SkZD/A+emCP9esggAdWEl8GPjTNeyRYj+H6uetRDcU+7E451zwWiUYGVAX+lApsAZgsQ==",
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.6.0.tgz",
+			"integrity": "sha512-Xk2sqXYPi9nXgq70nBiZkbQm/QOOKd83NBTaBE1fXEWAEeRlgHnKC/E7kJFlT6K0SaNDOK5yIvR7GFPGsNLuOg==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^2.0.0",
@@ -14705,7 +14767,7 @@
 				"normalize-path": "^3.0.0",
 				"normalize-selector": "^0.2.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.6",
+				"postcss": "^8.4.12",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
 	},
 	"homepage": "https://magicmirror.builders",
 	"devDependencies": {
-		"eslint-config-prettier": "^8.4.0",
-		"eslint-plugin-jest": "^26.1.1",
-		"eslint-plugin-jsdoc": "^37.9.5",
+		"eslint-config-prettier": "^8.5.0",
+		"eslint-plugin-jest": "^26.1.2",
+		"eslint-plugin-jsdoc": "^38.0.6",
 		"eslint-plugin-prettier": "^4.0.0",
 		"express-basic-auth": "^1.2.1",
 		"husky": "^7.0.4",
@@ -57,24 +57,24 @@
 		"jsdom": "^19.0.0",
 		"lodash": "^4.17.21",
 		"nyc": "^15.1.0",
-		"playwright": "^1.19.2",
-		"prettier": "^2.5.1",
+		"playwright": "^1.20.0",
+		"prettier": "^2.6.0",
 		"pretty-quick": "^3.1.3",
 		"sinon": "^13.0.1",
-		"stylelint": "^14.5.3",
+		"stylelint": "^14.6.0",
 		"stylelint-config-prettier": "^9.0.3",
 		"stylelint-config-standard": "^25.0.0",
 		"stylelint-prettier": "^2.0.0",
 		"suncalc": "^1.9.0"
 	},
 	"optionalDependencies": {
-		"electron": "^17.1.0"
+		"electron": "^17.1.2"
 	},
 	"dependencies": {
 		"colors": "^1.4.0",
 		"console-stamp": "^3.0.4",
 		"digest-fetch": "^1.2.1",
-		"eslint": "^8.10.0",
+		"eslint": "^8.11.0",
 		"express": "^4.17.3",
 		"express-ipfilter": "^1.2.0",
 		"feedme": "^2.0.2",

--- a/vendor/package-lock.json
+++ b/vendor/package-lock.json
@@ -7,18 +7,18 @@
 			"name": "magicmirror-vendors",
 			"license": "MIT",
 			"dependencies": {
-				"@fortawesome/fontawesome-free": "^5.15.4",
+				"@fortawesome/fontawesome-free": "^6.1.1",
 				"moment": "^2.29.1",
 				"moment-timezone": "^0.5.34",
 				"nunjucks": "^3.2.3",
-				"suncalc": "^1.8.0",
+				"suncalc": "^1.9.0",
 				"weathericons": "^2.1.0"
 			}
 		},
 		"node_modules/@fortawesome/fontawesome-free": {
-			"version": "5.15.4",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
-			"integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+			"integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg==",
 			"hasInstallScript": true,
 			"engines": {
 				"node": ">=6"
@@ -86,9 +86,9 @@
 			}
 		},
 		"node_modules/suncalc": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.8.0.tgz",
-			"integrity": "sha1-HZiYEJVjB4dQ9JlKlZ5lTYdqy/U="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+			"integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
 		},
 		"node_modules/weathericons": {
 			"version": "2.1.0",
@@ -98,9 +98,9 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": {
-			"version": "5.15.4",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.15.4.tgz",
-			"integrity": "sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg=="
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.1.tgz",
+			"integrity": "sha512-J/3yg2AIXc9wznaVqpHVX3Wa5jwKovVF0AMYSnbmcXTiL3PpRPfF58pzWucCwEiCJBp+hCNRLWClTomD8SseKg=="
 		},
 		"a-sync-waterfall": {
 			"version": "1.0.1",
@@ -141,9 +141,9 @@
 			}
 		},
 		"suncalc": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.8.0.tgz",
-			"integrity": "sha1-HZiYEJVjB4dQ9JlKlZ5lTYdqy/U="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+			"integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
 		},
 		"weathericons": {
 			"version": "2.1.0",

--- a/vendor/package.json
+++ b/vendor/package.json
@@ -10,11 +10,11 @@
 		"url": "https://github.com/MichMich/MagicMirror/issues"
 	},
 	"dependencies": {
-		"@fortawesome/fontawesome-free": "^5.15.4",
+		"@fortawesome/fontawesome-free": "^6.1.1",
 		"moment": "^2.29.1",
 		"moment-timezone": "^0.5.34",
 		"nunjucks": "^3.2.3",
-		"suncalc": "^1.8.0",
+		"suncalc": "^1.9.0",
 		"weathericons": "^2.1.0"
 	}
 }


### PR DESCRIPTION
Fixes #2812 

Windspeed conversion to kmh should happen only when displaying it in the njk. Internally the windspeed should be the m/s (metric)

The provider did convert it twice: once when loading the data from the api and then again when displaying it.