### PR TITLE
Make the app start using async/await instead of callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Special thanks to: @rejas, @sdetweil
   - Reworked how weatherproviders handle units (#2849)
   - Use unix() method for parsing times, fix suntimes on the way (#2950)
   - Refactor conversion functions into utils class (#2958)
+- Use async/await for startup of the application instead of callbacks
 
 ### Fixed
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -153,10 +153,7 @@ app.on("activate", function () {
 app.on("before-quit", async (event) => {
 	Log.log("Shutting down server...");
 	event.preventDefault();
-	setTimeout(() => {
-		process.exit(0);
-	}, 3000); // Force-quit after 3 seconds.
-	await core.stop();
+	await core.stop(3000); // Force-quit after 3 seconds.
 	process.exit(0);
 });
 

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -1,7 +1,7 @@
 const app = require("../js/app.js");
 const Log = require("logger");
 
-app.start((config) => {
+app.start().then((config) => {
 	const bindAddress = config.address ? config.address : "localhost";
 	const httpType = config.useHttps ? "https" : "http";
 	Log.log("\nReady to go! Please point your browser to: " + httpType + "://" + bindAddress + ":" + config.port);

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -15,19 +15,14 @@ exports.startApplication = async (configFilename, exec) => {
 	if (exec) exec;
 	global.app = require("app.js");
 
-	return new Promise((resolve) => {
-		global.app.start(resolve);
-	});
+	await global.app.start();
 };
 
 exports.stopApplication = async () => {
 	if (global.app) {
-		return new Promise((resolve) => {
-			global.app.stop(resolve);
-			delete global.app;
-		});
+		await global.app.stop();
+		delete global.app;
 	}
-	return Promise.resolve();
 };
 
 exports.getDocument = () => {

--- a/tests/electron/env_spec.js
+++ b/tests/electron/env_spec.js
@@ -18,7 +18,7 @@ describe("Electron app environment", () => {
 
 describe("Development console tests", () => {
 	beforeEach(async () => {
-		await helpers.startApplication("tests/configs/modules/display.js", null, ["js/electron.js", "dev"]);
+		await helpers.startApplication("tests/configs/modules/display.js", ["js/electron.js", "dev"]);
 	});
 
 	afterEach(async () => {
@@ -26,9 +26,11 @@ describe("Development console tests", () => {
 	});
 
 	it("should open browserwindow and dev console", async () => {
-		const pageArray = await global.electronApp.windows();
-		expect(pageArray.length).toBe(2);
-		for (const page of pageArray) {
+		while (global.electronApp.windows().length < 2) {
+			await global.electronApp.waitForEvent("window");
+		}
+
+		for (let page of global.electronApp.windows()) {
 			expect(["MagicMirror²", "DevTools"]).toContain(await page.title());
 		}
 	});

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -12,18 +12,16 @@ exports.startApplication = async (configFilename, systemDate = null, electronPar
 	global.electronApp = await electron.launch({ args: electronParams });
 	expect(global.electronApp);
 
-	if ((await global.electronApp.windows().length) === 1) {
-		global.page = await global.electronApp.firstWindow();
-		if (systemDate) {
-			await global.page.evaluate((systemDate) => {
-				Date.now = () => {
-					return new Date(systemDate);
-				};
-			}, systemDate);
-		}
-		expect(await global.page.title()).toBe("MagicMirror²");
-		expect(await global.page.isVisible("body")).toBe(true);
+	global.page = await global.electronApp.firstWindow();
+	if (systemDate) {
+		await global.page.evaluate((systemDate) => {
+			Date.now = () => {
+				return new Date(systemDate);
+			};
+		}, systemDate);
 	}
+	expect(await global.page.title()).toBe("MagicMirror²");
+	expect(await global.page.isVisible("body")).toBe(true);
 };
 
 exports.stopApplication = async () => {

--- a/tests/electron/helpers/weather-setup.js
+++ b/tests/electron/helpers/weather-setup.js
@@ -25,5 +25,6 @@ exports.startApp = async (configFile, systemDate) => {
 	let content = fs.readFileSync(path.resolve(__dirname + "../../../../" + configFile)).toString();
 	content = content.replace("#####WEATHERDATA#####", mockWeather);
 	fs.writeFileSync(path.resolve(__dirname + "../../../../config/config.js"), content);
-	await helpers.startApplication("", systemDate);
+	await helpers.startApplication("");
+	await helpers.mockSystemDate(systemDate);
 };

--- a/tests/electron/helpers/weather-setup.js
+++ b/tests/electron/helpers/weather-setup.js
@@ -25,6 +25,6 @@ exports.startApp = async (configFile, systemDate) => {
 	let content = fs.readFileSync(path.resolve(__dirname + "../../../../" + configFile)).toString();
 	content = content.replace("#####WEATHERDATA#####", mockWeather);
 	fs.writeFileSync(path.resolve(__dirname + "../../../../config/config.js"), content);
+	helpers.mockSystemDate(systemDate);
 	await helpers.startApplication("");
-	await helpers.mockSystemDate(systemDate);
 };

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -20,14 +20,14 @@ describe("Calendar module", () => {
 
 	describe("Test css classes", () => {
 		it("has css class today", async () => {
+			helpers.mockSystemDate("01 Jan 2030 12:30:00 GMT");
 			await helpers.startApplication("tests/configs/modules/calendar/custom.js");
-			await helpers.mockSystemDate("01 Jan 2030 12:30:00 GMT");
 			await doTest(".today");
 		});
 
 		it("has css class tomorrow", async () => {
+			helpers.mockSystemDate("31 Dez 2029 12:30:00 GMT");
 			await helpers.startApplication("tests/configs/modules/calendar/custom.js");
-			await helpers.mockSystemDate("31 Dez 2029 12:30:00 GMT");
 			await doTest(".tomorrow");
 		});
 	});

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -7,11 +7,8 @@ describe("Calendar module", () => {
 	 * @param {string} cssClass css selector
 	 */
 	const doTest = async (cssClass) => {
-		await helpers.getElement(".calendar");
-		await helpers.getElement(".module-content");
-		const events = await global.page.locator(".event");
-		const elem = await events.locator(cssClass);
-		expect(elem).not.toBe(null);
+		let elem = await helpers.getElement(".calendar .module-content .event" + cssClass);
+		expect(await elem.isVisible()).toBe(true);
 	};
 
 	afterEach(async () => {
@@ -26,7 +23,7 @@ describe("Calendar module", () => {
 		});
 
 		it("has css class tomorrow", async () => {
-			helpers.mockSystemDate("31 Dez 2029 12:30:00 GMT");
+			helpers.mockSystemDate("31 Dec 2029 12:30:00 GMT");
 			await helpers.startApplication("tests/configs/modules/calendar/custom.js");
 			await doTest(".tomorrow");
 		});

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -20,12 +20,14 @@ describe("Calendar module", () => {
 
 	describe("Test css classes", () => {
 		it("has css class today", async () => {
-			await helpers.startApplication("tests/configs/modules/calendar/custom.js", "01 Jan 2030 12:30:00 GMT");
+			await helpers.startApplication("tests/configs/modules/calendar/custom.js");
+			await helpers.mockSystemDate("01 Jan 2030 12:30:00 GMT");
 			await doTest(".today");
 		});
 
 		it("has css class tomorrow", async () => {
-			await helpers.startApplication("tests/configs/modules/calendar/custom.js", "31 Dez 2029 12:30:00 GMT");
+			await helpers.startApplication("tests/configs/modules/calendar/custom.js");
+			await helpers.mockSystemDate("31 Dez 2029 12:30:00 GMT");
 			await doTest(".tomorrow");
 		});
 	});

--- a/tests/electron/modules/compliments_spec.js
+++ b/tests/electron/modules/compliments_spec.js
@@ -19,20 +19,20 @@ describe("Compliments module", () => {
 
 	describe("parts of days", () => {
 		it("Morning compliments for that part of day", async () => {
+			helpers.mockSystemDate("01 Oct 2022 10:00:00 GMT");
 			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
-			await helpers.mockSystemDate("01 Oct 2022 10:00:00 GMT");
 			await doTest(["Hi", "Good Morning", "Morning test"]);
 		});
 
 		it("Afternoon show Compliments for that part of day", async () => {
+			helpers.mockSystemDate("01 Oct 2022 15:00:00 GMT");
 			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
-			await helpers.mockSystemDate("01 Oct 2022 15:00:00 GMT");
 			await doTest(["Hello", "Good Afternoon", "Afternoon test"]);
 		});
 
 		it("Evening show Compliments for that part of day", async () => {
+			helpers.mockSystemDate("01 Oct 2022 20:00:00 GMT");
 			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
-			await helpers.mockSystemDate("01 Oct 2022 20:00:00 GMT");
 			await doTest(["Hello There", "Good Evening", "Evening test"]);
 		});
 	});
@@ -40,8 +40,8 @@ describe("Compliments module", () => {
 	describe("Feature date in compliments module", () => {
 		describe("Set date and empty compliments for anytime, morning, evening and afternoon", () => {
 			it("Show happy new year compliment on new years day", async () => {
+				helpers.mockSystemDate("01 Jan 2022 10:00:00 GMT");
 				await helpers.startApplication("tests/configs/modules/compliments/compliments_date.js");
-				await helpers.mockSystemDate("01 Jan 2022 10:00:00 GMT");
 				await doTest(["Happy new year!"]);
 			});
 		});

--- a/tests/electron/modules/compliments_spec.js
+++ b/tests/electron/modules/compliments_spec.js
@@ -19,17 +19,20 @@ describe("Compliments module", () => {
 
 	describe("parts of days", () => {
 		it("Morning compliments for that part of day", async () => {
-			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js", "01 Oct 2022 10:00:00 GMT");
+			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
+			await helpers.mockSystemDate("01 Oct 2022 10:00:00 GMT");
 			await doTest(["Hi", "Good Morning", "Morning test"]);
 		});
 
 		it("Afternoon show Compliments for that part of day", async () => {
-			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js", "01 Oct 2022 15:00:00 GMT");
+			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
+			await helpers.mockSystemDate("01 Oct 2022 15:00:00 GMT");
 			await doTest(["Hello", "Good Afternoon", "Afternoon test"]);
 		});
 
 		it("Evening show Compliments for that part of day", async () => {
-			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js", "01 Oct 2022 20:00:00 GMT");
+			await helpers.startApplication("tests/configs/modules/compliments/compliments_parts_day.js");
+			await helpers.mockSystemDate("01 Oct 2022 20:00:00 GMT");
 			await doTest(["Hello There", "Good Evening", "Evening test"]);
 		});
 	});
@@ -37,7 +40,8 @@ describe("Compliments module", () => {
 	describe("Feature date in compliments module", () => {
 		describe("Set date and empty compliments for anytime, morning, evening and afternoon", () => {
 			it("Show happy new year compliment on new years day", async () => {
-				await helpers.startApplication("tests/configs/modules/compliments/compliments_date.js", "01 Jan 2022 10:00:00 GMT");
+				await helpers.startApplication("tests/configs/modules/compliments/compliments_date.js");
+				await helpers.mockSystemDate("01 Jan 2022 10:00:00 GMT");
 				await doTest(["Happy new year!"]);
 			});
 		});


### PR DESCRIPTION
- Modernizing the startup using async/await instead of callbacks.
- Since it's not blocking now at startup I had to move the creation of the app/server into the `ready`-event for electron, otherwise the screen was black at startup.
- Moved the repeated code for timeouts when calling `app.close()` as an argument to that method instead.