### PR TITLE
Issue#3064 html alert title message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix wrong vertical alignment of calendar title column when wrapEvents is true (#3053)
 - Fix empty news feed stopping the reload forever
 - Fix e2e tests (failed after async changes) by running calendar and newsfeed tests last
+- Fix default alert module to render HTML for title and message
 
 ## [2.22.0] - 2023-01-01
 

--- a/modules/default/alert/templates/alert.njk
+++ b/modules/default/alert/templates/alert.njk
@@ -8,11 +8,11 @@
   <br/>
 {% endif %}
 {% if title %}
-  <span class="thin dimmed medium">{{ title | safe if (titleType == null || titleType == 'html') else title }}</span>
+  <span class="thin dimmed medium">{{ title | safe if (titleType == null or titleType == 'html') else title }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe if (messageType == null || messageType == 'html') else message }}</span>
+  <span class="light bright small">{{ message | safe if (messageType == null or messageType == 'html') else message }}</span>
 {% endif %}

--- a/modules/default/alert/templates/alert.njk
+++ b/modules/default/alert/templates/alert.njk
@@ -8,11 +8,11 @@
   <br/>
 {% endif %}
 {% if title %}
-  <span class="thin dimmed medium">{{ title }}</span>
+  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe }}</span>
+  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
 {% endif %}

--- a/modules/default/alert/templates/alert.njk
+++ b/modules/default/alert/templates/alert.njk
@@ -8,11 +8,11 @@
   <br/>
 {% endif %}
 {% if title %}
-  <span class="thin dimmed medium">{{ title | safe if (titleType == null or titleType == 'html') else title }}</span>
+  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe if (messageType == null or messageType == 'html') else message }}</span>
+  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
 {% endif %}

--- a/modules/default/alert/templates/alert.njk
+++ b/modules/default/alert/templates/alert.njk
@@ -8,11 +8,11 @@
   <br/>
 {% endif %}
 {% if title %}
-  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
+  <span class="thin dimmed medium">{{ title | safe if (titleType == null || titleType == 'html') else title }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
+  <span class="light bright small">{{ message | safe if (messageType == null || messageType == 'html') else message }}</span>
 {% endif %}

--- a/modules/default/alert/templates/notification.njk
+++ b/modules/default/alert/templates/notification.njk
@@ -1,9 +1,9 @@
 {% if title %}
-  <span class="thin dimmed medium">{{ title }}</span>
+  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe }}</span>
+  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
 {% endif %}

--- a/modules/default/alert/templates/notification.njk
+++ b/modules/default/alert/templates/notification.njk
@@ -1,9 +1,9 @@
 {% if title %}
-  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
+  <span class="thin dimmed medium">{{ title | safe if (titleType == null || titleType == 'html') else title }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
+  <span class="light bright small">{{ message | safe if (messageType == null || messageType == 'text') else message }}</span>
 {% endif %}

--- a/modules/default/alert/templates/notification.njk
+++ b/modules/default/alert/templates/notification.njk
@@ -1,9 +1,9 @@
 {% if title %}
-  <span class="thin dimmed medium">{{ title | safe if (titleType == null || titleType == 'html') else title }}</span>
+  <span class="thin dimmed medium">{{ title | safe if (titleType == null or titleType == 'html') else title }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe if (messageType == null || messageType == 'text') else message }}</span>
+  <span class="light bright small">{{ message | safe if (messageType == null or messageType == 'text') else message }}</span>
 {% endif %}

--- a/modules/default/alert/templates/notification.njk
+++ b/modules/default/alert/templates/notification.njk
@@ -1,9 +1,9 @@
 {% if title %}
-  <span class="thin dimmed medium">{{ title | safe if (titleType == null or titleType == 'html') else title }}</span>
+  <span class="thin dimmed medium">{{ title if titleType == 'text' else title | safe }}</span>
 {% endif %}
 {% if message %}
   {% if title %}
     <br/>
   {% endif %}
-  <span class="light bright small">{{ message | safe if (messageType == null or messageType == 'text') else message }}</span>
+  <span class="light bright small">{{ message if messageType == 'text' else message | safe }}</span>
 {% endif %}


### PR DESCRIPTION
Fixes [#3064](https://github.com/MichMich/MagicMirror/issues/3064)

- Fixes default alert module nunjucks templates to render HTML by default unless  'titleType' and 'messageType' are set to 'text' in the payload data

e.g. 

Display Text:
`this.sendNotification('SHOW_ALERT', {type: "notification", title: "<u>YoLink LeakSensor</u>", titleType: "text", message: "<b>" + deviceName + "</b> reported an alarm that needs attention.", messageType: "text"});`

Display HTML:
`this.sendNotification('SHOW_ALERT', {type: "notification", title: "<u>YoLink LeakSensor</u>", message: "<b>" + deviceName + "</b> reported an alarm that needs attention."});`