### PR TITLE
Ongoing multi-day events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _This release is scheduled to be released on 2022-10-01._
 - Fix weatherbit provider to use type config value instead of endpoint
 - Fix calendar events which DO NOT specify rrule byday adjusted incorrectly #2885
 - Fix e2e tests not failing on errors (#2911)
+- Ongoing multi-day events display time until end instead of "Today"
 
 ## [2.20.0] - 2022-07-02
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -366,7 +366,7 @@ Module.register("calendar", {
 					}
 				} else {
 					// Show relative times
-					if (event.startDate >= now || (event.fullDayEvent && event.today)) {
+					if (event.startDate >= now || (event.fullDayEvent && event.today && !event.multiDay)) {
 						// Use relative  time
 						if (!this.config.hideTime && !event.fullDayEvent) {
 							timeWrapper.innerHTML = this.capFirst(moment(event.startDate, "x").calendar(null, { sameElse: this.config.dateFormat }));
@@ -527,7 +527,8 @@ Module.register("calendar", {
 				 * otherwise, esp. in dateheaders mode it is not clear how long these events are.
 				 */
 				const maxCount = Math.ceil((event.endDate - 1 - moment(event.startDate, "x").endOf("day").format("x")) / (1000 * 60 * 60 * 24)) + 1;
-				if (this.config.sliceMultiDayEvents && maxCount > 1) {
+				event.multiDay = maxCount > 1 ? true : false;
+				if (this.config.sliceMultiDayEvents && event.multiDay) {
 					const splitEvents = [];
 					let midnight = moment(event.startDate, "x").clone().startOf("day").add(1, "day").format("x");
 					let count = 1;


### PR DESCRIPTION
This adds a `multiDay` flag to events, so that multi-day events can be treated slightly differently.  In the current code, ongoing multi-day events always occur "Today".  This code excludes multi-day events from that code block, causing them to fall down into the ongoing event code.  That renders them as "Ends in X days" until the last day of the multi-day event, then renders them as "Ends in X hours".

My preference would have been to reuse the code at line ~402 to get "Ends Today", "Ends Tomorrow", "Ends Thursday", etc. but the string in the translations file in "Ends in {time}" and I wasn't able to massage Moment to produce something that looks right without getting into multi-language world. Maybe an area for future work.