### PR TITLE
fix updatenotification where no branch is checked out ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ _This release is scheduled to be released on 2023-07-01._
 - Fix don't filter out ongoing full day events (#3095)
 - Fix date not shown when clock in analog mode (#3100)
 - Fix envcanada today percentage-of-precipitation (#3106)
+- Fix updatenotification where no branch is checked out but e.g. a version tag (#3130)
 
 ## [2.23.0] - 2023-04-04
 

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -94,18 +94,21 @@ class GitHelper {
 		// ## develop...origin/develop
 		// ## master...origin/master [behind 8]
 		// ## master...origin/master [ahead 8, behind 1]
+		// ## HEAD (no branch)
 		status = status.match(/## (.*)\.\.\.([^ ]*)(?: .*behind (\d+))?/);
 		// examples for status:
 		// [ '## develop...origin/develop', 'develop', 'origin/develop' ]
 		// [ '## master...origin/master [behind 8]', 'master', 'origin/master', '8' ]
 		// [ '## master...origin/master [ahead 8, behind 1]', 'master', 'origin/master', '1' ]
-		gitInfo.current = status[1];
-		gitInfo.tracking = status[2];
+		if (status) {
+			gitInfo.current = status[1];
+			gitInfo.tracking = status[2];
 
-		if (status[3]) {
-			// git fetch was already called before so `git status -sb` delivers already the behind number
-			gitInfo.behind = parseInt(status[3]);
-			gitInfo.isBehindInStatus = true;
+			if (status[3]) {
+				// git fetch was already called before so `git status -sb` delivers already the behind number
+				gitInfo.behind = parseInt(status[3]);
+				gitInfo.isBehindInStatus = true;
+			}
 		}
 
 		return gitInfo;
@@ -114,7 +117,7 @@ class GitHelper {
 	async getRepoInfo(repo) {
 		const gitInfo = await this.getStatusInfo(repo);
 
-		if (!gitInfo) {
+		if (!gitInfo || !gitInfo.current) {
 			return;
 		}
 


### PR DESCRIPTION
... but e.g. a version tag

fixes #3130 

This happens e.g. in my docker image where I use the version tag to get the mm sources.

With this PR the error message is avoided and there will be never an updatenotification when using a tag. This is o.k. because a tag should never be moved.