### PR TITLE
Broadcast all calendar events while still honoring global and per-calendar maximumEntries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ _This release is scheduled to be released on 2022-10-01._
 
 ## Fixed
 
+- Broadcast all calendar events while still honoring global and per-calendar maximumEntries.
+
 ## [2.20.0] - 2022-07-02
 
 Special thanks to the following contributors: @eouia, @khassel, @kolbyjack, @KristjanESPERANTO, @nathannaveen, @naveensrinivasan, @rejas, @rohitdharavath and @sdetweil.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -493,6 +493,7 @@ Module.register("calendar", {
 
 		for (const calendarUrl in this.calendarData) {
 			const calendar = this.calendarData[calendarUrl];
+			let remainingEntries = this.maximumEntriesForUrl(calendarUrl);
 			for (const e in calendar) {
 				const event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 
@@ -509,6 +510,9 @@ Module.register("calendar", {
 					}
 					if (this.listContainsEvent(events, event)) {
 						continue;
+					}
+					if (--remainingEntries < 0) {
+						break;
 					}
 				}
 				event.url = calendarUrl;
@@ -716,6 +720,16 @@ Module.register("calendar", {
 	 */
 	countTitleForUrl: function (url) {
 		return this.getCalendarProperty(url, "repeatingCountTitle", this.config.defaultRepeatingCountTitle);
+	},
+
+	/**
+	 * Retrieves the maximum entry count for a specific calendar url.
+	 *
+	 * @param {string} url The calendar url
+	 * @returns {int} The maximum entry count
+	 */
+	maximumEntriesForUrl: function (url) {
+		return this.getCalendarProperty(url, "maximumEntries", this.config.maximumEntries);
 	},
 
 	/**

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -498,8 +498,7 @@ const CalendarUtils = {
 			return a.startDate - b.startDate;
 		});
 
-		let maxEvents = newEvents.slice(0, config.maximumEntries);
-		return maxEvents;
+		return newEvents;
 	},
 
 	/**


### PR DESCRIPTION
My previous PR [2787](https://github.com/MichMich/MagicMirror/pull/2787) didn't account for per-calendar `maximumEntries` configuration.  Update `createEventList` to read the configuration value and only add the proper number of events when limiting the result.
