### PR TITLE
English doesn't have a "day after tomorrow" word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _This release is scheduled to be released on 2022-10-01._
 
 ## Updated
 
+- Removed DAYAFTERTOMORROW from English
+
 ## Fixed
 
 - Broadcast all calendar events while still honoring global and per-calendar maximumEntries.

--- a/tests/e2e/translations_spec.js
+++ b/tests/e2e/translations_spec.js
@@ -164,7 +164,7 @@ describe("Translations", function () {
 			dom.window.onload = function () {
 				const { Translator } = dom.window;
 
-				Translator.load(mmm, translations.en, false, function () {
+				Translator.load(mmm, translations.de, false, function () {
 					base = Object.keys(Translator.translations[mmm.name]).sort();
 					done();
 				});
@@ -175,8 +175,10 @@ describe("Translations", function () {
 			console.log(missing);
 		});
 
+		// Using German as the base rather than English, since
+		// at least one translated word doesn't exist in English.
 		for (let language in translations) {
-			if (language === "en") {
+			if (language === "de") {
 				continue;
 			}
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -3,7 +3,6 @@
 
 	"TODAY": "Today",
 	"TOMORROW": "Tomorrow",
-	"DAYAFTERTOMORROW": "In 2 days",
 	"RUNNING": "Ends in",
 	"EMPTY": "No upcoming events.",
 	"WEEK": "Week {weekNumber}",


### PR DESCRIPTION
English doesn't have a word for the day after the day after today.  "In 2 days" doesn't align with the behavior around `relative` formatting for non-full-day events -- that uses "today," "tomorrow," and then goes to days of the week.

Having played around with different formats, I've concluded that "In 2 days" is an odd-ball that shows up here only(?) for English.  Many languages have a word for that; obviously the code should continue to accommodate those languages.

The simplest "fix" then is simply to drop this term from `en.json`, as the code already handles the `DAYAFTERTOMORROW` field not being defined for a given language.  So let's just let English be such a language.