### PR TITLE
Review eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-	"extends": ["eslint:recommended", "plugin:prettier/recommended", "plugin:jsdoc/recommended"],
-	"plugins": ["import", "jsdoc", "jest"],
+	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:prettier/recommended", "plugin:jsdoc/recommended"],
+	"plugins": ["jsdoc", "jest"],
 	"env": {
 		"browser": true,
 		"es2022": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
 		"eqeqeq": "error",
 		"import/order": "error",
 		"import/extensions": "error",
+		"import/newline-after-import": "error",
 		"no-param-reassign": "error",
 		"no-prototype-builtins": "off",
 		"no-throw-literal": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:prettier/recommended", "plugin:jsdoc/recommended"],
-	"plugins": ["jsdoc", "jest"],
+	"plugins": ["jest"],
 	"env": {
 		"browser": true,
 		"es2022": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
 	"rules": {
 		"eqeqeq": "error",
 		"import/order": "error",
+		"import/extensions": "error",
 		"no-param-reassign": "error",
 		"no-prototype-builtins": "off",
 		"no-throw-literal": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:prettier/recommended", "plugin:jsdoc/recommended"],
+	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:jsdoc/recommended", "plugin:prettier/recommended"],
 	"plugins": ["jest"],
 	"env": {
 		"browser": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
 	"extends": ["eslint:recommended", "plugin:prettier/recommended", "plugin:jsdoc/recommended"],
-	"plugins": ["prettier", "import", "jsdoc", "jest"],
+	"plugins": ["import", "jsdoc", "jest"],
 	"env": {
 		"browser": true,
 		"es2022": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ _This release is scheduled to be released on 2024-01-01._
 
 - Update electron to v27 and update other dependencies as well as github actions
 - Update newsfeed: Use `html-to-text` instead of regex for transform description
+- Review ESLint config (#3269)
 
 ### Fixed
 

--- a/js/app.js
+++ b/js/app.js
@@ -12,6 +12,7 @@ const fs = require("fs");
 const path = require("path");
 const envsub = require("envsub");
 const Log = require("logger");
+
 const Server = require(`${__dirname}/server`);
 const Utils = require(`${__dirname}/utils`);
 const defaultModules = require(`${__dirname}/../modules/default/defaultmodules`);

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const Log = require("logger");
+
 const startUp = new Date();
 
 /**

--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -10,6 +10,7 @@
  */
 const path = require("path");
 const moment = require("moment");
+
 const zoneTable = require(path.join(__dirname, "windowsZones.json"));
 const Log = require("../../../js/logger");
 

--- a/tests/e2e/animateCSS_spec.js
+++ b/tests/e2e/animateCSS_spec.js
@@ -5,7 +5,7 @@
  * 09/2023
  * MIT Licensed.
  */
-const helpers = require("./helpers/global-setup.js");
+const helpers = require("./helpers/global-setup");
 
 describe("AnimateCSS integration Test", () => {
 	// define config file for testing

--- a/tests/e2e/helpers/basic-auth.js
+++ b/tests/e2e/helpers/basic-auth.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const auth = require("express-basic-auth");
 const express = require("express");
+
 const app = express();
 
 const basicAuth = auth({


### PR DESCRIPTION
- Remove "prettier" from plugin array, because it's already enabled by "plugin:prettier/recommended"
- Remove "jsdoc" from plugin array, because it's already enabled by "plugin:jsdoc/recommended"
- Enable recommended import rules
- Add two additional import rules

Note: To avoid overloading this PR I'll tackle the jest part with another PR after this one has been dealt with.