### PR TITLE
Fix empty news feed stopping the feed from ever updating again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ _This release is scheduled to be released on 2023-04-01._
 - The wind direction arrow now points in the direction the wind is flowing, not into the wind (#3019)
 - Fix precipitation css styles and rounding value
 - Fix wrong vertical alignment of calendar title column when wrapEvents is true (#3053)
+- Fix empty news feed stopping the reload forever
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -72,11 +72,15 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 
 		parser.on("end", () => {
 			this.broadcastItems();
-			scheduleTimer();
 		});
 
 		parser.on("error", (error) => {
 			fetchFailedCallback(this, error);
+			scheduleTimer();
+		});
+
+		//"end" event is not broadcast if the feed is empty but "finish" is used for both
+		parser.on("finish", () => {
 			scheduleTimer();
 		});
 


### PR DESCRIPTION
If a news feed returns an empty file it will cause the feed to only show the previous entries forever since no new fetch is scheduled.