### PR TITLE
Use type value in weatherbit provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2022-10-01._
 - Broadcast all calendar events while still honoring global and per-calendar maximumEntries.
 - Respect rss ttl provided by newsfeed (#2883).
 - Fix multi day calendar events always presented as "(1/X)" instead of the amount of days the event has progressed.
+- Fix weatherbit provider to use type config value instead of endpoint
 
 ## [2.20.0] - 2022-07-02
 
@@ -32,8 +33,8 @@ Special thanks to the following contributors: @eouia, @khassel, @kolbyjack, @Kri
 
 - Added a new config option `httpHeaders` used by helmet (see https://helmetjs.github.io/). You can now set own httpHeaders which will override the defaults in `js/defauls.js` which is useful e.g. if you want to embed MagicMirror into annother website (solves #2847).
 - Show endDate for calendar events when dateHeader is enabled and showEnd is set to true (#2192).
-- Added the notification emitting from the weather module on infromation updated.
-- Use recommended file extention for YAML files (#2864).
+- Added the notification emitting from the weather module on information updated.
+- Use recommended file extension for YAML files (#2864).
 
 ### Updated
 

--- a/modules/default/weather/providers/weatherbit.js
+++ b/modules/default/weather/providers/weatherbit.js
@@ -69,6 +69,31 @@ WeatherProvider.register("weatherbit", {
 			.finally(() => this.updateAvailable());
 	},
 
+	/**
+	 * Overrides method for setting config to check if endpoint is correct for hourly
+	 *
+	 * @param {object} config The configuration object
+	 */
+	setConfig(config) {
+		this.config = config;
+		if (!this.config.weatherEndpoint) {
+			switch (this.config.type) {
+				case "hourly":
+					this.config.weatherEndpoint = "/forecast/hourly";
+					break;
+				case "daily":
+				case "forecast":
+					this.config.weatherEndpoint = "/forecast/daily";
+					break;
+				case "current":
+					this.config.weatherEndpoint = "/current";
+					break;
+				default:
+					Log.error("weatherEndpoint not configured and could not resolve it based on type");
+			}
+		}
+	},
+
 	// Create a URL from the config and base URL.
 	getUrl() {
 		const units = this.units[this.config.units] || "auto";

--- a/modules/default/weather/providers/weatherbit.js
+++ b/modules/default/weather/providers/weatherbit.js
@@ -18,7 +18,6 @@ WeatherProvider.register("weatherbit", {
 	// Set the default config properties that is specific to this provider
 	defaults: {
 		apiBase: "https://api.weatherbit.io/v2.0",
-		weatherEndpoint: "/current",
 		apiKey: "",
 		lat: 0,
 		lon: 0


### PR DESCRIPTION
... which is the documented way of configuring a provider instead of relying on undocumented weatherEndpoint param.

Fixes #2899