### PR TITLE
Include duplicate events in broadcasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ _This release is scheduled to be released on 2022-07-01._
 - Use latest node 18 when running tests on github actions
 - Update `electron` to v19 and other dependencies.
 - Use internal fetch function of node instead external `node-fetch` library if used node version >= `v18`.
+- Include duplicate events in broadcasts.
 
 ### Fixed
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -510,7 +510,7 @@ Module.register("calendar", {
 						continue;
 					}
 				}
-				if (this.listContainsEvent(events, event)) {
+				if (this.listContainsEvent(events, event) && limitNumberOfEntries) {
 					continue;
 				}
 				event.url = calendarUrl;


### PR DESCRIPTION
Event deduplication based on event title and start date should only apply to displayed events, and not to broadcasts.  This is a regression from #2787.