### PR TITLE
Fix: Uncaught SyntaxError: Identifier 'getCorsUrl' has already been declared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ _This release is scheduled to be released on 2023-10-01._
 - Fix ipWhiteList test (#3179)
 - Fix newsfeed: Convert HTML entities, codes and tag in description (#3191)
 - Respect width/height (no fullscreen) if set in electronOptions (together with `fullscreen: false`) in `config.js` (#3174)
-- Fix `Uncaught SyntaxError: Identifier 'getCorsUrl' has already been declared (at utils.js:1:1)` when using `clock` and `weather` module (#xxxx)
+- Fix `Uncaught SyntaxError: Identifier 'getCorsUrl' has already been declared (at utils.js:1:1)` when using `clock` and `weather` module (#3204)
 
 ## [2.24.0] - 2023-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _This release is scheduled to be released on 2023-10-01._
 - Fix ipWhiteList test (#3179)
 - Fix newsfeed: Convert HTML entities, codes and tag in description (#3191)
 - Respect width/height (no fullscreen) if set in electronOptions (together with `fullscreen: false`) in `config.js` (#3174)
+- Fix `Uncaught SyntaxError: Identifier 'getCorsUrl' has already been declared (at utils.js:1:1)` when using `clock` and `weather` module (#xxxx)
 
 ## [2.24.0] - 2023-07-01
 

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <script type="text/javascript" src="#CONFIG_FILE#"></script>
     <script type="text/javascript" src="vendor/vendor.js"></script>
     <script type="text/javascript" src="modules/default/defaultmodules.js"></script>
+    <script type="text/javascript" src="modules/default/utils.js"></script>
     <script type="text/javascript" src="js/logger.js"></script>
     <script type="text/javascript" src="translations/translations.js"></script>
     <script type="text/javascript" src="js/translator.js"></script>

--- a/modules/default/clock/clock.js
+++ b/modules/default/clock/clock.js
@@ -38,7 +38,7 @@ Module.register("clock", {
 	},
 	// Define required scripts.
 	getScripts: function () {
-		return ["moment.js", "moment-timezone.js", "suncalc.js", this.file("../utils.js")];
+		return ["moment.js", "moment-timezone.js", "suncalc.js"];
 	},
 	// Define styles.
 	getStyles: function () {

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -62,7 +62,7 @@ Module.register("weather", {
 
 	// Return the scripts that are necessary for the weather module.
 	getScripts: function () {
-		return ["moment.js", this.file("../utils.js"), "weatherutils.js", "weatherobject.js", this.file("providers/overrideWrapper.js"), "weatherprovider.js", "suncalc.js", this.file(`providers/${this.config.weatherProvider.toLowerCase()}.js`)];
+		return ["moment.js", "weatherutils.js", "weatherobject.js", this.file("providers/overrideWrapper.js"), "weatherprovider.js", "suncalc.js", this.file(`providers/${this.config.weatherProvider.toLowerCase()}.js`)];
 	},
 
 	// Override getHeader method.


### PR DESCRIPTION
Issue #3202 

move shared modules/default/utils.js file to index.html