### PR TITLE
Calendar Module QOL Features and Adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Special thanks to @khassel, @rejas and @sdetweil for taking over most (if not al
 
 ### Added
 
+- Added new calendar options for colored entries and improved styling (#3033)
 - Added test for remoteFile option in compliments module
 - Added hourlyWeather functionality to Weather.gov weather provider
 - Removed weatherEndpoint definition from weathergov.js (not used)

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -1,4 +1,7 @@
 .calendar .symbol {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
   padding-left: 0;
   padding-right: 10px;
   font-size: var(--font-size-small);

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -1,7 +1,4 @@
 .calendar .symbol {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
   padding-left: 0;
   padding-right: 10px;
   font-size: var(--font-size-small);

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -240,6 +240,17 @@ Module.register("calendar", {
 				}
 			}
 
+			const eventContainer = document.createElement("table");
+			eventContainer.className = "event-container";
+
+			if (this.config.coloredBackground) {
+				eventContainer.style.backgroundColor = this.bgColorForUrl(event.url);
+			}
+
+			if (this.config.coloredBorder) {
+				eventContainer.style.borderColor = this.colorForUrl(event.url);
+			}
+
 			const eventWrapper = document.createElement("tr");
 
 			if (this.config.coloredText) {

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -91,6 +91,8 @@ Module.register("calendar", {
 
 	// Override start method.
 	start: function () {
+		const ONE_MINUTE = 60 * 1000;
+
 		Log.info("Starting module: " + this.name);
 
 		// Set locale.
@@ -136,6 +138,14 @@ Module.register("calendar", {
 			// fetcher till cycle
 			this.addCalendar(calendar.url, calendar.auth, calendarConfig);
 		});
+
+		// Refresh the DOM every minute if needed: When using relative date format for events that start
+		// or end in less than an hour, the date shows minute granularity and we want to keep that accurate.
+		setTimeout(() => {
+			setInterval(() => {
+				this.updateDom(1);
+			}, ONE_MINUTE);
+		}, ONE_MINUTE - (new Date() % ONE_MINUTE));
 	},
 
 	// Override socket notification handler.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -67,7 +67,7 @@ Module.register("calendar", {
 		coloredSymbol: false,
 		coloredBackground: false,
 		limitDaysNeverSkip: false,
-		flipDateHeaderTitle: false,
+		flipDateHeaderTitle: false
 	},
 
 	requiresVersion: "2.1.0",
@@ -230,7 +230,7 @@ Module.register("calendar", {
 					lastSeenDate = dateAsString;
 				}
 			}
-			
+
 			const eventWrapper = document.createElement("tr");
 
 			if (this.config.coloredText) {
@@ -312,8 +312,7 @@ Module.register("calendar", {
 			}
 
 			if (this.config.timeFormat === "dateheaders") {
-				if (this.config.flipDateHeaderTitle) 
-					eventWrapper.appendChild(titleWrapper);
+				if (this.config.flipDateHeaderTitle) eventWrapper.appendChild(titleWrapper);
 
 				if (event.fullDayEvent) {
 					titleWrapper.colSpan = "2";
@@ -332,11 +331,9 @@ Module.register("calendar", {
 
 					eventWrapper.appendChild(timeWrapper);
 
-					if (!this.config.flipDateHeaderTitle) 
-						titleWrapper.classList.add("align-right");
+					if (!this.config.flipDateHeaderTitle) titleWrapper.classList.add("align-right");
 				}
-				if (!this.config.flipDateHeaderTitle)
-					eventWrapper.appendChild(titleWrapper);
+				if (!this.config.flipDateHeaderTitle) eventWrapper.appendChild(titleWrapper);
 			} else {
 				const timeWrapper = document.createElement("td");
 
@@ -527,18 +524,18 @@ Module.register("calendar", {
 				const event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 
 				if (this.config.hidePrivate && event.class === "PRIVATE") {
-						// do not add the current event, skip it
-						continue;
-					}
+					// do not add the current event, skip it
+					continue;
+				}
 				if (limitNumberOfEntries) {
 					if (event.endDate < now) {
 						continue;
 					}
 					if (this.config.hideOngoing && event.startDate < now) {
 						continue;
-				}
-				if (this.listContainsEvent(events, event)) {
-					continue;
+					}
+					if (this.listContainsEvent(events, event)) {
+						continue;
 					}
 					if (--remainingEntries < 0) {
 						break;
@@ -605,7 +602,7 @@ Module.register("calendar", {
 				// check if we already are showing max unique days
 				if (eventDate > lastDate) {
 					// if the only entry in the first day is a full day event that day is not counted as unique
-					if (!this.config.limitDaysNeverSkip && (newEvents.length === 1 && days === 1 && newEvents[0].fullDayEvent)) {
+					if (!this.config.limitDaysNeverSkip && newEvents.length === 1 && days === 1 && newEvents[0].fullDayEvent) {
 						days--;
 					}
 					days++;
@@ -751,10 +748,9 @@ Module.register("calendar", {
 	 * @param {string} url The calendar url
 	 * @returns {string} The color
 	 */
-	 bgColorForUrl: function (url) {
+	bgColorForUrl: function (url) {
 		return this.getCalendarProperty(url, "bgColor", "#fff");
 	},
-	
 
 	/**
 	 * Retrieves the count title for a specific calendar url.
@@ -772,9 +768,9 @@ Module.register("calendar", {
 	 * @param {string} url The calendar url
 	 * @returns {number} The maximum entry count
 	 */
-		maximumEntriesForUrl: function (url) {
-			return this.getCalendarProperty(url, "maximumEntries", this.config.maximumEntries);
-		},
+	maximumEntriesForUrl: function (url) {
+		return this.getCalendarProperty(url, "maximumEntries", this.config.maximumEntries);
+	},
 
 	/**
 	 * Helper method to retrieve the property for a specific calendar url.

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -251,21 +251,18 @@ Module.register("calendar", {
 				}
 			}
 
-			const eventContainer = document.createElement("table");
-			eventContainer.className = "event-container";
-
-			if (this.config.coloredBackground) {
-				eventContainer.style.backgroundColor = this.colorForUrl(event.url, true);
-			}
-
-			if (this.config.coloredBorder) {
-				eventContainer.style.borderColor = this.colorForUrl(event.url, false);
-			}
-
 			const eventWrapper = document.createElement("tr");
 
 			if (this.config.coloredText) {
 				eventWrapper.style.cssText = "color:" + this.colorForUrl(event.url, false);
+			}
+
+			if (this.config.coloredBackground) {
+				eventWrapper.style.backgroundColor = this.colorForUrl(event.url, true);
+			}
+
+			if (this.config.coloredBorder) {
+				eventWrapper.style.borderColor = this.colorForUrl(event.url, false);
 			}
 
 			eventWrapper.className = "normal event";
@@ -453,8 +450,6 @@ Module.register("calendar", {
 				eventWrapper.appendChild(timeWrapper);
 			}
 
-			eventContainer.appendChild(eventWrapper);
-
 			// Create fade effect.
 			if (index >= startFade) {
 				currentFadeStep = index - startFade;
@@ -479,7 +474,7 @@ Module.register("calendar", {
 					descCell.innerHTML = this.titleTransform(event.location, this.config.locationTitleReplace, this.config.wrapLocationEvents, this.config.maxLocationTitleLength, this.config.maxEventTitleLines);
 					locationRow.appendChild(descCell);
 
-					eventContainer.appendChild(locationRow);
+					eventWrapper.appendChild(locationRow);
 
 					if (index >= startFade) {
 						currentFadeStep = index - startFade;
@@ -487,7 +482,7 @@ Module.register("calendar", {
 					}
 				}
 			}
-			wrapper.appendChild(eventContainer);
+			wrapper.appendChild(eventWrapper);
 		});
 
 		return wrapper;

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -710,7 +710,6 @@ Module.register("calendar", {
 					// Get the default prefix for this class name and add to the custom symbol provided
 					const className = this.getCalendarProperty(event.url, "symbolClassName", this.config.defaultSymbolClassName);
 					symbols[0] = className + ev.symbol;
-					symbols[0] = ev.symbol;
 					break;
 				}
 			}

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -98,7 +98,7 @@ Module.register("calendar", {
 		if (this.config.colored) {
 			Log.warn("Your are using the deprecated config values 'colored'. Please switch to  'coloredSymbol' & 'coloredText'!");
 			this.config.coloredText = true;
-			this.config.coloredSymbol = true;		
+			this.config.coloredSymbol = true;
 		}
 		if (this.config.coloredSymbolOnly) {
 			Log.warn("Your are using the deprecated config values 'coloredSymbolOnly'. Please switch to  'coloredSymbol' & 'coloredText'!");
@@ -150,7 +150,6 @@ Module.register("calendar", {
 			this.addCalendar(calendar.url, calendar.auth, calendarConfig);
 		});
 
-		
 		// Refresh the DOM every minute if needed: When using relative date format for events that start
 		// or end in less than an hour, the date shows minute granularity and we want to keep that accurate.
 		setTimeout(() => {

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -265,7 +265,7 @@ Module.register("calendar", {
 				eventWrapper.style.borderColor = this.colorForUrl(event.url, false);
 			}
 
-			eventWrapper.className = "normal event";
+			eventWrapper.className = "event-wrapper normal event";
 			if (event.today) eventWrapper.className += " today";
 			else if (event.tomorrow) eventWrapper.className += " tomorrow";
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -95,6 +95,11 @@ Module.register("calendar", {
 
 		Log.info("Starting module: " + this.name);
 
+		if (this.config.colored) {
+			Log.warn("Your are using the deprecated config values 'colored'. Please switch to  'coloredSymbol' & 'coloredText'!");
+			this.config.coloredText = true;
+			this.config.coloredSymbol = true;		
+		}
 		if (this.config.coloredSymbolOnly) {
 			Log.warn("Your are using the deprecated config values 'coloredSymbolOnly'. Please switch to  'coloredSymbol' & 'coloredText'!");
 			this.config.coloredText = false;

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -40,7 +40,6 @@ Module.register("calendar", {
 		hideTime: false,
 		showTimeToday: false,
 		colored: false,
-		coloredSymbolOnly: false,
 		customEvents: [], // Array of {keyword: "", symbol: "", color: ""} where Keyword is a regexp and symbol/color are to be applied for matched
 		tableClass: "small",
 		calendars: [
@@ -675,6 +674,9 @@ Module.register("calendar", {
 			if (typeof ev.symbol !== "undefined" && ev.symbol !== "") {
 				let needle = new RegExp(ev.keyword, "gi");
 				if (needle.test(event.title)) {
+					// Get the default prefix for this class name and add to the custom symbol provided
+					const className = this.getCalendarProperty(event.url, "symbolClassName", this.config.defaultSymbolClassName);
+					symbols[0] = className + ev.symbol;
 					symbols[0] = ev.symbol;
 					break;
 				}

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -455,11 +455,12 @@ Module.register("calendar", {
 				currentFadeStep = index - startFade;
 				eventWrapper.style.opacity = 1 - (1 / fadeSteps) * currentFadeStep;
 			}
+			wrapper.appendChild(eventWrapper);
 
 			if (this.config.showLocation) {
 				if (event.location !== false) {
 					const locationRow = document.createElement("tr");
-					locationRow.className = "normal xsmall light";
+					locationRow.className = "event-wrapper-location normal xsmall light";
 					if (event.today) locationRow.className += " today";
 					else if (event.tomorrow) locationRow.className += " tomorrow";
 
@@ -468,13 +469,25 @@ Module.register("calendar", {
 						locationRow.appendChild(symbolCell);
 					}
 
+					if (this.config.coloredText) {
+						locationRow.style.cssText = "color:" + this.colorForUrl(event.url, false);
+					}
+
+					if (this.config.coloredBackground) {
+						locationRow.style.backgroundColor = this.colorForUrl(event.url, true);
+					}
+
+					if (this.config.coloredBorder) {
+						locationRow.style.borderColor = this.colorForUrl(event.url, false);
+					}
+
 					const descCell = document.createElement("td");
 					descCell.className = "location";
 					descCell.colSpan = "2";
 					descCell.innerHTML = this.titleTransform(event.location, this.config.locationTitleReplace, this.config.wrapLocationEvents, this.config.maxLocationTitleLength, this.config.maxEventTitleLines);
 					locationRow.appendChild(descCell);
 
-					eventWrapper.appendChild(locationRow);
+					wrapper.appendChild(locationRow);
 
 					if (index >= startFade) {
 						currentFadeStep = index - startFade;
@@ -482,7 +495,6 @@ Module.register("calendar", {
 					}
 				}
 			}
-			wrapper.appendChild(eventWrapper);
 		});
 
 		return wrapper;

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -91,6 +91,8 @@ Module.register("calendar", {
 
 	// Override start method.
 	start: function () {
+		const ONE_MINUTE = 60 * 1000;
+
 		Log.info("Starting module: " + this.name);
 
 		if (this.config.coloredSymbolOnly) {
@@ -142,6 +144,15 @@ Module.register("calendar", {
 			// fetcher till cycle
 			this.addCalendar(calendar.url, calendar.auth, calendarConfig);
 		});
+
+		
+		// Refresh the DOM every minute if needed: When using relative date format for events that start
+		// or end in less than an hour, the date shows minute granularity and we want to keep that accurate.
+		setTimeout(() => {
+			setInterval(() => {
+				this.updateDom(1);
+			}, ONE_MINUTE);
+		}, ONE_MINUTE - (new Date() % ONE_MINUTE));
 	},
 
 	// Override socket notification handler.


### PR DESCRIPTION
This commit adds several QOL features and adjustments to the calendar module including: 
- **New Options**
    - ``coloredText``: ``(default: false)`` Determines if you want your entry text to be colored based on the calendar's color
    - ``coloredBorder``: ``(default: false)`` Determines if you want entry borders to be colored based on the calendar's color 
    - ``coloredSymbol``: ``(default: false)`` Determines if you want entry symbols to be colored based on the calendar's color
    - ``coloredBackground``: ``(default: false)`` Determines if you want entry backgrounds to be colored based on the calendar's color
        > These new colored options allows for more out-of-box styling options for the calendar module. With this the ``coloredSymbolOnly`` option has been removed due to redundancy
    - ``limitDaysNeverSkip``: ``(default: false)`` show every event for every day regardless of if the day only has a single full day event  
    - ``flipDateHeaderTitle``: ``(default: false)`` determines if the title for the date header in the ``dateheaders`` time format should align to the left ``[eg: false]`` or right ``[eg: true]``
- **Layout Changes** 
    - ``dateheader`` is now a class avaliable for date headers in the ``dateheaders`` time format.
    - Event entries have been better *container-ized* for better styling (using the ``event-container`` class)
    - ``repeatingCountTitle`` now has a seperator between the ``yearDiff`` and ``repeatingCountTitle``
    - ``endDate`` in ``dateheaders`` now capitalizes it's first letter
