### PR TITLE
remove "x-frame-options" and "content-security-policy" response headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Special thanks to: @rejas, @sdetweil, @MagMar94
 - Added css class names "today" and "tomorrow" for default calendar
 - Added Collaboration.md
 - Added new github action for dependency review (#2862)
+- Added config options "ignoreXOriginHeader" and "ignoreContentSecurityPolicy"
 
 ### Removed
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -103,6 +103,20 @@ function createWindow() {
 			}, 1000);
 		});
 	}
+
+	//remove response headers that prevent sites of being embedded into iframes if configured
+	mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+		let curHeaders = details.responseHeaders;
+		if (config["ignoreXOriginHeader"] || false) {
+			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !/x-frame-options/i.test(header[0])));
+		}
+
+		if (config["ignoreContentSecurityPolicy"] || false) {
+			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !/content-security-policy/i.test(header[0])));
+		}
+
+		callback({ responseHeaders: curHeaders });
+	});
 }
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
Many users like me do have the problem that they want to embed other sites to their mirror by "iframe".
As some developers set the "x-frame-options" and "content-security-policy" for security reasons these sites can not be embedded.
Electron provides the "webview" element additionally to "iframe" which allows to embed these sites although. The main difference is that a new process is started which handles the "webview" element.
BUT: As the "webview" process needs to be started and is isolated "webview" is slower and the elements can not be accessed from the embedding website.

As an alternative i implemented a small callback function in electron.js which removes the response headers that forbid the embedding.

The removing can be controlled with the new config options:
* ignoreXOriginHeader
* ignoreContentSecurityPolicy
