### PR TITLE
Add openweathermap UV index support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ _This release is scheduled to be released on 2023-10-01._
 
 ### Added
 
+- Added UV Index support to OpenWeatherMap
+
 ### Removed
 
 ### Updated

--- a/modules/default/weather/providers/openweathermap.js
+++ b/modules/default/weather/providers/openweathermap.js
@@ -295,6 +295,7 @@ WeatherProvider.register("openweathermap", {
 			current.temperature = data.current.temp;
 			current.weatherType = this.convertWeatherType(data.current.weather[0].icon);
 			current.humidity = data.current.humidity;
+			current.uv_index = data.current.uvi;
 			if (data.current.hasOwnProperty("rain") && !isNaN(data.current["rain"]["1h"])) {
 				current.rain = data.current["rain"]["1h"];
 				precip = true;
@@ -323,6 +324,7 @@ WeatherProvider.register("openweathermap", {
 				weather.windFromDirection = hour.wind_deg;
 				weather.weatherType = this.convertWeatherType(hour.weather[0].icon);
 				weather.precipitationProbability = hour.pop ? hour.pop * 100 : undefined;
+				weather.uv_index = hour.uvi;
 				precip = false;
 				if (hour.hasOwnProperty("rain") && !isNaN(hour.rain["1h"])) {
 					weather.rain = hour.rain["1h"];
@@ -355,6 +357,7 @@ WeatherProvider.register("openweathermap", {
 				weather.windFromDirection = day.wind_deg;
 				weather.weatherType = this.convertWeatherType(day.weather[0].icon);
 				weather.precipitationProbability = day.pop ? day.pop * 100 : undefined;
+				weather.uv_index = day.uvi;
 				precip = false;
 				if (!isNaN(day.rain)) {
 					weather.rain = day.rain;


### PR DESCRIPTION
This PR adds UV index support to the openweathermap provider for the One Call api.