### PR TITLE
Only add clock type wrappers to DOM when they are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Special thanks to: @rejas, @sdetweil, @MagMar94
 - Possibility to change FontAwesome class in calendar, so icons like `fab fa-facebook-square` works.
 - Fix cors problems with newsfeed articles (as far as possible), allow disabling cors per feed with option `useCorsProxy: false` (#2840)
 - Tests not waiting for the application to start and stop before starting the next test
+- Fixed gap in clock module when displayed on the left side with displayType=digital
 
 ## [2.21.0] - 2022-10-01
 

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -303,7 +303,7 @@ Module.register("clock", {
 		}
 
 		/*******************************************
-		 * Update placement, respect old analogShowDate even if its not needed anymore
+		 * Update placement, respect old analogShowDate even if it's not needed anymore
 		 */
 		if (this.config.displayType === "analog") {
 			// Display only an analog clock
@@ -311,15 +311,15 @@ Module.register("clock", {
 				wrapper.classList.add("clockGrid--bottom");
 			} else if (this.config.analogShowDate === "bottom") {
 				wrapper.classList.add("clockGrid--top");
-			} else {
-				//analogWrapper.style.gridArea = "center";
 			}
+			wrapper.appendChild(analogWrapper);
+		} else if (this.config.displayType === "digital") {
+			wrapper.appendChild(digitalWrapper);
 		} else if (this.config.displayType === "both") {
 			wrapper.classList.add("clockGrid--" + this.config.analogPlacement);
+			wrapper.appendChild(analogWrapper);
+			wrapper.appendChild(digitalWrapper);
 		}
-
-		wrapper.appendChild(analogWrapper);
-		wrapper.appendChild(digitalWrapper);
 
 		// Return the wrapper to the dom.
 		return wrapper;


### PR DESCRIPTION
Fixes a layout gap when digital clock is displayd on the left

Reported via discord: https://discord.com/channels/545884423703494657/545884914982322177/1044376412997562418

