### PR TITLE
Fixed wind speed units for Open-Meteo Weather Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Cleanup jest coverage for patches
 - Update `stylelint` dependencies, switch to `stylelint-config-standard` and handle `stylelint` issues
 - Convert lots of callbacks to async/await
+- Fixed Open-Meteo wind speed units
 
 ### Fixed
 

--- a/modules/default/weather/providers/openmeteo.js
+++ b/modules/default/weather/providers/openmeteo.js
@@ -24,7 +24,7 @@ WeatherProvider.register("openmeteo", {
 		apiBase: OPEN_METEO_BASE,
 		lat: 0,
 		lon: 0,
-		past_days: 0,
+		pastDays: 0,
 		type: "current"
 	},
 
@@ -227,12 +227,12 @@ WeatherProvider.register("openmeteo", {
 			longitude: this.config.lon,
 			timeformat: "unixtime",
 			timezone: "auto",
-			past_days: this.config.past_days ?? 0,
+			past_days: this.config.pastDays ?? 0,
 			daily: this.dailyParams,
 			hourly: this.hourlyParams,
 			// Fixed units as metric
 			temperature_unit: "celsius",
-			windspeed_unit: "kmh",
+			windspeed_unit: "ms",
 			precipitation_unit: "mm"
 		};
 


### PR DESCRIPTION
Resolved technical debt for [2964](https://github.com/MichMich/MagicMirror/pull/2964):

- Set wind speed unit to m/s
- Rename parameter `past_days` to `pastDays` to be consistent with all configs