### PR TITLE
Fixcal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ _This release is scheduled to be released on 2022-10-01._
 - Respect rss ttl provided by newsfeed (#2883).
 - Fix multi day calendar events always presented as "(1/X)" instead of the amount of days the event has progressed.
 - Fix weatherbit provider to use type config value instead of endpoint
+- Fix calendar events which DO NOT specify rrule byday adjusted incorrectly #2885 
 
 ## [2.20.0] - 2022-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ _This release is scheduled to be released on 2022-10-01._
 - Respect rss ttl provided by newsfeed (#2883).
 - Fix multi day calendar events always presented as "(1/X)" instead of the amount of days the event has progressed.
 - Fix weatherbit provider to use type config value instead of endpoint
-- Fix calendar events which DO NOT specify rrule byday adjusted incorrectly #2885 
+- Fix calendar events which DO NOT specify rrule byday adjusted incorrectly #2885
 
 ## [2.20.0] - 2022-07-02
 

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -333,9 +333,9 @@ const CalendarUtils = {
 							// If the offset is negative (east of GMT), where the problem is
 							if (dateoffset < 0) {
 								if (dh < Math.abs(dateoffset / 60)) {
-									// if the rrule byweekday WAS explicitly set , correct it									
+									// if the rrule byweekday WAS explicitly set , correct it
 									// reduce the time by the offset
-									if(curEvent.rrule.origOptions.byweekday !== undefined){									
+									if (curEvent.rrule.origOptions.byweekday !== undefined) {
 										// Apply the correction to the date/time to get it UTC relative
 										date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
 									}
@@ -350,8 +350,8 @@ const CalendarUtils = {
 								// if the date hour is less than the offset
 								if (24 - dh <= Math.abs(dateoffset / 60)) {
 									// if the rrule byweekday WAS explicitly set , correct it
-									if(curEvent.rrule.origOptions.byweekday !== undefined){
-										if(curEvent.rrule.origOptions.byweekday !== undefined){
+									if (curEvent.rrule.origOptions.byweekday !== undefined) {
+										if (curEvent.rrule.origOptions.byweekday !== undefined) {
 											// apply the correction to the date/time back to right day
 											date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
 										}
@@ -370,7 +370,7 @@ const CalendarUtils = {
 								// if the date hour is less than the offset
 								if (dh <= Math.abs(dateoffset / 60)) {
 									// if the rrule byweekday WAS explicitly set , correct it
-									if(curEvent.rrule.origOptions.byweekday !== undefined){
+									if (curEvent.rrule.origOptions.byweekday !== undefined) {
 										// Reduce the time by t:
 										// Apply the correction to the date/time to get it UTC relative
 										date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
@@ -386,7 +386,7 @@ const CalendarUtils = {
 								// if the date hour is less than the offset
 								if (24 - dh <= Math.abs(dateoffset / 60)) {
 									// if the rrule byweekday WAS explicitly set , correct it
-									if(curEvent.rrule.origOptions.byweekday !== undefined){									
+									if (curEvent.rrule.origOptions.byweekday !== undefined) {
 										// apply the correction to the date/time back to right day
 										date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
 									}

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -351,10 +351,8 @@ const CalendarUtils = {
 								if (24 - dh <= Math.abs(dateoffset / 60)) {
 									// if the rrule byweekday WAS explicitly set , correct it
 									if (curEvent.rrule.origOptions.byweekday !== undefined) {
-										if (curEvent.rrule.origOptions.byweekday !== undefined) {
-											// apply the correction to the date/time back to right day
-											date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
-										}
+										// apply the correction to the date/time back to right day
+										date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
 									}
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry

--- a/modules/default/calendar/calendarutils.js
+++ b/modules/default/calendar/calendarutils.js
@@ -333,9 +333,12 @@ const CalendarUtils = {
 							// If the offset is negative (east of GMT), where the problem is
 							if (dateoffset < 0) {
 								if (dh < Math.abs(dateoffset / 60)) {
+									// if the rrule byweekday WAS explicitly set , correct it									
 									// reduce the time by the offset
-									// Apply the correction to the date/time to get it UTC relative
-									date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
+									if(curEvent.rrule.origOptions.byweekday !== undefined){									
+										// Apply the correction to the date/time to get it UTC relative
+										date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
+									}
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry
 									//duration = 24 * 60 * 60 * 1000;
@@ -346,8 +349,13 @@ const CalendarUtils = {
 								//if (event.start.tz === moment.tz.guess()) {
 								// if the date hour is less than the offset
 								if (24 - dh <= Math.abs(dateoffset / 60)) {
-									// apply the correction to the date/time back to right day
-									date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
+									// if the rrule byweekday WAS explicitly set , correct it
+									if(curEvent.rrule.origOptions.byweekday !== undefined){
+										if(curEvent.rrule.origOptions.byweekday !== undefined){
+											// apply the correction to the date/time back to right day
+											date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
+										}
+									}
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry
 									//duration = 24 * 60 * 60 * 1000;
@@ -361,9 +369,12 @@ const CalendarUtils = {
 							if (dateoffset < 0) {
 								// if the date hour is less than the offset
 								if (dh <= Math.abs(dateoffset / 60)) {
-									// Reduce the time by the offset:
-									// Apply the correction to the date/time to get it UTC relative
-									date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
+									// if the rrule byweekday WAS explicitly set , correct it
+									if(curEvent.rrule.origOptions.byweekday !== undefined){
+										// Reduce the time by t:
+										// Apply the correction to the date/time to get it UTC relative
+										date = new Date(date.getTime() - Math.abs(24 * 60) * 60000);
+									}
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry
 									//duration = 24 * 60 * 60 * 1000;
@@ -374,8 +385,11 @@ const CalendarUtils = {
 								//if (event.start.tz === moment.tz.guess()) {
 								// if the date hour is less than the offset
 								if (24 - dh <= Math.abs(dateoffset / 60)) {
-									// apply the correction to the date/time back to right day
-									date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
+									// if the rrule byweekday WAS explicitly set , correct it
+									if(curEvent.rrule.origOptions.byweekday !== undefined){									
+										// apply the correction to the date/time back to right day
+										date = new Date(date.getTime() + Math.abs(24 * 60) * 60000);
+									}
 									// the duration was calculated way back at the top before we could correct the start time..
 									// fix it for this event entry
 									//duration = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
rrule and luxon miscalculate event day when byday is specified, but NOT without. 

correct adjustment in calendarutils.js to adjust only when byday is specified

fixes: #2885
