### PR TITLE
Fix: AnimateCSS merge hide() and show() animated css class when we do multiple call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _This release is scheduled to be released on 2023-10-01._
 - Fix ipWhiteList test (#3179)
 - Fix newsfeed: Convert HTML entities, codes and tag in description (#3191)
 - Respect width/height (no fullscreen) if set in electronOptions (together with `fullscreen: false`) in `config.js` (#3174)
+- Fix: AnimateCSS merge hide() and show() animated css class when we do multiple call
 
 ## [2.24.0] - 2023-07-01
 

--- a/js/animateCSS.js
+++ b/js/animateCSS.js
@@ -130,36 +130,35 @@ const AnimateCSSOut = [
 
 /**
  * Create an animation with Animate CSS
- * resolved as Promise when done
  * @param {string} [element] div element to animate.
  * @param {string} [animation] animation name.
  * @param {number} [animationTime] animation duration.
  */
-function AnimateCSS(element, animation, animationTime) {
-	/* We create a Promise and return it */
-	return new Promise((resolve) => {
-		const animationName = `animate__${animation}`;
-		const node = document.getElementById(element);
-		if (!node) {
-			// don't execute animate and resolve
-			Log.warn(`AnimateCSS: node not found for`, element);
-			resolve();
-			return;
-		}
-		node.style.setProperty("--animate-duration", `${animationTime}s`);
-		node.classList.add("animate__animated", animationName);
+function addAnimateCSS(element, animation, animationTime) {
+	const animationName = `animate__${animation}`;
+	const node = document.getElementById(element);
+	if (!node) {
+		// don't execute animate: we don't find div
+		Log.warn(`addAnimateCSS: node not found for`, element);
+		return;
+	}
+	node.style.setProperty("--animate-duration", `${animationTime}s`);
+	node.classList.add("animate__animated", animationName);
+}
 
-		/**
-		 * When the animation ends, we clean the classes and resolve the Promise
-		 * @param {object} event object
-		 */
-		function handleAnimationEnd(event) {
-			node.classList.remove("animate__animated", animationName);
-			node.style.removeProperty("--animate-duration", `${animationTime}s`);
-			event.stopPropagation();
-			resolve();
-		}
-
-		node.addEventListener("animationend", handleAnimationEnd, { once: true });
-	});
+/**
+ * Remove an animation with Animate CSS
+ * @param {string} [element] div element to animate.
+ * @param {string} [animation] animation name.
+ */
+function removeAnimateCSS(element, animation) {
+	const animationName = `animate__${animation}`;
+	const node = document.getElementById(element);
+	if (!node) {
+		// don't execute animate: we don't find div
+		Log.warn(`removeAnimateCSS: node not found for`, element);
+		return;
+	}
+	node.classList.remove("animate__animated", animationName);
+	node.style.removeProperty("--animate-duration");
 }

--- a/js/main.js
+++ b/js/main.js
@@ -269,7 +269,7 @@ const MM = (function () {
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the hide method.
 	 */
-	const hideModule = async function (module, speed, callback, options = {}) {
+	const hideModule = function (module, speed, callback, options = {}) {
 		// set lockString if set in options.
 		if (options.lockString) {
 			// Log.log("Has lockstring: " + options.lockString);
@@ -302,7 +302,7 @@ const MM = (function () {
 				// with AnimateCSS
 				Log.debug(`${module.identifier} Has animateOut: ${haveAnimateName}`);
 				module.hasAnimateOut = haveAnimateName;
-				await addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
+				addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
 				module.showHideTimer = setTimeout(function () {
 					removeAnimateCSS(module.identifier, haveAnimateName);
 					Log.debug(`${module.identifier} Remove animateOut: ${module.hasAnimateOut}`);
@@ -351,7 +351,7 @@ const MM = (function () {
 	 * @param {Function} callback Called when the animation is done.
 	 * @param {object} [options] Optional settings for the show method.
 	 */
-	const showModule = async function (module, speed, callback, options = {}) {
+	const showModule = function (module, speed, callback, options = {}) {
 		// remove lockString if set in options.
 		if (options.lockString) {
 			const index = module.lockStrings.indexOf(options.lockString);
@@ -415,7 +415,7 @@ const MM = (function () {
 				// with AnimateCSS
 				Log.debug(`${module.identifier} Has animateIn: ${haveAnimateName}`);
 				module.hasAnimateIn = haveAnimateName;
-				await addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
+				addAnimateCSS(module.identifier, haveAnimateName, speed / 1000);
 				module.showHideTimer = setTimeout(function () {
 					removeAnimateCSS(module.identifier, haveAnimateName);
 					Log.debug(`${module.identifier} Remove animateIn: ${haveAnimateName}`);

--- a/js/module.js
+++ b/js/module.js
@@ -205,6 +205,8 @@ const Module = Class.extend({
 		this.name = data.name;
 		this.identifier = data.identifier;
 		this.hidden = false;
+		this.hasAnimateIn = false;
+		this.hasAnimateOut = false;
 
 		this.setConfig(data.config, data.configDeepMerge);
 	},


### PR DESCRIPTION
PR: #3113  

I see this bugs:

AnimateCSS merge hide() and show() animated css class when we do multiple call
--> result it will stay en hide state

I think event listener (is animateCSS file) is not a proper solution

I correct it with like traditional code with timer