### PR TITLE
Fix yr weather direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix weathergov provider hourly forecast (#3008)
 - Fix message display with HTML code into alert module (#2828)
 - Fix typo into french translation
+- Yr wind direction is no longer inverted
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/weather/current.njk
+++ b/modules/default/weather/current.njk
@@ -7,7 +7,7 @@
                 {% if config.showWindDirection %}
                     <sup>
                         {% if config.showWindDirectionAsArrow %}
-                            <i class="fas fa-long-arrow-alt-up" style="transform:rotate({{ current.windDirection }}deg);"></i>
+                            <i class="fas fa-long-arrow-alt-up" style="transform:rotate({{ current.windFromDirection }}deg);"></i>
                         {% else %}
                             {{ current.cardinalWindDirection() | translate }}
                         {% endif %}

--- a/modules/default/weather/providers/envcanada.js
+++ b/modules/default/weather/providers/envcanada.js
@@ -165,7 +165,7 @@ WeatherProvider.register("envcanada", {
 
 		currentWeather.windSpeed = WeatherUtils.convertWindToMs(ECdoc.querySelector("siteData currentConditions wind speed").textContent);
 
-		currentWeather.windDirection = ECdoc.querySelector("siteData currentConditions wind bearing").textContent;
+		currentWeather.windFromDirection = ECdoc.querySelector("siteData currentConditions wind bearing").textContent;
 
 		currentWeather.humidity = ECdoc.querySelector("siteData currentConditions relativeHumidity").textContent;
 

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -371,7 +371,7 @@ WeatherProvider.register("openmeteo", {
 
 		currentWeather.date = weather.current_weather.time;
 		currentWeather.windSpeed = weather.current_weather.windspeed;
-		currentWeather.windDirection = weather.current_weather.winddirection;
+		currentWeather.windFromDirection = weather.current_weather.winddirection;
 		currentWeather.sunrise = weather.daily[0].sunrise;
 		currentWeather.sunset = weather.daily[0].sunset;
 		currentWeather.temperature = parseFloat(weather.current_weather.temperature);
@@ -395,7 +395,7 @@ WeatherProvider.register("openmeteo", {
 
 			currentWeather.date = weather.time;
 			currentWeather.windSpeed = weather.windspeed_10m_max;
-			currentWeather.windDirection = weather.winddirection_10m_dominant;
+			currentWeather.windFromDirection = weather.winddirection_10m_dominant;
 			currentWeather.sunrise = weather.sunrise;
 			currentWeather.sunset = weather.sunset;
 			currentWeather.temperature = parseFloat((weather.apparent_temperature_max + weather.apparent_temperature_min) / 2);
@@ -427,7 +427,7 @@ WeatherProvider.register("openmeteo", {
 
 			currentWeather.date = weather.time;
 			currentWeather.windSpeed = weather.windspeed_10m;
-			currentWeather.windDirection = weather.winddirection_10m;
+			currentWeather.windFromDirection = weather.winddirection_10m;
 			currentWeather.sunrise = weathers.daily[h].sunrise;
 			currentWeather.sunset = weathers.daily[h].sunset;
 			currentWeather.temperature = parseFloat(weather.apparent_temperature);

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -132,7 +132,7 @@ WeatherProvider.register("openweathermap", {
 		currentWeather.temperature = currentWeatherData.main.temp;
 		currentWeather.feelsLikeTemp = currentWeatherData.main.feels_like;
 		currentWeather.windSpeed = currentWeatherData.wind.speed;
-		currentWeather.windDirection = currentWeatherData.wind.deg;
+		currentWeather.windFromDirection = currentWeatherData.wind.deg;
 		currentWeather.weatherType = this.convertWeatherType(currentWeatherData.weather[0].icon);
 		currentWeather.sunrise = moment.unix(currentWeatherData.sys.sunrise);
 		currentWeather.sunset = moment.unix(currentWeatherData.sys.sunset);
@@ -303,7 +303,7 @@ WeatherProvider.register("openweathermap", {
 		if (data.hasOwnProperty("current")) {
 			current.date = moment.unix(data.current.dt).utcOffset(data.timezone_offset / 60);
 			current.windSpeed = data.current.wind_speed;
-			current.windDirection = data.current.wind_deg;
+			current.windFromDirection = data.current.wind_deg;
 			current.sunrise = moment.unix(data.current.sunrise).utcOffset(data.timezone_offset / 60);
 			current.sunset = moment.unix(data.current.sunset).utcOffset(data.timezone_offset / 60);
 			current.temperature = data.current.temp;
@@ -342,7 +342,7 @@ WeatherProvider.register("openweathermap", {
 				weather.feelsLikeTemp = hour.feels_like;
 				weather.humidity = hour.humidity;
 				weather.windSpeed = hour.wind_speed;
-				weather.windDirection = hour.wind_deg;
+				weather.windFromDirection = hour.wind_deg;
 				weather.weatherType = this.convertWeatherType(hour.weather[0].icon);
 				precip = false;
 				if (hour.hasOwnProperty("rain") && !isNaN(hour.rain["1h"])) {
@@ -381,7 +381,7 @@ WeatherProvider.register("openweathermap", {
 				weather.maxTemperature = day.temp.max;
 				weather.humidity = day.humidity;
 				weather.windSpeed = day.wind_speed;
-				weather.windDirection = day.wind_deg;
+				weather.windFromDirection = day.wind_deg;
 				weather.weatherType = this.convertWeatherType(day.weather[0].icon);
 				precip = false;
 				if (!isNaN(day.rain)) {

--- a/modules/default/weather/providers/pirateweather.js
+++ b/modules/default/weather/providers/pirateweather.js
@@ -72,7 +72,7 @@ WeatherProvider.register("pirateweather", {
 		currentWeather.humidity = parseFloat(currentWeatherData.currently.humidity);
 		currentWeather.temperature = parseFloat(currentWeatherData.currently.temperature);
 		currentWeather.windSpeed = parseFloat(currentWeatherData.currently.windSpeed);
-		currentWeather.windDirection = currentWeatherData.currently.windBearing;
+		currentWeather.windFromDirection = currentWeatherData.currently.windBearing;
 		currentWeather.weatherType = this.convertWeatherType(currentWeatherData.currently.icon);
 		currentWeather.sunrise = moment.unix(currentWeatherData.daily.data[0].sunriseTime);
 		currentWeather.sunset = moment.unix(currentWeatherData.daily.data[0].sunsetTime);

--- a/modules/default/weather/providers/smhi.js
+++ b/modules/default/weather/providers/smhi.js
@@ -145,7 +145,7 @@ WeatherProvider.register("smhi", {
 		currentWeather.humidity = this.paramValue(weatherData, "r");
 		currentWeather.temperature = this.paramValue(weatherData, "t");
 		currentWeather.windSpeed = this.paramValue(weatherData, "ws");
-		currentWeather.windDirection = this.paramValue(weatherData, "wd");
+		currentWeather.windFromDirection = this.paramValue(weatherData, "wd");
 		currentWeather.weatherType = this.convertWeatherType(this.paramValue(weatherData, "Wsymb2"), currentWeather.isDayTime());
 		currentWeather.feelsLikeTemp = this.calculateApparentTemperature(weatherData);
 

--- a/modules/default/weather/providers/ukmetoffice.js
+++ b/modules/default/weather/providers/ukmetoffice.js
@@ -102,7 +102,7 @@ WeatherProvider.register("ukmetoffice", {
 							currentWeather.feelsLikeTemp = rep.F;
 							currentWeather.precipitation = parseInt(rep.Pp);
 							currentWeather.windSpeed = WeatherUtils.convertWindToMetric(rep.S);
-							currentWeather.windDirection = WeatherUtils.convertWindDirection(rep.D);
+							currentWeather.windFromDirection = WeatherUtils.convertWindDirection(rep.D);
 							currentWeather.weatherType = this.convertWeatherType(rep.W);
 						}
 					}

--- a/modules/default/weather/providers/ukmetofficedatahub.js
+++ b/modules/default/weather/providers/ukmetofficedatahub.js
@@ -126,7 +126,7 @@ WeatherProvider.register("ukmetofficedatahub", {
 			if (nowUtc.isSameOrAfter(forecastTime) && nowUtc.isBefore(moment(forecastTime.add(1, "h")))) {
 				currentWeather.date = forecastTime;
 				currentWeather.windSpeed = forecastDataHours[hour].windSpeed10m;
-				currentWeather.windDirection = forecastDataHours[hour].windDirectionFrom10m;
+				currentWeather.windFromDirection = forecastDataHours[hour].windDirectionFrom10m;
 				currentWeather.temperature = forecastDataHours[hour].screenTemperature;
 				currentWeather.minTemperature = forecastDataHours[hour].minScreenAirTemp;
 				currentWeather.maxTemperature = forecastDataHours[hour].maxScreenAirTemp;
@@ -204,7 +204,7 @@ WeatherProvider.register("ukmetofficedatahub", {
 
 				// Using daytime forecast values
 				forecastWeather.windSpeed = forecastDataDays[day].midday10MWindSpeed;
-				forecastWeather.windDirection = forecastDataDays[day].midday10MWindDirection;
+				forecastWeather.windFromDirection = forecastDataDays[day].midday10MWindDirection;
 				forecastWeather.weatherType = this.convertWeatherType(forecastDataDays[day].daySignificantWeatherCode);
 				forecastWeather.precipitation = forecastDataDays[day].dayProbabilityOfPrecipitation;
 				forecastWeather.temperature = forecastDataDays[day].dayMaxScreenTemperature;

--- a/modules/default/weather/providers/weatherbit.js
+++ b/modules/default/weather/providers/weatherbit.js
@@ -106,7 +106,7 @@ WeatherProvider.register("weatherbit", {
 		currentWeather.humidity = parseFloat(currentWeatherData.data[0].rh);
 		currentWeather.temperature = parseFloat(currentWeatherData.data[0].temp);
 		currentWeather.windSpeed = parseFloat(currentWeatherData.data[0].wind_spd);
-		currentWeather.windDirection = currentWeatherData.data[0].wind_dir;
+		currentWeather.windFromDirection = currentWeatherData.data[0].wind_dir;
 		currentWeather.weatherType = this.convertWeatherType(currentWeatherData.data[0].weather.icon);
 		currentWeather.sunrise = moment(currentWeatherData.data[0].sunrise, "HH:mm").add(tzOffset, "m");
 		currentWeather.sunset = moment(currentWeatherData.data[0].sunset, "HH:mm").add(tzOffset, "m");

--- a/modules/default/weather/providers/weatherflow.js
+++ b/modules/default/weather/providers/weatherflow.js
@@ -32,7 +32,7 @@ WeatherProvider.register("weatherflow", {
 				currentWeather.humidity = data.current_conditions.relative_humidity;
 				currentWeather.temperature = data.current_conditions.air_temperature;
 				currentWeather.windSpeed = WeatherUtils.convertWindToMs(data.current_conditions.wind_avg);
-				currentWeather.windDirection = data.current_conditions.wind_direction;
+				currentWeather.windFromDirection = data.current_conditions.wind_direction;
 				currentWeather.weatherType = data.forecast.daily[0].icon;
 				currentWeather.sunrise = moment.unix(data.forecast.daily[0].sunrise);
 				currentWeather.sunset = moment.unix(data.forecast.daily[0].sunset);

--- a/modules/default/weather/providers/weathergov.js
+++ b/modules/default/weather/providers/weathergov.js
@@ -180,7 +180,7 @@ WeatherProvider.register("weathergov", {
 				weather.windSpeed = forecast.windSpeed.slice(0, forecast.windSpeed.search(" "));
 			}
 			weather.windSpeed = WeatherUtils.convertWindToMs(weather.windSpeed);
-			weather.windDirection = forecast.windDirection;
+			weather.windFromDirection = forecast.windDirection;
 			weather.temperature = forecast.temperature;
 			// use the forecast isDayTime attribute to help build the weatherType label
 			weather.weatherType = this.convertWeatherType(forecast.shortForecast, forecast.isDaytime);
@@ -206,7 +206,7 @@ WeatherProvider.register("weathergov", {
 		currentWeather.date = moment(currentWeatherData.timestamp);
 		currentWeather.temperature = currentWeatherData.temperature.value;
 		currentWeather.windSpeed = WeatherUtils.convertWindToMs(currentWeatherData.windSpeed.value);
-		currentWeather.windDirection = currentWeatherData.windDirection.value;
+		currentWeather.windFromDirection = currentWeatherData.windDirection.value;
 		currentWeather.minTemperature = currentWeatherData.minTemperatureLast24Hours.value;
 		currentWeather.maxTemperature = currentWeatherData.maxTemperatureLast24Hours.value;
 		currentWeather.humidity = Math.round(currentWeatherData.relativeHumidity.value);

--- a/modules/default/weather/providers/yr.js
+++ b/modules/default/weather/providers/yr.js
@@ -364,7 +364,7 @@ WeatherProvider.register("yr", {
 
 		weather.date = moment(forecast.time);
 		weather.windSpeed = forecast.data.instant.details.wind_speed;
-		weather.windDirection = (forecast.data.instant.details.wind_from_direction + 180) % 360;
+		weather.windDirection = forecast.data.instant.details.wind_from_direction;
 		weather.temperature = forecast.data.instant.details.air_temperature;
 		weather.minTemperature = forecast.minTemperature;
 		weather.maxTemperature = forecast.maxTemperature;

--- a/modules/default/weather/providers/yr.js
+++ b/modules/default/weather/providers/yr.js
@@ -7,7 +7,7 @@
  * By Magnus Marthinsen
  * MIT Licensed
  *
- * This class is a provider for Yr.no, a norwegian sweather service.
+ * This class is a provider for Yr.no, a norwegian weather service.
  *
  * Terms of service: https://developer.yr.no/doc/TermsOfService/
  */
@@ -47,7 +47,7 @@ WeatherProvider.register("yr", {
 		const getRequests = [this.getWeatherData(), this.getStellarData()];
 		const [weatherData, stellarData] = await Promise.all(getRequests);
 		if (!stellarData) {
-			Log.warn("No stelar data available.");
+			Log.warn("No stellar data available.");
 		}
 		if (!weatherData.properties.timeseries || !weatherData.properties.timeseries[0]) {
 			Log.error("No weather data available.");
@@ -530,7 +530,7 @@ WeatherProvider.register("yr", {
 			return;
 		}
 		if (!stellarData) {
-			Log.warn("No stelar data available.");
+			Log.warn("No stellar data available.");
 		}
 		let forecasts;
 		switch (type) {

--- a/modules/default/weather/providers/yr.js
+++ b/modules/default/weather/providers/yr.js
@@ -364,7 +364,7 @@ WeatherProvider.register("yr", {
 
 		weather.date = moment(forecast.time);
 		weather.windSpeed = forecast.data.instant.details.wind_speed;
-		weather.windDirection = forecast.data.instant.details.wind_from_direction;
+		weather.windFromDirection = forecast.data.instant.details.wind_from_direction;
 		weather.temperature = forecast.data.instant.details.air_temperature;
 		weather.minTemperature = forecast.minTemperature;
 		weather.maxTemperature = forecast.maxTemperature;

--- a/modules/default/weather/weatherobject.js
+++ b/modules/default/weather/weatherobject.js
@@ -18,7 +18,7 @@ class WeatherObject {
 	constructor() {
 		this.date = null;
 		this.windSpeed = null;
-		this.windDirection = null;
+		this.windFromDirection = null;
 		this.sunrise = null;
 		this.sunset = null;
 		this.temperature = null;
@@ -34,35 +34,35 @@ class WeatherObject {
 	}
 
 	cardinalWindDirection() {
-		if (this.windDirection > 11.25 && this.windDirection <= 33.75) {
+		if (this.windFromDirection > 11.25 && this.windFromDirection <= 33.75) {
 			return "NNE";
-		} else if (this.windDirection > 33.75 && this.windDirection <= 56.25) {
+		} else if (this.windFromDirection > 33.75 && this.windFromDirection <= 56.25) {
 			return "NE";
-		} else if (this.windDirection > 56.25 && this.windDirection <= 78.75) {
+		} else if (this.windFromDirection > 56.25 && this.windFromDirection <= 78.75) {
 			return "ENE";
-		} else if (this.windDirection > 78.75 && this.windDirection <= 101.25) {
+		} else if (this.windFromDirection > 78.75 && this.windFromDirection <= 101.25) {
 			return "E";
-		} else if (this.windDirection > 101.25 && this.windDirection <= 123.75) {
+		} else if (this.windFromDirection > 101.25 && this.windFromDirection <= 123.75) {
 			return "ESE";
-		} else if (this.windDirection > 123.75 && this.windDirection <= 146.25) {
+		} else if (this.windFromDirection > 123.75 && this.windFromDirection <= 146.25) {
 			return "SE";
-		} else if (this.windDirection > 146.25 && this.windDirection <= 168.75) {
+		} else if (this.windFromDirection > 146.25 && this.windFromDirection <= 168.75) {
 			return "SSE";
-		} else if (this.windDirection > 168.75 && this.windDirection <= 191.25) {
+		} else if (this.windFromDirection > 168.75 && this.windFromDirection <= 191.25) {
 			return "S";
-		} else if (this.windDirection > 191.25 && this.windDirection <= 213.75) {
+		} else if (this.windFromDirection > 191.25 && this.windFromDirection <= 213.75) {
 			return "SSW";
-		} else if (this.windDirection > 213.75 && this.windDirection <= 236.25) {
+		} else if (this.windFromDirection > 213.75 && this.windFromDirection <= 236.25) {
 			return "SW";
-		} else if (this.windDirection > 236.25 && this.windDirection <= 258.75) {
+		} else if (this.windFromDirection > 236.25 && this.windFromDirection <= 258.75) {
 			return "WSW";
-		} else if (this.windDirection > 258.75 && this.windDirection <= 281.25) {
+		} else if (this.windFromDirection > 258.75 && this.windFromDirection <= 281.25) {
 			return "W";
-		} else if (this.windDirection > 281.25 && this.windDirection <= 303.75) {
+		} else if (this.windFromDirection > 281.25 && this.windFromDirection <= 303.75) {
 			return "WNW";
-		} else if (this.windDirection > 303.75 && this.windDirection <= 326.25) {
+		} else if (this.windFromDirection > 303.75 && this.windFromDirection <= 326.25) {
 			return "NW";
-		} else if (this.windDirection > 326.25 && this.windDirection <= 348.75) {
+		} else if (this.windFromDirection > 326.25 && this.windFromDirection <= 348.75) {
 			return "NNW";
 		} else {
 			return "N";


### PR DESCRIPTION
Fixes so the Yr weather direction is not inverted. This error was [reported in the community](https://forum.magicmirror.builders/topic/17561/wind-direction-180-degrees-twisted-at-yr).

I misunderstood when developing the module because of the wind direction arrow was pointing opposite to the arrow displayed on Yr.no. I renamed the variable to help other developers in the future.