### PR TITLE
Make the calendar show the whole multi day event with how far it has progressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2022-10-01._
 
 - Broadcast all calendar events while still honoring global and per-calendar maximumEntries.
 - Respect rss ttl provided by newsfeed (#2883).
+- Fix multi day calendar events always presented as "(1/X)" instead of the amount of days the event has progressed.
 
 ## [2.20.0] - 2022-07-02
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -469,10 +469,6 @@ const CalendarUtils = {
 						return;
 					}
 
-					// Adjust start date so multiple day events will be displayed as happening today even though they started some days ago already
-					if (fullDayEvent && startDate <= today && endDate > today) {
-						startDate = moment(today);
-					}
 					// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)
 					if (fullDayEvent && startDate.format("x") === endDate.format("x")) {
 						endDate = endDate.endOf("day");


### PR DESCRIPTION
Made an attempt to debug issue https://github.com/MichMich/MagicMirror/issues/2685 and couldn't really find a reason to why multi day events had their start date changed to the current date. So I tried to remove it and made comparisons with and without it, using sliceMultiDayEvents=true/false.

|| sliceMultiDayEvents=false | sliceMultiDayEvents=true |
|-|------------------------------------|-----------------------------------|
|**startDate=today**| Vacation - Today | Vacation (1/13) - Today |
|**Don't modify startDate**| Vacation - Ends in 12 days | Vacation (25/37) - Today |

It feels like it's wrong with sliceMultiDayEvents=true without this pull request, but since it changes the other one from "Today" to "Ends in 12 days" there might be something more that is needed to be changed? Both looks fine for me at least.