### PR TITLE
weathergov.js:  Removed weatherEndpoint definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Special thanks to: @rejas, @sdetweil
 
 - Added test for remoteFile option in compliments module
 - Added hourlyWeather functionality to Weather.gov weather provider
+- Removed weatherEndpoint definition from weathergov.js (not used)
 
 ### Removed
 

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -22,7 +22,6 @@ WeatherProvider.register("weathergov", {
 	// Set the default config properties that is specific to this provider
 	defaults: {
 		apiBase: "https://api.weather.gov/points/",
-		weatherEndpoint: "/forecast",
 		lat: 0,
 		lon: 0
 	},


### PR DESCRIPTION
Removed weatherEnpoint definition in defaults.  It is not used in the weathergov.js provider.