### PR TITLE
removed unneeded (and unwanted) '.' in calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _This release is scheduled to be released on 2023-04-01._
 ### Removed
 
 - Removed darksky weather provider
+- Removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (#2896)
 
 ### Updated
 

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -5,8 +5,13 @@ This document describes how collaborators of this repository should work togethe
 - never merge your own PR's
 - never merge without someone having approved (approving and merging from same person is allowed)
 - wait for all approvals requested (or the author decides something different in the comments)
+- never merge to `master`, except for releases (because of update notification)
 
 ## Issues
 
 - "real" Issues are closed if the problem is solved and the fix is released
 - unrelated Issues (e.g. related to a foreign module) are closed immediately with a comment to open an issue in the module repository or to discuss this further in the forum or discord
+
+## Releases
+
+- are done by @MichMich only

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -271,7 +271,7 @@ Module.register("calendar", {
 					const thisYear = new Date(parseInt(event.startDate)).getFullYear(),
 						yearDiff = thisYear - event.firstYear;
 
-					repeatingCountTitle = ", " + yearDiff + ". " + repeatingCountTitle;
+					repeatingCountTitle = ", " + yearDiff + repeatingCountTitle;
 				}
 			}
 


### PR DESCRIPTION
- removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (fixes #2896)
- update Collaboration.md