### PR TITLE
set Timezone `Europe/Berlin` in unit tests

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -22,12 +22,6 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
-      - name: "Set timezone"
-        uses: szenius/set-timezone@v1.2
-        with:
-          timezoneLinux: "Europe/Berlin"
-          timezoneMacos: "Europe/Berlin"
-          timezoneWindows: "Europe/Berlin"
       - name: "Use Node.js ${{ matrix.node-version }}"
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/codecov-test-suites.yaml
+++ b/.github/workflows/codecov-test-suites.yaml
@@ -19,12 +19,6 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
-      - name: "Set timezone"
-        uses: szenius/set-timezone@v1.2
-        with:
-          timezoneLinux: "Europe/Berlin"
-          timezoneMacos: "Europe/Berlin"
-          timezoneWindows: "Europe/Berlin"
       - name: "Install dependencies and run coverage"
         run: |
           Xvfb :99 -screen 0 1024x768x16 &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ _This release is scheduled to be released on 2023-07-01._
 ### Added
 
 - Added tests for severonly
+- Set Timezone `Europe/Berlin` in unit tests (needed for new formatTime tests)
 
 ### Removed
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,23 +6,24 @@ module.exports = async () => {
 		projects: [
 			{
 				displayName: "unit",
+				globalSetup: "<rootDir>/tests/unit/helpers/global-setup.js",
 				moduleNameMapper: {
 					logger: "<rootDir>/js/logger.js"
 				},
 				testMatch: ["**/tests/unit/**/*.[jt]s?(x)"],
-				testPathIgnorePatterns: ["<rootDir>/tests/unit/mocks"]
+				testPathIgnorePatterns: ["<rootDir>/tests/unit/mocks", "<rootDir>/tests/unit/helpers"]
 			},
 			{
 				displayName: "electron",
 				testMatch: ["**/tests/electron/**/*.[jt]s?(x)"],
-				testPathIgnorePatterns: ["<rootDir>/tests/electron/helpers/"]
+				testPathIgnorePatterns: ["<rootDir>/tests/electron/helpers"]
 			},
 			{
 				displayName: "e2e",
 				setupFilesAfterEnv: ["<rootDir>/tests/e2e/helpers/mock-console.js"],
 				testMatch: ["**/tests/e2e/**/*.[jt]s?(x)"],
 				modulePaths: ["<rootDir>/js/"],
-				testPathIgnorePatterns: ["<rootDir>/tests/e2e/helpers/", "<rootDir>/tests/e2e/mocks"]
+				testPathIgnorePatterns: ["<rootDir>/tests/e2e/helpers", "<rootDir>/tests/e2e/mocks"]
 			}
 		],
 		collectCoverageFrom: ["./clientonly/**/*.js", "./js/**/*.js", "./modules/default/**/*.js", "./serveronly/**/*.js"],

--- a/tests/unit/helpers/global-setup.js
+++ b/tests/unit/helpers/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+	process.env.TZ = "Europe/Berlin";
+};

--- a/tests/unit/modules/default/utils_spec.js
+++ b/tests/unit/modules/default/utils_spec.js
@@ -116,7 +116,6 @@ describe("Default modules utils tests", () => {
 
 		beforeAll(() => {
 			jest.useFakeTimers();
-			moment.tz.setDefault("Europe/Berlin");
 		});
 
 		beforeEach(async () => {


### PR DESCRIPTION
needed for new formatTime unit tests.

Avoiding ugly TZ setting in github workflows, see https://github.com/MichMich/MagicMirror/pull/3073
