### PR TITLE
Newsfeed: Convert HTML entities to characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2023-07-01._
 - Use node v19 in github workflow (replacing v14)
 - Refactor formatTime into common util function for default modules
 - Refactor some calendar methods into own class and added tests for them
+- Properly convert newsfeed titles
 
 ### Fixed
 

--- a/modules/default/newsfeed/newsfeed.js
+++ b/modules/default/newsfeed/newsfeed.js
@@ -215,6 +215,11 @@ Module.register("newsfeed", {
 				return true;
 			}, this);
 		}
+
+		// HTML entity conversion: dummy textarea for conversion and regex for safe matching
+		const entity_regex = /&(?:#x[a-f0-9]+|#[0-9]+|[a-z0-9]+);?/gi;
+		const entity_converter = document.createElement("textarea");
+
 		newsItems.forEach((item) => {
 			//Remove selected tags from the beginning of rss feed items (title or description)
 			if (this.config.removeStartTags === "title" || this.config.removeStartTags === "both") {
@@ -251,6 +256,12 @@ Module.register("newsfeed", {
 					}
 				}
 			}
+
+			//Convert HTML entities to characters
+			item.title = item.title.replace(entity_regex, (t) => {
+				entity_converter.innerHTML = t;
+				return entity_converter.textContent;
+			});
 		});
 
 		// get updated news items and broadcast them


### PR DESCRIPTION
Hey everyone, a local newsfeed includes HTML entities (like `&quot;` and some Umlauts) rather than normal characters in their titles. 

Looks quite strange: 
![image](https://user-images.githubusercontent.com/13392434/232578466-66bbb0a8-2f13-43ed-8b2d-164ac16b4c53.png)

This PR adds some code to properly convert those [entities](https://developer.mozilla.org/en-US/docs/Glossary/Entity) (basically anything starting with `&` and ending with `;`) in a safe manner, while not requiring `dangerouslyDisableAutoEscaping` to be set.

Let me know if you've got any thoughts! 