### PR TITLE
toggle pointer-events with suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ _This release is scheduled to be released on 2022-04-01._
 
 - Added a config option under the weather module, absoluteDates, providing an option to format weather forecast date output with either absolute or relative dates.
 - Added test for new weather forecast absoluteDates porperty.
-- The modules get a class hidden added/removed if they get hidden/shown
+- The modules get a class hidden added/removed if they get hidden/shown which will also toggle pointer-events.
 - Added new config option `showTitleAsUrl` to newsfeed module. If set, the diplayed title is a link to the article which is useful when running in a browser and you want to read this article.
 - Added internal cors proxy to get weather providers working without public proxies (fixes #2714). The new url `http(s)://address:port/cors?url=https://whatever-to-proxy` can be used in other modules too.
 - Added a WeatherProvider for Weatherflow

--- a/css/main.css
+++ b/css/main.css
@@ -138,6 +138,14 @@ sup {
   margin-bottom: var(--gap-modules);
 }
 
+.module.hidden {
+  pointer-events: none;
+}
+
+.module:not(.hidden) {
+  pointer-events: auto;
+}
+
 .region.bottom .module {
   margin-top: var(--gap-modules);
   margin-bottom: 0;
@@ -168,10 +176,6 @@ sup {
   right: calc(-1 * var(--gap-body-right));
   bottom: calc(-1 * var(--gap-body-bottom));
   pointer-events: none;
-}
-
-.region.fullscreen * {
-  pointer-events: auto;
 }
 
 .region.right {


### PR DESCRIPTION
Hi,

I added two classes for the hidden/visible modules to toggle the pointer-events with the new `.hidden` class.
Further I removed the one with the universal selector, which made hidden modules and just anything in them stealing pointer events, if they were placed in any fullscreen area.
