### PR TITLE
Prevent too frequent request for sample ical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ _This release is scheduled to be released on 2023-07-01._
 - Refactor formatTime into common util function for default modules
 - Refactor some calendar methods into own class and added tests for them
 - Split install and run commands in github actions
+- Add `fetchInterval` of calendar in `config.js.sample` not to request example calendar too frequently. (Requested by calendarlab, the ical provider)
 
 ### Fixed
 

--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -53,6 +53,7 @@ let config = {
 			header: "US Holidays",
 			position: "top_left",
 			config: {
+				fetchInterval: 30 * 60 * 1000,
 				calendars: [
 					{
 						symbol: "calendar-check",


### PR DESCRIPTION
Recently `CalendarLab` told me they have troubles due to Too many/frequent requests from MagicMirror Project. 
So they will change their URL scheme and service privately per user. 

This commit is changing the `5min` update cycle to `30min`.
But anyway, the example of config should be changed from 30th July.
(I'll post this thing detail in the community)
