### PR TITLE
fix clientOnly not starting up after async startup added in 2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _This release is scheduled to be released on 2023-10-01._
 ### Fixed
 
 - Fix undefined formatTime method in clock module (#3143)
+- Fix clientonly startup fails after async added (#3151)
 
 ## [2.24.0] - 2023-07-01
 

--- a/clientonly/index.js
+++ b/clientonly/index.js
@@ -84,6 +84,7 @@
 			.then(function (configReturn) {
 				// Pass along the server config via an environment variable
 				const env = Object.create(process.env);
+				env.clientonly = true; // set to pass to electron.js
 				const options = { env: env };
 				configReturn.address = config.address;
 				configReturn.port = config.port;

--- a/js/electron.js
+++ b/js/electron.js
@@ -168,6 +168,13 @@ app.on("certificate-error", (event, webContents, url, error, certificate, callba
 	callback(true);
 });
 
+if (process.env.clientonly) {
+	app.whenReady().then(() => {
+		Log.log("Launching client viewer application.");
+		createWindow();
+	});
+}
+
 // Start the core application if server is run on localhost
 // This starts all node helpers and starts the webserver.
 if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].includes(config.address)) {


### PR DESCRIPTION
Fixes #3151 

app.whenReady() was removed when async changes made, needed for clientonly in electron.js
