### PR TITLE
Use `html-to-text` instead of regex for transform description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ _This release is scheduled to be released on 2024-01-01._
 ### Updated
 
 - Update electron to v27 and update other dependencies as well as github actions
+- Update newsfeed: Use `html-to-text` instead of regex for transform description
 
 ### Fixed
 

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -52,10 +52,22 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 			const url = item.url || item.link || "";
 
 			if (title && pubdate) {
-				const regex = /(<([^>]+)>)/gi;
-				description = description.toString().replace(regex, "");
+				Log.log("---");
+				Log.log("newsfeed -- Feed: ", description);
+				// const regex = /(<([^>]+)>)/gi;
+				// description = description.toString().replace(regex, " ");
 				// Convert HTML entities, codes and tag
-				description = htmlToText(description, { wordwrap: false });
+
+				description = htmlToText(description, {
+					wordwrap: false,
+					selectors: [
+						{ selector: "a", options: { ignoreHref: true, noAnchorUrl: true } },
+						{ selector: "br", format: "inlineSurround", options: { prefix: " " } },
+						{ selector: "img", format: "skip" }
+						// { selector: 'p', format: "inlineSurround", options: { prefix: " " } },
+					]
+				});
+				Log.log("newsfeed -- Result:", description);
 
 				items.push({
 					title: title,

--- a/modules/default/newsfeed/newsfeedfetcher.js
+++ b/modules/default/newsfeed/newsfeedfetcher.js
@@ -52,22 +52,15 @@ const NewsfeedFetcher = function (url, reloadInterval, encoding, logFeedWarnings
 			const url = item.url || item.link || "";
 
 			if (title && pubdate) {
-				Log.log("---");
-				Log.log("newsfeed -- Feed: ", description);
-				// const regex = /(<([^>]+)>)/gi;
-				// description = description.toString().replace(regex, " ");
 				// Convert HTML entities, codes and tag
-
 				description = htmlToText(description, {
 					wordwrap: false,
 					selectors: [
 						{ selector: "a", options: { ignoreHref: true, noAnchorUrl: true } },
 						{ selector: "br", format: "inlineSurround", options: { prefix: " " } },
 						{ selector: "img", format: "skip" }
-						// { selector: 'p', format: "inlineSurround", options: { prefix: " " } },
 					]
 				});
-				Log.log("newsfeed -- Result:", description);
 
 				items.push({
 					title: title,


### PR DESCRIPTION
I try to use only `html-to-text` library

it's will solve issue #3235 

@rejas, @sdetweil, @khassel: Can you do tests with your own feeds?

Thanks for feedbacks