### PR TITLE
Update last Dependencies before release and add dependabot to vendor/fonts directory

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,3 +17,9 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "develop"
+
+  - package-ecosystem: "npm"
+    directory: "/fonts"
+    schedule:
+      interval: "monthly"
+    target-branch: "develop"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: "monthly"
     target-branch: "develop"
+
+  - package-ecosystem: "npm"
+    directory: "/vendor"
+    schedule:
+      interval: "monthly"
+    target-branch: "develop"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ _This release is scheduled to be released on 2023-10-01._
 - Cleaned up nunjuck templates
 - Replace `node-fetch` with internal fetch (#2649) and remove `digest-fetch`
 - Update the French translation according to the English file.
+- Update dependabot incl. vendor/fonts (monthly check)
+- Renew `package-lock.json` for release
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 			"devDependencies": {
 				"eslint-config-prettier": "^9.0.0",
 				"eslint-plugin-import": "^2.28.1",
-				"eslint-plugin-jest": "^27.4.0",
+				"eslint-plugin-jest": "^27.4.2",
 				"eslint-plugin-jsdoc": "^46.8.2",
 				"eslint-plugin-prettier": "^5.0.0",
 				"express-basic-auth": "^1.2.1",
@@ -4009,9 +4009,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.4.0.tgz",
-			"integrity": "sha512-ukVeKmMPAUA5SWjHenvyyXnirKfHKMdOsTZdn5tZx5EW05HGVQwBohigjFZGGj3zuv1cV6hc82FvWv6LdIbkgg==",
+			"version": "27.4.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.4.2.tgz",
+			"integrity": "sha512-3Nfvv3wbq2+PZlRTf2oaAWXWwbdBejFRBR2O8tAO67o+P8zno+QGbcDYaAXODlreXVg+9gvWhKKmG2rgfb8GEg==",
 			"dev": true,
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"colors": "^1.4.0",
 				"console-stamp": "^3.1.2",
+				"electron": "^26.2.4",
 				"envsub": "^4.1.0",
 				"eslint": "^8.50.0",
 				"express": "^4.18.2",
@@ -50,7 +51,7 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"electron": "^26.2.2"
+				"electron": "^26.2.4"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
@@ -3549,9 +3550,9 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
 		},
 		"node_modules/electron": {
-			"version": "26.2.2",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.2.2.tgz",
-			"integrity": "sha512-Ihb3Zt4XYnHF52DYSq17ySkgFqJV4OT0VnfhUYZASAql7Vembz3VsAq7mB3OALBHXltAW34P8BxTIwTqZaMS3g==",
+			"version": "26.2.4",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-26.2.4.tgz",
+			"integrity": "sha512-weMUSMyDho5E0DPQ3breba3D96IxwNvtYHjMd/4/wNN3BdI5s3+0orNnPVGJFcLhSvKoxuKUqdVonUocBPwlQA==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
 			"dependencies": {
 				"colors": "^1.4.0",
 				"console-stamp": "^3.1.2",
-				"electron": "^26.2.4",
 				"envsub": "^4.1.0",
 				"eslint": "^8.50.0",
 				"express": "^4.18.2",
@@ -842,9 +841,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.8.2",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.2.tgz",
-			"integrity": "sha512-0MGxAVt1m/ZK+LTJp/j0qF7Hz97D9O/FH9Ms3ltnyIdDD57cbb1ACIQTkbHvNXtWDv5TPq7w5Kq56+cNukbo7g==",
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.0.tgz",
+			"integrity": "sha512-zJmuCWj2VLBt4c25CfBIbMZLGLyhkvs7LznyVX5HfpzeocThgIj5XQK4L+g3U36mMcx8bPMhGyPpwCATamC4jQ==",
 			"engines": {
 				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
@@ -1634,15 +1633,15 @@
 			}
 		},
 		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+			"integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.18.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-			"integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw=="
+			"version": "18.18.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.1.tgz",
+			"integrity": "sha512-3G42sxmm0fF2+Vtb9TJQpnjmP+uKlWvFa8KoEGquh4gqRmoUG/N0ufuhikw6HEsdG2G2oIKhog1GCTfz9v5NdQ=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.2",
@@ -1651,9 +1650,9 @@
 			"dev": true
 		},
 		"node_modules/@types/responselike": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
-			"integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.1.tgz",
+			"integrity": "sha512-TiGnitEDxj2X0j+98Eqk5lv/Cij8oHd32bU4D/Yw6AOq7vvTk0gSD2GPj0G/HkvhMoVsdlhYF4yqqlyPBTM6Sg==",
 			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
@@ -1672,9 +1671,9 @@
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.25",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.25.tgz",
-			"integrity": "sha512-gy7iPgwnzNvxgAEi2bXOHWCVOG6f7xsprVJH4MjlAWeBmJ7vh/Y1kwMtUrs64ztf24zVIRCpr3n/z6gm9QIkgg==",
+			"version": "17.0.26",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.26.tgz",
+			"integrity": "sha512-Y3vDy2X6zw/ZCumcwLpdhM5L7jmyGpmBCTYMHDLqT2IKVMYRRLdv6ZakA+wxhra6Z/3bwhNbNl9bDGXaFU+6rw==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
@@ -2426,9 +2425,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.21.11",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.11.tgz",
-			"integrity": "sha512-xn1UXOKUz7DjdGlg9RrUr0GGiWzI97UQJnugHtH0OLDfJB7jMgoIkYvRIEO1l9EeEERVqeqLYOcFBW9ldjypbQ==",
+			"version": "4.22.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -2445,8 +2444,8 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001538",
-				"electron-to-chromium": "^1.4.526",
+				"caniuse-lite": "^1.0.30001541",
+				"electron-to-chromium": "^1.4.535",
 				"node-releases": "^2.0.13",
 				"update-browserslist-db": "^1.0.13"
 			},
