### PR TITLE
set all calendar colums to vertical align top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix async node_helper stopping electron start (#2487)
 - The wind direction arrow now points in the direction the wind is flowing, not into the wind (#3019)
 - Fix precipitation css styles and rounding value
+- Fix wrong vertical alignment of calendar title column when wrapEvents is true (#3053)
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -1,7 +1,10 @@
-.calendar .symbol {
+.calendar .event-wrapper {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
+}
+
+.calendar .symbol {
   padding-left: 0;
   padding-right: 10px;
   font-size: var(--font-size-small);
@@ -19,5 +22,4 @@
 .calendar .time {
   padding-left: 30px;
   text-align: right;
-  vertical-align: top;
 }

--- a/modules/default/calendar/calendar.css
+++ b/modules/default/calendar/calendar.css
@@ -1,10 +1,7 @@
-.calendar .event-wrapper {
+.calendar .symbol {
   display: flex;
   flex-direction: row;
   justify-content: flex-end;
-}
-
-.calendar .symbol {
   padding-left: 0;
   padding-right: 10px;
   font-size: var(--font-size-small);
@@ -17,9 +14,11 @@
 .calendar .title {
   padding-left: 0;
   padding-right: 0;
+  vertical-align: top;
 }
 
 .calendar .time {
   padding-left: 30px;
   text-align: right;
+  vertical-align: top;
 }


### PR DESCRIPTION
The title column was vertical centered before.

Fixes #3053 
