### PR TITLE
removed unneeded (and unwanted) '.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ _This release is scheduled to be released on 2023-07-01._
 
 ### Removed
 
+- Removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (#2896, second attempt ...)
+
 ### Updated
 
 - Update electron to v24

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -313,7 +313,7 @@ Module.register("calendar", {
 					const thisYear = new Date(parseInt(event.startDate)).getFullYear(),
 						yearDiff = thisYear - event.firstYear;
 
-					repeatingCountTitle = `, ${yearDiff}. ${repeatingCountTitle}`;
+					repeatingCountTitle = `, ${yearDiff} ${repeatingCountTitle}`;
 				}
 			}
 


### PR DESCRIPTION
 after the year in calendar repeatingCountTitle (#2896, second attempt ...)
