### PR TITLE
fix electron width/heigth when using xrandr under bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2023-10-01._
 
 - Fix undefined formatTime method in clock module (#3143)
 - Fix clientonly startup fails after async added (#3151)
+- Fix electron width/heigth when using xrandr under bullseye
 
 ## [2.24.0] - 2023-07-01
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -25,11 +25,20 @@ let mainWindow;
  *
  */
 function createWindow() {
+	// see https://www.electronjs.org/docs/latest/api/screen
+	// Create a window that fills the screen's available work area.
+	let electronSize = (800, 600);
+	try {
+		electronSize = electron.screen.getPrimaryDisplay().workAreaSize;
+	} catch {
+		Log.warn("Could not get display size, using defaults ...");
+	}
+
 	let electronSwitchesDefaults = ["autoplay-policy", "no-user-gesture-required"];
 	app.commandLine.appendSwitch(...new Set(electronSwitchesDefaults, config.electronSwitches));
 	let electronOptionsDefaults = {
-		width: 800,
-		height: 600,
+		width: electronSize.width,
+		height: electronSize.height,
 		x: 0,
 		y: 0,
 		darkTheme: true,


### PR DESCRIPTION
This PR uses `electron.screen.getPrimaryDisplay().workAreaSize` under electron to get the screen size.

If this fails the current defaults (800x600) are used.

This solves some problems with xrandr under bullseye where the sreen comes up with 800x600 instead of fullscreen, e.g. described [here](https://khassel.gitlab.io/magicmirror/pi-modules/).

Tested this on my pi setup.

By the way, the Issue #1919 is back on my side (not related to this PR) ...