### PR TITLE
Fix async node_helper stopping electron start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix message display with HTML code into alert module (#2828)
 - Fix typo into french translation
 - Yr wind direction is no longer inverted
+- Fix async node_helper stopping electron start (#2487)
 
 ## [2.22.0] - 2023-01-01
 

--- a/js/app.js
+++ b/js/app.js
@@ -249,11 +249,12 @@ function App() {
 					});
 
 					Log.log("Sockets connected & modules started ...");
-					if (typeof callback === "function") {
-						callback(config);
-					}
 				});
 			});
+
+			if (typeof callback === "function") {
+				callback(config);
+			}
 		});
 	};
 


### PR DESCRIPTION
Async node_helper dont have to finish immediately in loadModules. So the start callback in the app.js with the config isnt called for some time. But the electron ready event can already be fired in the meantime.

This lead to the electron app starting but without a config (which is provded by the node_helper callback) therefor crashing. 

This PR fixes #2487 by moving the callback call out of the loadModules block, therefor the config is provided in time.

If any new async node_helper doesnt like this, we will see it :-)