### PR TITLE
Fix maximumEntries regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Special thanks to the following contributors: @10bias, @CFenner, @JHWelch, @k1rd
 - Don't adjust startDate for full day events if endDate is in the past.
 - Fix windspeed conversion error in openweathermap provider. (#2812)
 - Fix conflicting parms turning off showEnd for full day events. (#2629)
+- Fix regression, calendar.maximumEntries not used to filter calendar level entries (#2868)
 
 ## [2.18.0] - 2022-01-01
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -498,7 +498,8 @@ const CalendarUtils = {
 			return a.startDate - b.startDate;
 		});
 
-		return newEvents;
+		let maxEvents=newEvents.slice(0,config.maximumEntries)
+		return maxEvents;
 	},
 
 	/**

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -498,7 +498,7 @@ const CalendarUtils = {
 			return a.startDate - b.startDate;
 		});
 
-		let maxEvents=newEvents.slice(0,config.maximumEntries)
+		let maxEvents = newEvents.slice(0, config.maximumEntries);
 		return maxEvents;
 	},
 


### PR DESCRIPTION
calendar.maximumEntries not used per doc

Fixes #2868


