### PR TITLE
fix newsfeedfetcher using correct stream version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ _This release is scheduled to be released on 2022-07-01._
 
 - Use latest node 18 when running tests on github actions
 - Update `electron` to v19 and other dependencies.
-- Use internal fetch function of node instead external `node-fetch` library if node version >= `v18`.
+- Use internal fetch function of node instead external `node-fetch` library if used node version >= `v18`.
 
 ### Fixed
 

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -9,6 +9,7 @@ const FeedMe = require("feedme");
 const NodeHelper = require("node_helper");
 const fetch = require("fetch");
 const iconv = require("iconv-lite");
+const stream = require("stream");
 
 /**
  * Responsible for requesting an update on the set interval and broadcasting the data.
@@ -87,7 +88,13 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 		fetch(url, { headers: headers })
 			.then(NodeHelper.checkFetchStatus)
 			.then((response) => {
-				response.body.pipe(iconv.decodeStream(encoding)).pipe(parser);
+				let nodeStream;
+				if (response.body instanceof stream.Readable) {
+					nodeStream = response.body;
+				} else {
+					nodeStream = stream.Readable.fromWeb(response.body);
+				}
+				nodeStream.pipe(iconv.decodeStream(encoding)).pipe(parser);
 			})
 			.catch((error) => {
 				fetchFailedCallback(this, error);


### PR DESCRIPTION
correction for https://github.com/MichMich/MagicMirror/pull/2855

The stream format has changed in the node-internal fetch method which breaks the newsfeed module (when using node 18).