### PR TITLE
fix: don't filter out ongoing full day events in Calendar module (#3095)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ _This release is scheduled to be released on 2023-07-01._
 - Fix envcanada hourly forecast time (#3080)
 - Fix electron not running under windows after async changes (#3083)
 - Fix style issues after eslint-plugin-jsdoc update
+- Fix don't filter out ongoing full day events (#3095)
 
 ## [2.23.0] - 2023-04-04
 

--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -453,6 +453,11 @@ const CalendarFetcherUtils = {
 					const fullDayEvent = isFacebookBirthday ? true : CalendarFetcherUtils.isFullDayEvent(event);
 					// Log.debug("full day event")
 
+					// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)
+					if (fullDayEvent && startDate.format("x") === endDate.format("x")) {
+						endDate = endDate.endOf("day");
+					}
+
 					if (config.includePastEvents) {
 						// Past event is too far in the past, so skip.
 						if (endDate < past) {
@@ -479,10 +484,6 @@ const CalendarFetcherUtils = {
 						return;
 					}
 
-					// if the start and end are the same, then make end the 'end of day' value (start is at 00:00:00)
-					if (fullDayEvent && startDate.format("x") === endDate.format("x")) {
-						endDate = endDate.endOf("day");
-					}
 					// get correction for date saving and dst change between now and then
 					let adjustDays = CalendarFetcherUtils.calculateTimezoneAdjustment(event, startDate.toDate());
 					// Every thing is good. Add it to the list.

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
@@ -1,0 +1,48 @@
+global.moment = require("moment-timezone");
+
+const CalendarFetcherUtils = require("../../../../../modules/default/calendar/calendarfetcherutils");
+
+describe("Calendar fetcher utils test", () => {
+	const defaultConfig = {
+		excludedEvents: [],
+		includePastEvents: false,
+		maximumEntries: 10,
+		maximumNumberOfDays: 365
+	};
+	describe("filterEvents", () => {
+		it("should return only ongoing and upcoming non full day events", () => {
+			const minusOneHour = moment().subtract(1, "hours").toDate();
+			const minusTwoHours = moment().subtract(2, "hours").toDate();
+			const plusOneHour = moment().add(1, "hours").toDate();
+			const plusTwoHours = moment().add(2, "hours").toDate();
+
+			const newEvents = CalendarFetcherUtils.filterEvents(
+				{
+					pastEvent: { type: "VEVENT", start: minusTwoHours, end: minusOneHour },
+					ongoingEvent: { type: "VEVENT", start: minusOneHour, end: plusOneHour },
+					upcomingEvent: { type: "VEVENT", start: plusOneHour, end: plusTwoHours }
+				},
+				defaultConfig
+			);
+
+			expect(newEvents.length).toEqual(2);
+		});
+
+		it("should return only ongoing and upcoming full day events", () => {
+			const yesterday = moment().subtract(1, "days").startOf("day").toDate();
+			const today = moment().startOf("day").toDate();
+			const tomorrow = moment().add(1, "days").startOf("day").toDate();
+
+			const newEvents = CalendarFetcherUtils.filterEvents(
+				{
+					pastEvent: { type: "VEVENT", start: yesterday, end: yesterday },
+					ongoingEvent: { type: "VEVENT", start: today, end: today },
+					upcomingEvent: { type: "VEVENT", start: tomorrow, end: tomorrow }
+				},
+				defaultConfig
+			);
+
+			expect(newEvents.length).toEqual(2);
+		});
+	});
+});


### PR DESCRIPTION
Param `hideOngoing` is by default set to `false`, but the event filtering handles `full day` & `non-full day` events inconsistently. For `non-full day` _ongoing_ and _upcoming_ events are returned, while for `full day` only _upcoming_ events where returned.
