### PR TITLE
added possibility to ignore MagicMirror repo in updatenotification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _This release is scheduled to be released on 2023-04-01._
 
 - Added increments for hourly forecasts in weather module (#2996)
 - Added tests for hourly weather forecast
+- Added possibility to ignore MagicMirror repo in updatenotification module
 
 ### Removed
 

--- a/modules/default/updatenotification/node_helper.js
+++ b/modules/default/updatenotification/node_helper.js
@@ -19,7 +19,9 @@ module.exports = NodeHelper.create({
 			}
 		}
 
-		await this.gitHelper.add("default");
+		if (!this.ignoreUpdateChecking("MagicMirror")) {
+			await this.gitHelper.add("MagicMirror");
+		}
 	},
 
 	async socketNotificationReceived(notification, payload) {

--- a/modules/default/updatenotification/updatenotification.js
+++ b/modules/default/updatenotification/updatenotification.js
@@ -77,7 +77,7 @@ Module.register("updatenotification", {
 
 	addFilters() {
 		this.nunjucksEnvironment().addFilter("diffLink", (text, status) => {
-			if (status.module !== "default") {
+			if (status.module !== "MagicMirror") {
 				return text;
 			}
 

--- a/modules/default/updatenotification/updatenotification.njk
+++ b/modules/default/updatenotification/updatenotification.njk
@@ -3,7 +3,7 @@
     <div class="small bright">
       <i class="fas fa-exclamation-circle"></i>
       <span>
-        {% set mainTextLabel = "UPDATE_NOTIFICATION" if name === "default" else "UPDATE_NOTIFICATION_MODULE" %}
+        {% set mainTextLabel = "UPDATE_NOTIFICATION" if name === "MagicMirror" else "UPDATE_NOTIFICATION_MODULE" %}
         {{ mainTextLabel | translate({MODULE_NAME: name}) }}
       </span>
     </div>

--- a/tests/unit/functions/__snapshots__/updatenotification_spec.js.snap
+++ b/tests/unit/functions/__snapshots__/updatenotification_spec.js.snap
@@ -11,24 +11,24 @@ exports[`Updatenotification custom module returns status information without has
 }
 `;
 
-exports[`Updatenotification default returns status information 1`] = `
+exports[`Updatenotification MagicMirror returns status information 1`] = `
 {
   "behind": 5,
   "current": "develop",
   "hash": "332e429a41f1a2339afd4f0ae96dd125da6beada",
   "isBehindInStatus": false,
-  "module": "default",
+  "module": "MagicMirror",
   "tracking": "origin/develop",
 }
 `;
 
-exports[`Updatenotification default returns status information early if isBehindInStatus 1`] = `
+exports[`Updatenotification MagicMirror returns status information early if isBehindInStatus 1`] = `
 {
   "behind": 5,
   "current": "develop",
   "hash": "332e429a41f1a2339afd4f0ae96dd125da6beada",
   "isBehindInStatus": true,
-  "module": "default",
+  "module": "MagicMirror",
   "tracking": "origin/develop",
 }
 `;

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -57,7 +57,7 @@ describe("Updatenotification", () => {
 				return { stdout: gitRevParseOut, stderr: gitRevParseErr };
 			} else if (command.includes("git status -sb")) {
 				return { stdout: gitStatusOut, stderr: gitStatusErr };
-			} else if (command.includes("git fetch --dry-run")) {
+			} else if (command.includes("git fetch -n --dry-run")) {
 				return { stdout: gitFetchOut, stderr: gitFetchErr };
 			} else if (command.includes("git rev-list --ancestry-path --count")) {
 				return { stdout: gitRevListOut, stderr: gitRevListErr };
@@ -71,8 +71,8 @@ describe("Updatenotification", () => {
 		jest.clearAllMocks();
 	});
 
-	describe("default", () => {
-		const moduleName = "default";
+	describe("MagicMirror", () => {
+		const moduleName = "MagicMirror";
 
 		beforeEach(async () => {
 			gitRemoteOut = "origin\tgit@github.com:MichMich/MagicMirror.git (fetch)\norigin\tgit@github.com:MichMich/MagicMirror.git (push)\n";
@@ -107,13 +107,6 @@ describe("Updatenotification", () => {
 
 			const { error } = require("logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);
-		});
-
-		it("excludes repo if refs don't match regex", async () => {
-			gitFetchErr = "";
-
-			const repos = await gitHelper.getRepos();
-			expect(repos.length).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
was [requested in the forum](https://forum.magicmirror.builders/topic/17519/updatenotification).

- added possibility to exclude MagicMirror Repo and renamed it from `default` to `MagicMirror`
- improved getting `behind` in case a hard `git fetch` was already done
- removed test "excludes repo if refs don't match regex" because of above improvement this case is obsolete
- improved `git fetch --dry-run` with `-n` option to exclude tags (noise reduction)