### PR TITLE
Use single config backup file when config.template is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Special thanks to @khassel, @rejas and @sdetweil for taking over most (if not al
 - Update Eslint config, add new rule and handle issue
 - Convert lots of callbacks to async/await
 - Revise require imports (#3071 and #3072)
+- Use `config.js-old` instead of file with timestamp suffix when backing up config with a `config.template` in use (#3104)
 
 ### Fixed
 

--- a/js/app.js
+++ b/js/app.js
@@ -76,7 +76,7 @@ function App() {
 			// save current config.js
 			try {
 				if (fs.existsSync(configFilename)) {
-					fs.copyFileSync(configFilename, `${configFilename}_${Date.now()}`);
+					fs.copyFileSync(configFilename, `${configFilename}-old`);
 				}
 			} catch (err) {
 				Log.warn(`Could not copy ${configFilename}: ${err.message}`);


### PR DESCRIPTION
Copy `config.js` to a single `config.js-old` file whenever a `config.template` is present, instead of using `Date()` as a suffix. Creating files with a timestamp suffix means that whenever Magic Mirror is restarted or recreated a new file is written into the config directory.

Benefits:
* Single backup file will avoid excessive writing of files
* Saves space and usage on SD cards.
* Makes the folder cleaner and easier to overview, compared to ending up with something like this as time goes on:
![image](https://github.com/MichMich/MagicMirror/assets/17575446/9b66a99c-e760-471e-884c-9daa19689702)
