### PR TITLE
Refresh the Calendar DOM every minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2023-04-01._
 
 - Use develop as target branch for dependabot
 - Update issue template and contributing doc
+- Update dates in Calendar widgets every minute
 
 ### Fixed
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -86,6 +86,9 @@ Module.register("calendar", {
 
 	// Override start method.
 	start: function () {
+		const ONE_SECOND = 1000; // 1,000 milliseconds
+		const ONE_MINUTE = ONE_SECOND * 60;
+
 		Log.info("Starting module: " + this.name);
 
 		// Set locale.
@@ -131,6 +134,14 @@ Module.register("calendar", {
 			// fetcher till cycle
 			this.addCalendar(calendar.url, calendar.auth, calendarConfig);
 		});
+
+		// Refresh the DOM every minute if needed: When using relative date format for events that start
+		// or end in less than an hour, the date shows minute granularity and we want to keep that accurate.
+		setTimeout(() => {
+			setInterval(() => {
+				this.updateDom(1);
+			}, ONE_MINUTE);
+		}, ONE_MINUTE - (new Date() % ONE_MINUTE));
 	},
 
 	// Override socket notification handler.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -86,8 +86,7 @@ Module.register("calendar", {
 
 	// Override start method.
 	start: function () {
-		const ONE_SECOND = 1000; // 1,000 milliseconds
-		const ONE_MINUTE = ONE_SECOND * 60;
+		const ONE_MINUTE = 60 * 1000;
 
 		Log.info("Starting module: " + this.name);
 


### PR DESCRIPTION
This keeps relative dates accurate when the calendar's fetch frequency is much larger than a minute.
As fetching incurs network traffic and load on servers and most calendars don't update that often, simply refreshing locally is enough.

When using relative for today's events, dates will show as "in X minutes" or "ends in X minutes" for events within an hour and this goes out of date quickly. It's weird to see that the time is, say, 16:30 and an event that you know ends at 16:45 is shown to "ends in 23 minutes" because that's when the last fetch happened.

Please forgive me if there's style issue, I don't have npm set up on my machine to run the formatter.