### PR TITLE
Fix envcanada today pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ _This release is scheduled to be released on 2023-07-01._
 - Fix style issues after eslint-plugin-jsdoc update
 - Fix don't filter out ongoing full day events (#3095)
 - Fix date not shown when clock in analog mode (#3100)
+- Fix envcanada today percentage-of-precipitation (#3106)
 
 ## [2.23.0] - 2023-04-04
 

--- a/modules/default/weather/providers/envcanada.js
+++ b/modules/default/weather/providers/envcanada.js
@@ -505,9 +505,9 @@ WeatherProvider.register("envcanada", {
 		}
 
 		// Check Today element for POP
-
-		if (foreGroup[today].querySelector("abbreviatedForecast pop").textContent > 0) {
-			weather.precipitationProbability = foreGroup[today].querySelector("abbreviatedForecast pop").textContent;
+		const precipPOP = foreGroup[today].querySelector("abbreviatedForecast pop").textContent * 1.0;
+		if (precipPOP > 0) {
+			weather.precipitationProbability = precipPOP;
 		}
 	},
 


### PR DESCRIPTION
Fix for today's probability-of-precipitation weather module's envcanada provider.

Without which, requesting `showPrecipitationProbability` causes "undefined" to be shown.

Consistent with method used elsewhere in the file:
https://github.com/MichMich/MagicMirror/blob/abe5c08a52ffee6b37c30c1f3160e130f0e966a2/modules/default/weather/providers/envcanada.js#L395-L399