### PR TITLE
Fix wrong day labels in envcanada forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ _This release is scheduled to be released on 2023-04-01._
 
 ### Fixed
 
+- Fix wrong day labels in envcanada forecast (#2987)
+
 ## [2.22.0] - 2023-01-01
 
 Thanks to: @angeldeejay, @buxxi, @dariom, @dWoolridge, @KristjanESPERANTO, @MagMar94, @naveensrinivasan, @retroflex, @SkySails and @Tom.

--- a/modules/default/weather/providers/envcanada.js
+++ b/modules/default/weather/providers/envcanada.js
@@ -336,7 +336,7 @@ WeatherProvider.register("envcanada", {
 			// Add 1 to the date to reflect the current forecast day we are building
 
 			lastDate = lastDate.add(1, "day");
-			weather.date = moment.unix(lastDate);
+			weather.date = moment(lastDate);
 
 			// Capture the temperatures for the current Element and the next Element in order to set
 			// the Min and Max temperatures for the forecast


### PR DESCRIPTION
Fixes #2987

lastDate isnt a unix date, but just a normal moment-date
