### PR TITLE
fix clientOnly not starting up after async startup added in 2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,29 +5,167 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ❤️ **Donate:** Enjoying MagicMirror²? [Please consider a donation!](https://magicmirror.builders/donate) With your help we can continue to improve the MagicMirror².
 
-## [2.22.0] - Unreleased (Develop)
-
-_This release is scheduled to be released on 2023-01-01._
-
-Special thanks to: @rejas, @sdetweil
-
-### Added
-
-- Added test for remoteFile option in compliments module
-- Added hourlyWeather functionality to Weather.gov weather provider
-
-### Removed
-
-### Updated
-
-- Updated e2e tests (moved `done()` in helper functions) and use es6 syntax in all tests
-- Updated da translation
-- Rework weather module
-  - Use fetch instead of XMLHttpRequest in weatherprovider
+## [2.25.0] - 2023-10-01
 
 ### Fixed
 
-- Correctly show apparent temperature in SMHI weather provider
+- Fix electron.js startup for clientOnly (#3151)
+
+## [2.24.0] - 2023-07-01
+
+Thanks to: @angeldeejay, @bugsounet, @buxxi, @CarJem, @dariom, @DaveChild, @dWoolridge, @eddiehung, @grenagit, @Hirschberger, @ismarslomic, @JakeBinney, @KristjanESPERANTO, @MagMar94, @naveensrinivasan, @nfogal, @oscarb, @OWL4C, @psieg, @rajniszp, @retroflex, @SkySails and @tomzt
+
+Special thanks to @khassel, @rejas and @sdetweil for taking over most (if not all) of the work on this release as project collaborators. This version would not be there without their effort. Thank you guys! You are awesome!
+
+### Added
+
+- Added UV Index to hourly and current Weather, with support for Openmeteo
+- Added tests for serveronly
+- Set Timezone `Europe/Berlin` in unit tests (needed for new formatTime tests)
+- Added no-param-reassign eslint rule and fix warnings
+- updatenotification: Added `sendUpdatesNotifications` feature. Broadcast update with `UPDATES` notification to other modules
+- updatenotification: allow force scanning with `SCAN_UPDATES` notification from other modules
+- Added per-calendar fetchInterval
+
+### Removed
+
+- Removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (#2896, second attempt ...)
+
+### Updated
+
+- Added support for precipitation probability with openmeteo weather-provider
+- Update electron to v25.2 and other dependencies
+- Use node v20 in github workflow (replacing v14)
+- Refactor formatTime into common util function for default modules
+- Refactor some calendar methods into own class and added tests for them
+- Split install and run commands in github actions
+- Changed `fetchInterval` of calendar in `config.js.sample` to 7 days so we not to request example calendar too frequently
+- Changed default calendar fetchInterval to one hour
+- Changed calendar url in sample config
+
+### Fixed
+
+- Fix envcanada hourly forecast time (#3080)
+- Fix electron not running under windows after async changes (#3083)
+- Fix style issues after eslint-plugin-jsdoc update
+- Fix don't filter out ongoing full day events (#3095)
+- Fix date not shown when clock in analog mode (#3100)
+- Fix envcanada today percentage-of-precipitation (#3106)
+- Fix updatenotification where no branch is checked out but e.g. a version tag (#3130)
+
+## [2.23.0] - 2023-04-04
+
+Thanks to: @angeldeejay, @buxxi, @CarJem, @dariom, @DaveChild, @dWoolridge, @grenagit, @Hirschberger, @KristjanESPERANTO, @MagMar94, @naveensrinivasan, @nfogal, @psieg, @rajniszp, @retroflex, @SkySails and @tomzt.
+
+Special thanks to @khassel, @rejas and @sdetweil for taking over most (if not all) of the work on this release as project collaborators. This version would not be there without their effort. Thank you guys! You are awesome!
+
+### Added
+
+- Added increments for hourly forecasts in weather module (#2996)
+- Added tests for hourly weather forecast
+- Added possibility to ignore MagicMirror repo in updatenotification module
+- Added Pirate Weather as new weather-provider (#3005)
+- Added possibility to use your own templates in Alert module
+- Added error message if `<modulename>.js` file is missing in module folder to get a hint in the logs (#2403)
+- Added possibility to use environment variables in `config.js` (#1756)
+- Added option `pastDaysCount` to default calendar module to control of how many days past events should be displayed
+- Added thai language to alert module
+- Added option `sendNotifications` in clock module (#3056)
+- Added tests for some weather utils
+
+### Removed
+
+- Removed darksky weather-provider
+- Removed unneeded (and unwanted) '.' after the year in calendar repeatingCountTitle (#2896)
+
+### Updated
+
+- Use develop as target branch for dependabot
+- Update issue template, contributing doc and sample config
+- The weather modules clearly separates precipitation amount and probability (risk of rain/snow)
+  - This requires all providers that only supports probability to change the config from `showPrecipitationAmount` to `showPrecipitationProbability`.
+- Update tests for weather and calendar module
+- Changed updatenotification module for MagicMirror repo only: Send only notifications for `master` if there is a tag on a newer commit
+- Update dates in Calendar widgets every minute
+- Cleanup jest coverage for patches
+- Update `stylelint` dependencies, switch to `stylelint-config-standard` and handle `stylelint` issues, update `main.css` matching new rules
+- Update Eslint config, add new rule and handle issue
+- Convert lots of callbacks to async/await
+- Revise require imports (#3071 and #3072)
+- Use `config.js-old` instead of file with timestamp suffix when backing up config with a `config.template` in use (#3104)
+
+### Fixed
+
+- Fix wrong day labels in envcanada forecast (#2987)
+- Fix for missing default class name prefix for customEvents in calendar
+- Fix electron flashing white screen on startup (#1919)
+- Fix weathergov provider hourly forecast (#3008)
+- Fix message display with HTML code into alert module (#2828)
+- Fix typo in french translation
+- Yr wind direction is no longer inverted
+- Fix async node_helper stopping electron start (#2487)
+- The wind direction arrow now points in the direction the wind is flowing, not into the wind (#3019)
+- Fix precipitation css styles and rounding value
+- Fix wrong vertical alignment of calendar title column when wrapEvents is true (#3053)
+- Fix empty news feed stopping the reload forever
+- Fix e2e tests (failed after async changes) by running calendar and newsfeed tests last
+- Lint: Use template literals instead of string concatenation
+- Fix default alert module to render HTML for title and message
+- Fix Open-Meteo wind speed units
+
+## [2.22.0] - 2023-01-01
+
+Thanks to: @angeldeejay, @buxxi, @dariom, @dWoolridge, @KristjanESPERANTO, @MagMar94, @naveensrinivasan, @retroflex, @SkySails and @Tom.
+
+Special thanks to @khassel, @rejas and @sdetweil for taking over most (if not all) of the work on this release as project collaborators. This version would not be there without their effort. Thank you!
+
+### Added
+
+- Added new calendar options for colored entries and improved styling (#3033)
+- Added test for remoteFile option in compliments module
+- Added hourlyWeather functionality to Weather.gov weather-provider
+- Added css class names "today" and "tomorrow" for default calendar
+- Added Collaboration.md
+- Added new github action for dependency review (#2862)
+- Added a WeatherProvider for Open-Meteo
+- Added Yr as a weather-provider
+- Added config options "ignoreXOriginHeader" and "ignoreContentSecurityPolicy"
+- Added thai language
+- Added workflow rule to make sure PRs are based against develop
+
+### Removed
+
+- Removed usage of internal fetch function of node until it is more stable
+- Removed weatherEndpoint definition from weathergov.js (not used)
+
+### Updated
+
+- Cleaned up test directory (#2937) and jest config (#2959)
+- Wait for all modules to start before declaring the system ready (#2487)
+- Updated e2e tests (moved `done()` in helper functions) and use es6 syntax in all tests
+- Updated da translation
+- Rework weather module
+  - Make sure smhi provider api only gets a maximum of 6 digits coordinates (#2955)
+  - Use fetch instead of XMLHttpRequest in weather-provider (#2935)
+  - Reworked how weather-providers handle units (#2849)
+  - Use unix() method for parsing times, fix suntimes on the way (#2950)
+  - Refactor conversion functions into utils class (#2958)
+- The `cors`-method in `server.js` now supports sending and receiving HTTP headers
+- Replace `&hellip;` by `…`
+- Cleanup compliments module
+- Updated dependencies including electron to v22 (#2903)
+
+### Fixed
+
+- Correctly show apparent temperature in SMHI weather-provider
+- Ensure updatenotification module isn't shown when local is _ahead_ of remote
+- Handle node_helper errors during startup (#2944)
+- Possibility to change FontAwesome class in calendar, so icons like `fab fa-facebook-square` works.
+- Fix cors problems with newsfeed articles (as far as possible), allow disabling cors per feed with option `useCorsProxy: false` (#2840)
+- Tests not waiting for the application to start and stop before starting the next test
+- Fix electron tests failing sometimes in github workflow
+- Fixed gap in clock module when displayed on the left side with displayType=digital
+- Fixed playwright issue by upgrading to v1.29.1 (#2969)
 
 ## [2.21.0] - 2022-10-01
 
@@ -38,7 +176,8 @@ Special thanks to: @BKeyport, @buxxi, @davide125, @khassel, @kolbyjack, @krukle,
 - Added possibility to fetch calendars through socket notifications.
 - New scripts `install-mm` (and `install-mm:dev`) for simplifying mm installation (now: `npm run install-mm`) and adding params `--no-audit --no-fund --no-update-notifier` for less noise.
 - New `showTimeToday` option in calendar module shows time for current-day events even if `timeFormat` is `"relative"`.
-- Added hourly forecasts, apparent temperature & custom location name to SMHI weather provider.
+- Added hourly forecasts, apparent temperature & custom location name to SMHI weather-provider.
+- Added new electron tests for calendar and moved some compliments tests from `e2e` to `electron` because of date mocking, removed mock stuff from compliments module.
 
 ### Removed
 
@@ -93,7 +232,7 @@ Special thanks to the following contributors: @10bias, @CFenner, @JHWelch, @k1rd
 - Added test for new weather forecast `absoluteDates` property.
 - The modules get a class hidden added/removed if they get hidden/shown which will also toggle pointer-events.
 - Added new config option `showTitleAsUrl` to newsfeed module. If set, the displayed title is a link to the article which is useful when running in a browser and you want to read this article.
-- Added internal cors proxy to get weather providers working without public proxies (fixes #2714). The new url `http(s)://address:port/cors?url=https://whatever-to-proxy` can be used in other modules too.
+- Added internal cors proxy to get weather-providers working without public proxies (fixes #2714). The new url `http(s)://address:port/cors?url=https://whatever-to-proxy` can be used in other modules too.
 - Added a WeatherProvider for Weatherflow.
 - Added new env var `ELECTRON_DISABLE_GPU` which disable gpu under electron if set (fixes #2831).
 - Added missing Czech translations.
@@ -187,7 +326,7 @@ Special thanks to the following contributors: @apiontek, @eouia, @jupadin, @khas
 - Updated jsdocs and print warnings during testing too.
 - Updated weathergov provider to try fetching not just current, but also foreacst, when API URLs available.
 - Refactored clock layout.
-- Refactored methods from weatherproviders into weatherobject (isDaytime, updateSunTime).
+- Refactored methods from weather-providers into weatherobject (isDaytime, updateSunTime).
 - Use of `logger.js` in jest tests.
 - Run prettier over all relevant files.
 - Move tests needing electron in new category `electron`, use `server only` mode in `e2e` tests.
@@ -285,7 +424,7 @@ Special thanks to the following contributors: @EdgardosReis, @MystaraTheGreat, @
 - Code cleanup for FEELS like and added {DEGREE} placeholder for FEELSLIKE for each language.
 - Converted newsfeed module to use templates.
 - Updated documentation and help screen about invalid config files.
-- Moving weather provider specific code and configuration into each provider and making hourly part of the interface.
+- Moving weather-provider specific code and configuration into each provider and making hourly part of the interface.
 - Bump electron to v11 and enable contextIsolation.
 - Don't update the DOM when a module is not displayed.
 - Cleaned up jsdoc and tests.
@@ -367,7 +506,7 @@ Special thanks to the following contributors: @Alvinger, @AndyPoms, @ashishtank,
 - Rename Greek translation to correct ISO 639-1 alpha-2 code (gr > el). (#2155)
 - Add a space after icons of sunrise and sunset. (#2169)
 - Fix calendar when no DTEND record found in event, startDate overlay when endDate set. (#2177)
-- Fix windspeed conversion error in ukmetoffice weather provider. (#2189)
+- Fix windspeed conversion error in ukmetoffice weather-provider. (#2189)
 - Fix console.debug not having timestamps. (#2199)
 - Fix calendar full day event east of UTC start time. (#2200)
 - Fix non-fullday recurring rule processing. (#2216)
@@ -596,7 +735,7 @@ Special thanks to @sdetweil for all his great contributions!
 - Use Feels Like temp from feed if present
 - Optionally display probability of precipitation (PoP) in current weather (UK Met Office data)
 - Automatically try to fix eslint errors by passing `--fix` option to it
-- Added sunrise and sunset times to weathergov weather provider [#1705](https://github.com/MichMich/MagicMirror/issues/1705)
+- Added sunrise and sunset times to weathergov weather-provider [#1705](https://github.com/MichMich/MagicMirror/issues/1705)
 - Added "useLocationAsHeader" to display "location" in `config.js` as header when location name is not returned
 - Added to `newsfeed.js`: in order to design the news article better with css, three more class-names were introduced: newsfeed-desc, newsfeed-desc, newsfeed-desc
 
@@ -607,7 +746,7 @@ Special thanks to @sdetweil for all his great contributions!
 - Updated `ical.js` to solve various calendar issues.
 - Updated weather city list url [#1676](https://github.com/MichMich/MagicMirror/issues/1676)
 - Only update clock once per minute when seconds aren't shown
-- Updated weatherprovider documentation.
+- Updated weather-provider documentation.
 
 ### Fixed
 
@@ -689,7 +828,7 @@ Fixed `package.json` version number.
 - Added fade, fadePoint and maxNumberOfDays properties to the forecast mode [#1516](https://github.com/MichMich/MagicMirror/issues/1516)
 - Fixed Loading string and decimalSymbol string replace [#1538](https://github.com/MichMich/MagicMirror/issues/1538)
 - Show Snow amounts in new weather module [#1545](https://github.com/MichMich/MagicMirror/issues/1545)
-- Added weather.gov as a new weather provider for US locations
+- Added weather.gov as a new weather-provider for US locations
 
 ## [2.6.0] - 2019-01-01
 

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -11,7 +11,6 @@
 		/**
 		 * Get command line parameters
 		 * Assumes that a cmdline parameter is defined with `--key [value]`
-		 *
 		 * @param {string} key key to look for at the command line
 		 * @param {string} defaultValue value if no key is given at the command line
 		 * @returns {string} the value of the parameter
@@ -33,7 +32,6 @@
 
 	/**
 	 * Gets the config from the specified server url
-	 *
 	 * @param {string} url location where the server is running.
 	 * @returns {Promise} the config
 	 */
@@ -63,7 +61,6 @@
 
 	/**
 	 * Print a message to the console in case of errors
-	 *
 	 * @param {string} message error message to print
 	 * @param {number} code error code for the exit call
 	 */
@@ -87,6 +84,7 @@
 			.then(function (configReturn) {
 				// Pass along the server config via an environment variable
 				const env = Object.create(process.env);
+				env.clientonly = true; // set to pass to electron.js
 				const options = { env: env };
 				configReturn.address = config.address;
 				configReturn.port = config.port;

--- a/js/electron.js
+++ b/js/electron.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const electron = require("electron");
-const core = require("./app.js");
-const Log = require("logger");
+const core = require("./app");
+const Log = require("./logger");
 
 // Config
 let config = process.env.config ? JSON.parse(process.env.config) : {};
@@ -46,8 +46,10 @@ function createWindow() {
 	if (config.kioskmode) {
 		electronOptionsDefaults.kiosk = true;
 	} else {
-		electronOptionsDefaults.fullscreen = true;
-		electronOptionsDefaults.autoHideMenuBar = true;
+		electronOptionsDefaults.show = false;
+		electronOptionsDefaults.frame = false;
+		electronOptionsDefaults.transparent = true;
+		electronOptionsDefaults.hasShadow = false;
 	}
 
 	const electronOptions = Object.assign({}, electronOptionsDefaults, config.electronOptions);
@@ -103,14 +105,26 @@ function createWindow() {
 			}, 1000);
 		});
 	}
-}
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-app.on("ready", function () {
-	Log.log("Launching application.");
-	createWindow();
-});
+	//remove response headers that prevent sites of being embedded into iframes if configured
+	mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+		let curHeaders = details.responseHeaders;
+		if (config["ignoreXOriginHeader"] || false) {
+			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !/x-frame-options/i.test(header[0])));
+		}
+
+		if (config["ignoreContentSecurityPolicy"] || false) {
+			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !/content-security-policy/i.test(header[0])));
+		}
+
+		callback({ responseHeaders: curHeaders });
+	});
+
+	mainWindow.once("ready-to-show", () => {
+		mainWindow.setFullScreen(true);
+		mainWindow.show();
+	});
+}
 
 // Quit when all windows are closed.
 app.on("window-all-closed", function () {
@@ -136,27 +150,39 @@ app.on("activate", function () {
  * Note: this is only used if running Electron. Otherwise
  * core.stop() is called by process.on("SIGINT"... in `app.js`
  */
-app.on("before-quit", (event) => {
+app.on("before-quit", async (event) => {
 	Log.log("Shutting down server...");
 	event.preventDefault();
 	setTimeout(() => {
 		process.exit(0);
 	}, 3000); // Force-quit after 3 seconds.
-	core.stop();
+	await core.stop();
 	process.exit(0);
 });
 
-/* handle errors from self signed certificates */
-
+/**
+ * Handle errors from self-signed certificates
+ */
 app.on("certificate-error", (event, webContents, url, error, certificate, callback) => {
 	event.preventDefault();
 	callback(true);
 });
 
+if (process.env.clientonly) {
+	app.whenReady().then(() => {
+		Log.log("Launching client viewer application.");
+		createWindow();
+	});
+}
+
 // Start the core application if server is run on localhost
 // This starts all node helpers and starts the webserver.
 if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].includes(config.address)) {
-	core.start(function (c) {
+	core.start().then((c) => {
 		config = c;
+		app.whenReady().then(() => {
+			Log.log("Launching application.");
+			createWindow();
+		});
 	});
 }


### PR DESCRIPTION
Fixes #3151 

app.whenReady() was removed when async changes made, needed for clientonly in electron.js
