### PR TITLE
Fix import order in serveronly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Update `stylelint` dependencies, switch to `stylelint-config-standard` and handle `stylelint` issues, update `main.css` matching new rules
 - Update Eslint config, add new rule and handle issue
 - Convert lots of callbacks to async/await
-- Revise require imports
+- Revise require imports (#3071 and #3072)
 
 ### Fixed
 
@@ -58,7 +58,7 @@ _This release is scheduled to be released on 2023-04-01._
 - Fix e2e tests (failed after async changes) by running calendar and newsfeed tests last
 - Lint: Use template literals instead of string concatenation
 - Fix default alert module to render HTML for title and message
-- Fixed Open-Meteo wind speed units
+- Fix Open-Meteo wind speed units
 
 ## [2.22.0] - 2023-01-01
 

--- a/serveronly/index.js
+++ b/serveronly/index.js
@@ -1,5 +1,5 @@
-const Log = require("logger");
 const app = require("../js/app");
+const Log = require("../js/logger");
 
 app.start().then((config) => {
 	const bindAddress = config.address ? config.address : "localhost";


### PR DESCRIPTION
To fix issue caused by #3071

In order to still fulfill the new linter rule `import/order`, I replaced the alias with the path.

I also see two other approaches, but I opted for the simplest one here for now.

The other approaches:
1. Also create an alias for `app`.
2. Use new `imports` (like in PR #2934), but let  `_moduleAliases` untouched to stay compatible to 3rd party modules.

**Edit**: Oh, I thought of another option:
- Add `require("module-alias/register");`