### PR TITLE
Point wind arrow in the direction the wind is flowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix message display with HTML code into alert module (#2828)
 - Fix typo into french translation
 - Yr wind direction is no longer inverted
+- The wind direction arrow now points in the direction the wind is flowing, not into the wind.
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/weather/current.njk
+++ b/modules/default/weather/current.njk
@@ -7,7 +7,7 @@
                 {% if config.showWindDirection %}
                     <sup>
                         {% if config.showWindDirectionAsArrow %}
-                            <i class="fas fa-long-arrow-alt-up" style="transform:rotate({{ current.windFromDirection }}deg);"></i>
+                            <i class="fas fa-long-arrow-alt-down" style="transform:rotate({{ current.windFromDirection }}deg);"></i>
                         {% else %}
                             {{ current.cardinalWindDirection() | translate }}
                         {% endif %}

--- a/tests/e2e/modules/weather_current_spec.js
+++ b/tests/e2e/modules/weather_current_spec.js
@@ -46,7 +46,7 @@ describe("Weather module", () => {
 		});
 
 		it("should render windDirection with an arrow", async () => {
-			const elem = await helpers.waitForElement(".weather .normal.medium sup i.fa-long-arrow-alt-up");
+			const elem = await helpers.waitForElement(".weather .normal.medium sup i.fa-long-arrow-alt-down");
 			expect(elem).not.toBe(null);
 			expect(elem.outerHTML).toContain("transform:rotate(250deg);");
 		});


### PR DESCRIPTION
Fixes #3019

The previous implementation had the arrow pointing in to the wind. When the wind blows from the north (0 degrees), the arrow should point straight down. In other words, no rotation of the arrow-down symbol. When the wind blows from the south (180 degrees), the arrow should point straight up (I.e. the arrow down symbol rotated 180 degrees).