### PR TITLE
fix cors problems with newsfeed articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Special thanks to: @rejas, @sdetweil
 - Correctly show apparent temperature in SMHI weather provider
 - Ensure updatenotification module isn't shown when local is _ahead_ of remote
 - Possibility to change FontAwesome class in calendar, so icons like `fab fa-facebook-square` works.
-- Fix cors problems with newsfeed articles (as far as possible) (#2840)
+- Fix cors problems with newsfeed articles (as far as possible), allow disabling cors per feed with option `useCorsProxy: false` (#2840)
 
 ## [2.21.0] - 2022-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Special thanks to: @rejas, @sdetweil
 - Correctly show apparent temperature in SMHI weather provider
 - Ensure updatenotification module isn't shown when local is _ahead_ of remote
 - Possibility to change FontAwesome class in calendar, so icons like `fab fa-facebook-square` works.
+- Fix cors problems with newsfeed articles (as far as possible) (#2840)
 
 ## [2.21.0] - 2022-10-01
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -42,7 +42,13 @@ Module.register("newsfeed", {
 		dangerouslyDisableAutoEscaping: false
 	},
 
-	urlPrefix: location.protocol + "//" + location.host + "/cors?url=",
+	getUrlPrefix: function (item) {
+		if (item.useCorsProxy) {
+			return location.protocol + "//" + location.host + "/cors?url=";
+		} else {
+			return "";
+		}
+	},
 
 	// Define required scripts.
 	getScripts: function () {
@@ -144,7 +150,7 @@ Module.register("newsfeed", {
 			sourceTitle: item.sourceTitle,
 			publishDate: moment(new Date(item.pubdate)).fromNow(),
 			title: item.title,
-			url: this.urlPrefix + item.url,
+			url: this.getUrlPrefix(item) + item.url,
 			description: item.description,
 			items: items
 		};
@@ -153,7 +159,7 @@ Module.register("newsfeed", {
 	getActiveItemURL: function () {
 		const item = this.newsItems[this.activeItem];
 		if (item) {
-			return typeof item.url === "string" ? this.urlPrefix + item.url : this.urlPrefix + item.url.href;
+			return typeof item.url === "string" ? this.getUrlPrefix(item) + item.url : this.getUrlPrefix(item) + item.url.href;
 		} else {
 			return "";
 		}

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -42,6 +42,8 @@ Module.register("newsfeed", {
 		dangerouslyDisableAutoEscaping: false
 	},
 
+	urlPrefix: location.protocol + "//" + location.host + "/cors?url=",
+
 	// Define required scripts.
 	getScripts: function () {
 		return ["moment.js"];
@@ -142,14 +144,19 @@ Module.register("newsfeed", {
 			sourceTitle: item.sourceTitle,
 			publishDate: moment(new Date(item.pubdate)).fromNow(),
 			title: item.title,
-			url: item.url,
+			url: this.urlPrefix + item.url,
 			description: item.description,
 			items: items
 		};
 	},
 
 	getActiveItemURL: function () {
-		return typeof this.newsItems[this.activeItem].url === "string" ? this.newsItems[this.activeItem].url : this.newsItems[this.activeItem].url.href;
+		const item = this.newsItems[this.activeItem];
+		if (item) {
+			return typeof item.url === "string" ? this.urlPrefix + item.url : this.urlPrefix + item.url.href;
+		} else {
+			return "";
+		}
 	},
 
 	/**

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -20,7 +20,7 @@ const stream = require("stream");
  * @param {boolean} logFeedWarnings If true log warnings when there is an error parsing a news article.
  * @class
  */
-const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings) {
+const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings, useCorsProxy) {
 	let reloadTimer = null;
 	let items = [];
 
@@ -57,7 +57,8 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 					title: title,
 					description: description,
 					pubdate: pubdate,
-					url: url
+					url: url,
+					useCorsProxy: useCorsProxy
 				});
 			} else if (logFeedWarnings) {
 				Log.warn("Can't parse feed item:");

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -18,6 +18,7 @@ const stream = require("stream");
  * @param {number} reloadInterval Reload interval in milliseconds.
  * @param {string} encoding Encoding of the feed.
  * @param {boolean} logFeedWarnings If true log warnings when there is an error parsing a news article.
+ * @param {boolean} useCorsProxy If true cors proxy is used for article url's.
  * @class
  */
 const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings, useCorsProxy) {

--- a/modules/default/newsfeed/node_helper.js
+++ b/modules/default/newsfeed/node_helper.js
@@ -34,6 +34,8 @@ module.exports = NodeHelper.create({
 		const url = feed.url || "";
 		const encoding = feed.encoding || "UTF-8";
 		const reloadInterval = feed.reloadInterval || config.reloadInterval || 5 * 60 * 1000;
+		let useCorsProxy = feed.useCorsProxy;
+		if (useCorsProxy === undefined) useCorsProxy = true;
 
 		try {
 			new URL(url);
@@ -46,7 +48,7 @@ module.exports = NodeHelper.create({
 		let fetcher;
 		if (typeof this.fetchers[url] === "undefined") {
 			Log.log("Create new newsfetcher for url: " + url + " - Interval: " + reloadInterval);
-			fetcher = new NewsfeedFetcher(url, reloadInterval, encoding, config.logFeedWarnings);
+			fetcher = new NewsfeedFetcher(url, reloadInterval, encoding, config.logFeedWarnings, useCorsProxy);
 
 			fetcher.onReceive(() => {
 				this.broadcastFeeds();


### PR DESCRIPTION
solves #2840 as far as possible. There could still be errors on the embedded iframe when the owner of the site has set `X-Frame-Options` or `Access-Control-Allow-Origin` headers (as already mentioned in the docs).