### PR TITLE
Ensure updatenotification module isn't shown when local is *ahead* of remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Special thanks to: @rejas, @sdetweil
 ### Fixed
 
 - Correctly show apparent temperature in SMHI weather provider
-- Ensure updatenotification module isn't shown when local is *ahead* of remote
+- Ensure updatenotification module isn't shown when local is _ahead_ of remote
 
 ## [2.21.0] - 2022-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Special thanks to: @rejas, @sdetweil
 ### Fixed
 
 - Correctly show apparent temperature in SMHI weather provider
+- Ensure updatenotification module isn't shown when local is *ahead* of remote
 
 ## [2.21.0] - 2022-10-01
 

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -92,20 +92,18 @@ class GitHelper {
 		// examples for status:
 		// ## develop...origin/develop
 		// ## master...origin/master [behind 8]
-		status = status.match(/(?![.#])([^.]*)/g);
+		// ## master...origin/master [ahead 8, behind 1]
+		status = status.match(/## (.*)\.\.\.([^ ]*)(?: .*behind (\d+))?/);
 		// examples for status:
-		// [ ' develop', 'origin/develop', '' ]
-		// [ ' master', 'origin/master [behind 8]', '' ]
-		gitInfo.current = status[0].trim();
-		status = status[1].split(" ");
-		// examples for status:
-		// [ 'origin/develop' ]
-		// [ 'origin/master', '[behind', '8]' ]
-		gitInfo.tracking = status[0].trim();
+		// [ '## develop...origin/develop', 'develop', 'origin/develop' ]
+		// [ '## master...origin/master [behind 8]', 'master', 'origin/master', '8' ]
+		// [ '## master...origin/master [ahead 8, behind 1]', 'master', 'origin/master', '1' ]
+		gitInfo.current = status[1];
+		gitInfo.tracking = status[2];
 
-		if (status[2]) {
+		if (status[3]) {
 			// git fetch was already called before so `git status -sb` delivers already the behind number
-			gitInfo.behind = parseInt(status[2].substring(0, status[2].length - 1));
+			gitInfo.behind = parseInt(status[3]);
 			gitInfo.isBehindInStatus = true;
 		}
 


### PR DESCRIPTION
This PR resolves a small bug in the updatenotification module if a local git repo is ahead of the remote (for example I have made local commits for my personal needs).

Currently, if `git status -sb` reports a status like: `## master...origin/master [ahead 2]` then updatenotification treats this as though it's "behind".

This PR uses a single Regex to match `git status -sb` output and uses capture groups to extract info to populate the `gitInfo` object to avoid needing to do string manipulation to extract this information.