### PR TITLE
Show time today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ _This release is scheduled to be released on 2022-10-01._
 
 ## Added
 
+- New `showTimeToday` option in calendar module shows time for current-day
+  events even if `timeFormat` is `"relative"`
+
 ## Updated
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ _This release is scheduled to be released on 2022-10-01._
 
 ## Added
 
-- New `showTimeToday` option in calendar module shows time for current-day
-  events even if `timeFormat` is `"relative"`
+- New `showTimeToday` option in calendar module shows time for current-day events even if `timeFormat` is `"relative"`
 
 ## Updated
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -37,6 +37,7 @@ Module.register("calendar", {
 		hidePrivate: false,
 		hideOngoing: false,
 		hideTime: false,
+		showTimeToday: false,
 		colored: false,
 		coloredSymbolOnly: false,
 		customEvents: [], // Array of {keyword: "", symbol: "", color: ""} where Keyword is a regexp and symbol/color are to be applied for matched
@@ -368,7 +369,7 @@ Module.register("calendar", {
 						} else {
 							timeWrapper.innerHTML = this.capFirst(
 								moment(event.startDate, "x").calendar(null, {
-									sameDay: "[" + this.translate("TODAY") + "]",
+									sameDay: this.config.showTimeToday ? "LT" : "[" + this.translate("TODAY") + "]",
 									nextDay: "[" + this.translate("TOMORROW") + "]",
 									nextWeek: "dddd",
 									sameElse: event.fullDayEvent ? this.config.fullDayEventDateFormat : this.config.dateFormat


### PR DESCRIPTION
When I was trying to move to the "relative" timeFormat, I found that while relative was useful for events that were approaching -- the baseball game is on Saturday, etc. -- present-day events in relative format were at best annoying.

This adds an additional option that displays non-full-day events with an absolute time on the current day, while leaving the relative behavior alone for other days.  (Full-day events continue to display "Today".)