@@ -2615,9 +2614,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001539",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001539.tgz",
-			"integrity": "sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==",
+			"version": "1.0.30001541",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001541.tgz",
+			"integrity": "sha512-bLOsqxDgTqUBkzxbNlSBt8annkDpQB9NdzdTbO2ooJ+eC/IQcvDspDc058g84ejCelF7vHUx57KIOjEecOHXaw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3568,9 +3567,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.530",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.530.tgz",
-			"integrity": "sha512-rsJ9O8SCI4etS8TBsXuRfHa2eZReJhnGf5MHZd3Vo05PukWHKXhk3VQGbHHnDLa8nZz9woPCpLCMQpLGgkGNRA==",
+			"version": "1.4.537",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.537.tgz",
+			"integrity": "sha512-W1+g9qs9hviII0HAwOdehGYkr+zt7KKdmCcJcjH0mYg6oL8+ioT3Skjmt7BLoAQqXhjf40AXd+HlR4oAWMlXjA==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -7943,9 +7942,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.30",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-			"integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -8136,9 +8135,9 @@
 			}
 		},
 		"node_modules/pure-rand": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
-			"integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+			"integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"suncalc": "^1.9.0"
 	},
 	"optionalDependencies": {
-		"electron": "^26.2.2"
+		"electron": "^26.2.4"
 	},
 	"dependencies": {
 		"colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"eslint-config-prettier": "^9.0.0",
 		"eslint-plugin-import": "^2.28.1",
-		"eslint-plugin-jest": "^27.4.0",
+		"eslint-plugin-jest": "^27.4.2",
 		"eslint-plugin-jsdoc": "^46.8.2",
 		"eslint-plugin-prettier": "^5.0.0",
 		"express-basic-auth": "^1.2.1",


### PR DESCRIPTION
Last check before release:

* update to electron: v2.26.4
* update eslint-plugins-jest: v27.4.2
* renew `package-lock.json`
* add dependabot to `vendor` and `fonts` directory (monthly check)
