### PR TITLE
replace imports with new aliases

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -5,9 +5,6 @@
  * MIT Licensed.
  */
 
-// Alias modules mentioned in package.js under _moduleAliases.
-// require("module-alias/register");
-
 const fs = require("fs");
 const path = require("path");
 const Log = require("#logger");

--- a/js/app.js
+++ b/js/app.js
@@ -6,11 +6,11 @@
  */
 
 // Alias modules mentioned in package.js under _moduleAliases.
-require("module-alias/register");
+// require("module-alias/register");
 
 const fs = require("fs");
 const path = require("path");
-const Log = require("logger");
+const Log = require("#logger");
 const Server = require(`${__dirname}/server`);
 const Utils = require(`${__dirname}/utils`);
 const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`);

--- a/js/electron.js
+++ b/js/electron.js
@@ -2,7 +2,7 @@
 
 const electron = require("electron");
 const core = require("./app.js");
-const Log = require("logger");
+const Log = require("#logger");
 
 // Config
 let config = process.env.config ? JSON.parse(process.env.config) : {};

--- a/js/node_helper.js
+++ b/js/node_helper.js
@@ -5,7 +5,7 @@
  * MIT Licensed.
  */
 const Class = require("./class.js");
-const Log = require("logger");
+const Log = require("#logger");
 const express = require("express");
 
 const NodeHelper = Class.extend({

--- a/js/server.js
+++ b/js/server.js
@@ -10,9 +10,9 @@ const path = require("path");
 const ipfilter = require("express-ipfilter").IpFilter;
 const fs = require("fs");
 const helmet = require("helmet");
-const fetch = require("fetch");
+const fetch = require("#fetch");
 
-const Log = require("logger");
+const Log = require("#logger");
 const Utils = require("./utils.js");
 
 /**

--- a/modules/default/calendar/calendarfetcher.js
+++ b/modules/default/calendar/calendarfetcher.js
@@ -5,10 +5,10 @@
  * MIT Licensed.
  */
 const CalendarUtils = require("./calendarutils");
-const Log = require("logger");
-const NodeHelper = require("node_helper");
+const Log = require("#logger");
+const NodeHelper = require("#node_helper");
 const ical = require("node-ical");
-const fetch = require("fetch");
+const fetch = require("#fetch");
 const digest = require("digest-fetch");
 const https = require("https");
 

--- a/modules/default/calendar/node_helper.js
+++ b/modules/default/calendar/node_helper.js
@@ -4,9 +4,9 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-const NodeHelper = require("node_helper");
+const NodeHelper = require("#node_helper");
 const CalendarFetcher = require("./calendarfetcher.js");
-const Log = require("logger");
+const Log = require("#logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -4,10 +4,10 @@
  * By Michael Teeuw https://michaelteeuw.nl
  * MIT Licensed.
  */
-const Log = require("logger");
+const Log = require("#logger");
 const FeedMe = require("feedme");
-const NodeHelper = require("node_helper");
-const fetch = require("fetch");
+const NodeHelper = require("#node_helper");
+const fetch = require("#fetch");
 const iconv = require("iconv-lite");
 const stream = require("stream");
 

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -5,9 +5,9 @@
  * MIT Licensed.
  */
 
-const NodeHelper = require("node_helper");
+const NodeHelper = require("#node_helper");
 const NewsfeedFetcher = require("./newsfeedfetcher.js");
-const Log = require("logger");
+const Log = require("#logger");
 
 module.exports = NodeHelper.create({
 	// Override start method.

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -2,7 +2,7 @@ const util = require("util");
 const exec = util.promisify(require("child_process").exec);
 const fs = require("fs");
 const path = require("path");
-const Log = require("logger");
+const Log = require("#logger");
 
 const BASE_DIR = path.normalize(`${__dirname}/../../../`);
 

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -1,6 +1,6 @@
 const GitHelper = require("./git_helper");
 const defaultModules = require("../defaultmodules");
-const NodeHelper = require("node_helper");
+const NodeHelper = require("#node_helper");
 
 const ONE_MINUTE = 60 * 1000;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
 				"helmet": "^6.0.0",
 				"iconv-lite": "^0.6.3",
 				"luxon": "^1.28.0",
-				"module-alias": "^2.2.2",
 				"moment": "^2.29.4",
 				"node-fetch": "^2.6.7",
 				"node-ical": "^0.15.1",
@@ -5733,11 +5732,6 @@
 			"bin": {
 				"mkdirp": "bin/cmd.js"
 			}
-		},
-		"node_modules/module-alias": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-			"integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
 		},
 		"node_modules/moment": {
 			"version": "2.29.4",
@@ -12975,11 +12969,6 @@
 			"requires": {
 				"minimist": "^1.2.6"
 			}
-		},
-		"module-alias": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-			"integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
 		},
 		"moment": {
 			"version": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -83,16 +83,21 @@
 		"helmet": "^6.0.0",
 		"iconv-lite": "^0.6.3",
 		"luxon": "^1.28.0",
-		"module-alias": "^2.2.2",
 		"moment": "^2.29.4",
 		"node-fetch": "^2.6.7",
 		"node-ical": "^0.15.1",
 		"socket.io": "^4.5.2"
 	},
-	"_moduleAliases": {
-		"node_helper": "js/node_helper.js",
-		"logger": "js/logger.js",
-		"fetch": "js/fetch.js"
+	"imports": {
+		"#logger": {
+			"default": "./js/logger.js"
+		},
+		"#node_helper": {
+			"default": "./js/node_helper.js"
+		},
+		"#fetch": {
+			"default": "./js/fetch.js"
+		}
 	},
 	"engines": {
 		"node": ">=14"

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -1,5 +1,5 @@
 const app = require("../js/app.js");
-const Log = require("logger");
+const Log = require("#logger");
 
 app.start((config) => {
 	const bindAddress = config.address ? config.address : "localhost";

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -105,7 +105,7 @@ describe("Updatenotification", () => {
 			const repos = await gitHelper.getRepos();
 			expect(repos.length).toBe(0);
 
-			const { error } = require("logger");
+			const { error } = require("#logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);
 		});
 


### PR DESCRIPTION
Replace deprecated `module-alias` with built-in imports map. It is present since node v12 and will be soon available in `bun` (it works in `bun-canary`). My goal is to make this app runnable with bun and that's the first step to make it happen.
