### PR TITLE
Drop node v14 support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,7 +43,7 @@ When submitting a new issue, please supply the following information:
 
 **Platform**: Place your platform here... give us your web browser/Electron version _and_ your hardware (Raspberry Pi 2/3/4, Windows, Mac, Linux, System V UNIX).
 
-**Node Version**: Make sure it's version 14 or later (recommended is 16).
+**Node Version**: Make sure it's version 16 or later (recommended is 18).
 
 **MagicMirror² Version**: Please let us know which version of MagicMirror² you are running. It can be found in the `package.json` file.
 

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -31,7 +31,7 @@ When submitting a new issue, please supply the following information:
 
 **Platform**: Place your platform here... give us your web browser/Electron version _and_ your hardware (Raspberry Pi 2/3/4, Windows, Mac, Linux, System V UNIX).
 
-**Node Version**: Make sure it's version 14 or later (recommended is 16).
+**Node Version**: Make sure it's version 16 or later (recommended is 18).
 
 **MagicMirror² Version**: Please let us know which version of MagicMirror² you are running. It can be found in the `package.json` file.
 

--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 19.x]
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _This release is scheduled to be released on 2023-07-01._
 ### Updated
 
 - Update electron to v24
+- Use node v19 in github workflow (replacing v14).
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
 				"suncalc": "^1.9.0"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			},
 			"optionalDependencies": {
 				"electron": "^24.0.0"

--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
 		"fetch": "js/fetch.js"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	}
 }


### PR DESCRIPTION
node v14 will have reached end-of-life by the next release.

From April 18th we can use node v20 instead of v19 for testing.