### PR TITLE
fix e2e tests (failed after async changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix precipitation css styles and rounding value
 - Fix wrong vertical alignment of calendar title column when wrapEvents is true (#3053)
 - Fix empty news feed stopping the reload forever
+- Fix e2e tests (failed after async changes) by running calendar and newsfeed tests last
 
 ## [2.22.0] - 2023-01-01
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"test:coverage": "NODE_ENV=test jest --coverage -i --verbose false --forceExit",
 		"test:electron": "NODE_ENV=test jest --selectProjects electron -i --forceExit",
 		"test:e2e": "NODE_ENV=test jest --selectProjects e2e -i --forceExit",
-		"test:unit": "NODE_ENV=test jest --selectProjects unit -i --forceExit",
+		"test:unit": "NODE_ENV=test jest --selectProjects unit",
 		"test:prettier": "prettier . --check",
 		"test:js": "eslint 'js/**/*.js' 'modules/default/**/*.js' 'clientonly/*.js' 'serveronly/*.js' 'translations/*.js' 'vendor/*.js' 'tests/**/*.js' 'config/*' --config .eslintrc.json",
 		"test:css": "stylelint 'css/main.css' 'fonts/*.css' 'modules/default/**/*.css' 'vendor/*.css' --config .stylelintrc.json",

--- a/tests/utils/test_sequencer.js
+++ b/tests/utils/test_sequencer.js
@@ -2,11 +2,15 @@ const TestSequencer = require("@jest/test-sequencer").default;
 
 class CustomSequencer extends TestSequencer {
 	sort(tests) {
-		const orderPath = ["unit", "e2e", "electron"];
+		const orderPath = ["unit", "electron", "e2e"];
 		return tests.sort((testA, testB) => {
 			let indexA = -1;
 			let indexB = -1;
 			const reg = ".*/tests/([^/]*).*";
+
+			// move calendar and newsfeed at the end
+			if (testA.path.includes("e2e/modules/calendar_spec") || testA.path.includes("e2e/modules/newsfeed_spec")) return 1;
+			if (testB.path.includes("e2e/modules/calendar_spec") || testB.path.includes("e2e/modules/newsfeed_spec")) return -1;
 
 			let matchA = new RegExp(reg, "g").exec(testA.path);
 			if (matchA.length > 0) indexA = orderPath.indexOf(matchA[1]);


### PR DESCRIPTION
 by running calendar and newsfeed tests last.

Additional change: allow unit tests to run parallel

This is no fix of the real issue of calendar and newsfeed tests but I moved them to the end of the tests so other tests are not failing anymore.

There are coming follow up PR's for the real fixes (when I find the culprits).

With these change we can stay with the async changes done by @rejas and https://github.com/MichMich/MagicMirror/pull/3060 is obsolete.