### PR TITLE
Fix weathergov provider hourly weather forecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _This release is scheduled to be released on 2023-04-01._
 ### Fixed
 
 - Fix wrong day labels in envcanada forecast (#2987)
+- Fix weathergov provider hourly forecast (#3008)
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -181,7 +181,6 @@ WeatherProvider.register("weathergov", {
 			}
 			weather.windDirection = forecast.windDirection;
 			weather.temperature = forecast.temperature;
-			weather.tempUnits = forecast.temperatureUnit;
 			// use the forecast isDayTime attribute to help build the weatherType label
 			weather.weatherType = this.convertWeatherType(forecast.shortForecast, forecast.isDaytime);
 

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -179,7 +179,7 @@ WeatherProvider.register("weathergov", {
 			} else {
 				weather.windSpeed = forecast.windSpeed.slice(0, forecast.windSpeed.search(" "));
 			}
-			weather.windDirection = this.convertWindDirection(forecast.windDirection);
+			weather.windDirection = forecast.windDirection;
 			weather.temperature = forecast.temperature;
 			weather.tempUnits = forecast.temperatureUnit;
 			// use the forecast isDayTime attribute to help build the weatherType label

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -179,6 +179,7 @@ WeatherProvider.register("weathergov", {
 			} else {
 				weather.windSpeed = forecast.windSpeed.slice(0, forecast.windSpeed.search(" "));
 			}
+			weather.windSpeed = WeatherUtils.convertWindToMs(weather.windSpeed);
 			weather.windDirection = forecast.windDirection;
 			weather.temperature = forecast.temperature;
 			// use the forecast isDayTime attribute to help build the weatherType label


### PR DESCRIPTION
Hourly forecast wasnt converted properly during the last release cycle, one fix and two cleanups were necessary.

Fixes #3010 