### PR TITLE
fix(weather/smhi) Correctly reference apparent temp method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _This release is scheduled to be released on 2023-01-01._
 
 ### Fixed
 
+- Correctly show apparent temperature in SMHI weather provider
+
 ## [2.21.0] - 2022-10-01
 
 Special thanks to: @BKeyport, @buxxi, @davide125, @khassel, @kolbyjack, @krukle, @MikeBishop, @rejas, @sdetweil, @SkySails and @veeck

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -144,7 +144,7 @@ WeatherProvider.register("smhi", {
 		currentWeather.windSpeed = this.paramValue(weatherData, "ws");
 		currentWeather.windDirection = this.paramValue(weatherData, "wd");
 		currentWeather.weatherType = this.convertWeatherType(this.paramValue(weatherData, "Wsymb2"), currentWeather.isDayTime());
-		currentWeather.feelsLikeTemp = this.calculateAT(weatherData);
+		currentWeather.feelsLikeTemp = this.calculateApparentTemperature(weatherData);
 
 		// Determine the precipitation amount and category and update the
 		// weatherObject with it, the valuetype to use can be configured or uses


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/MichMich/MagicMirror/commit/48756e877403d914c64c8da06a4f7e5bfbace07c#commitcomment-85772193), which points out an issue with #2902.

Looks like the apparent temp calculation method was incorrectly referenced 😅 