### PR TITLE
Bug fix: adding date to the analog clock if showDate is true

### DIFF
--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -296,9 +296,14 @@ Module.register("clock", {
 		 */
 		if (this.config.displayType === "analog") {
 			// Display only an analog clock
-			if (this.config.analogShowDate === "top") {
+			if (this.config.showDate) {
+				// Add date to the analog clock
+				dateWrapper.innerHTML = now.format(this.config.dateFormat);
+				wrapper.appendChild(dateWrapper);
+			}
+			if (this.config.analogShowDate === "bottom") {
 				wrapper.classList.add("clock-grid-bottom");
-			} else if (this.config.analogShowDate === "bottom") {
+			} else if (this.config.analogShowDate === "top") {
 				wrapper.classList.add("clock-grid-top");
 			}
 			wrapper.appendChild(analogWrapper);


### PR DESCRIPTION
Adding date to the clock module when displayType is "analog" and "showDate" is true. The setting in analogShowDate is respected. 

Fixes #3100
