### PR TITLE
added test for serveronly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2023-07-01._
 
 ### Added
 
+- Added tests for severonly
+
 ### Removed
 
 - Removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (#2896, second attempt ...)

--- a/tests/configs/port_variable.js.template
+++ b/tests/configs/port_variable.js.template
@@ -3,7 +3,7 @@
  * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
  * MIT Licensed.
  */
-let config = require(process.cwd() + "/tests/configs/default.js").configFactory({
+let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	port: ${MM_PORT}
 });
 

--- a/tests/e2e/serveronly_spec.js
+++ b/tests/e2e/serveronly_spec.js
@@ -1,0 +1,28 @@
+const helpers = require("./helpers/global-setup");
+
+const delay = (time) => {
+	return new Promise((resolve) => setTimeout(resolve, time));
+};
+
+describe("App environment", () => {
+	let serverProcess;
+	beforeAll(async () => {
+		process.env.MM_CONFIG_FILE = "tests/configs/default.js";
+		serverProcess = await require("child_process").spawn("npm", ["run", "server"], { env: process.env, detached: true });
+		// we have to wait until the server is startet
+		await delay(2000);
+	});
+	afterAll(async () => {
+		await process.kill(-serverProcess.pid);
+	});
+
+	it("get request from http://localhost:8080 should return 200", async () => {
+		const res = await helpers.fetch("http://localhost:8080");
+		expect(res.status).toBe(200);
+	});
+
+	it("get request from http://localhost:8080/nothing should return 404", async () => {
+		const res = await helpers.fetch("http://localhost:8080/nothing");
+		expect(res.status).toBe(404);
+	});
+});


### PR DESCRIPTION
- add test for serveronly, fixes #3076 
- use template literals in port_variable.js.template
