### PR TITLE
fix  crash on rrule.between returned bad dates #3256

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
+.eslintignore
+.prettierignore
 /config
 /coverage
 package-lock.json
+**.ics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Fix cloneObject() function to respect RegExp (#3237)
 - Fix newsfeed module for feeds using "a10:updated" tag (#3238)
 - Fix issue template (3167)
+- Fix #3256 filter out bad results from rrule.between
 
 ## [2.25.0] - 2023-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Fix yr API version in locationforecast and sunrise call (#3227)
 - Fix cloneObject() function to respect RegExp (#3237)
 - Fix newsfeed module for feeds using "a10:updated" tag (#3238)
-- Fix issue template (3167)
+- Fix issue template (#3167)
 - Fix #3256 filter out bad results from rrule.between
 - Fix for failing unit test (#3254)
 

--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -283,8 +283,12 @@ const CalendarFetcherUtils = {
 						futureLocal = futureMoment.toDate(); // future
 					}
 					Log.debug(`Search for recurring events between: ${pastLocal} and ${futureLocal}`);
-					const dates = rule.between(pastLocal, futureLocal, true, limitFunction);
+					let dates = rule.between(pastLocal, futureLocal, true, limitFunction);
 					Log.debug(`Title: ${event.summary}, with dates: ${JSON.stringify(dates)}`);
+					dates = dates.filter((d) => {
+						if (JSON.stringify(d) === "null") return false;
+						else return true;
+					});
 					// The "dates" array contains the set of dates within our desired date range range that are valid
 					// for the recurrence rule. *However*, it's possible for us to have a specific recurrence that
 					// had its date changed from outside the range to inside the range.  For the time being,

--- a/tests/configs/modules/calendar/bad_rrule.js
+++ b/tests/configs/modules/calendar/bad_rrule.js
@@ -1,0 +1,27 @@
+/* MagicMirror² Test config default calendar with auth by default
+ *
+ * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
+ * MIT Licensed.
+ */
+let config = {
+	timeFormat: 12,
+	logLevel: ["INFO", "LOG", "WARN", "ERROR", "DEBUG"],
+	modules: [
+		{
+			module: "calendar",
+			position: "bottom_bar",
+			config: {
+				calendars: [
+					{
+						url: "http://localhost:8080/tests/mocks/bad_rrule.ics"
+					}
+				]
+			}
+		}
+	]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+	module.exports = config;
+}

--- a/tests/configs/modules/calendar/bad_rrule.js
+++ b/tests/configs/modules/calendar/bad_rrule.js
@@ -1,6 +1,6 @@
-/* MagicMirror² Test config default calendar with auth by default
+/* MagicMirror² Test ics with out of date event causing bad return from rrule.between
  *
- * By Rodrigo Ramírez Norambuena https://rodrigoramirez.com
+ * By Sam Detweiler
  * MIT Licensed.
  */
 let config = {

--- a/tests/mocks/bad_rrule.ics
+++ b/tests/mocks/bad_rrule.ics
@@ -1,0 +1,20 @@
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTAMP:20210413T203456Z
+UID:E689AEB8C02C4E2CADD8C7D3D303CEAD0
+DTSTART;TZID="Amsterdam, Belgrade, Berlin, Brussels, Budapest, Madrid, Paris, Prague, Stockholm":20210415T190000
+DTEND;TZID="Amsterdam, Belgrade, Berlin, Brussels, Budapest, Madrid, Paris, Prague, Stockholm":20210415T210000
+CLASS:PUBLIC
+LOCATION:albert heijn
+SUMMARY:xxx xxxx
+SEQUENCE:10
+RRULE:FREQ=DAILY;UNTIL=20210418T170000Z
+EXDATE;TZID="Amsterdam, Belgrade, Berlin, Brussels, Budapest, Madrid, Paris, Prague, Stockholm":20210417T190000
+EXDATE;TZID="Amsterdam, Belgrade, Berlin, Brussels, Budapest, Madrid, Paris, Prague, Stockholm":20210416T190000
+EXDATE;TZID="Amsterdam, Belgrade, Berlin, Brussels, Budapest, Madrid, Paris, Prague, Stockholm":20210415T190000
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;RELATED=START:-PT15M
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_bad_rrule.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_bad_rrule.js
@@ -1,0 +1,29 @@
+global.moment = require("moment-timezone");
+
+const CalendarFetcherUtils = require("../../../../../modules/default/calendar/calendarfetcherutils");
+
+describe("Calendar fetcher utils test", () => {
+	const defaultConfig = {
+		excludedEvents: []
+	};
+
+	describe("filterEvents", () => {
+		it("no events, not crash", () => {
+			const minusOneHour = moment().subtract(1, "hours").toDate();
+			const minusTwoHours = moment().subtract(2, "hours").toDate();
+			const plusOneHour = moment().add(1, "hours").toDate();
+			const plusTwoHours = moment().add(2, "hours").toDate();
+
+			const filteredEvents = CalendarFetcherUtils.filterEvents(
+				{
+					pastEvent: { type: "VEVENT", start: minusTwoHours, end: minusOneHour, summary: "pastEvent" },
+					ongoingEvent: { type: "VEVENT", start: minusOneHour, end: plusOneHour, summary: "ongoingEvent" },
+					upcomingEvent: { type: "VEVENT", start: plusOneHour, end: plusTwoHours, summary: "upcomingEvent" }
+				},
+				defaultConfig
+			);
+
+			expect(filteredEvents.length).toEqual(0);
+		});
+	});
+});


### PR DESCRIPTION
Fixes: #3256 

BUT.. the testcase is inconclusive.. as the code FAILS without the fix, BUT somehow RETURNS 0 entries..
in real life run the node helper fails, and all calendar processing stops. 