### PR TITLE
Enable and apply ESLint Jest rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
-	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:jsdoc/recommended", "plugin:prettier/recommended"],
-	"plugins": ["jest"],
+	"extends": ["eslint:recommended", "plugin:import/recommended", "plugin:jest/recommended", "plugin:jsdoc/recommended", "plugin:prettier/recommended"],
+	"plugins": [],
 	"env": {
 		"browser": true,
 		"es2022": true,
@@ -26,6 +26,13 @@
 		"import/order": "error",
 		"import/extensions": "error",
 		"import/newline-after-import": "error",
+		"jest/consistent-test-it": "warn",
+		"jest/expect-expect": "off",
+		"jest/no-done-callback": "off",
+		"jest/prefer-expect-resolves": "warn",
+		"jest/prefer-mock-promise-shorthand": "warn",
+		"jest/prefer-to-be": "warn",
+		"jest/prefer-to-have-length": "warn",
 		"no-param-reassign": "error",
 		"no-prototype-builtins": "off",
 		"no-throw-literal": "error",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Added updatenotification Updater (for 3rd party modules)
 - Added node 21 to the test matrix
 - Added transform object to calendar:customEvents
+- Added ESLint rules for jest
 
 ### Removed
 

--- a/tests/e2e/animateCSS_spec.js
+++ b/tests/e2e/animateCSS_spec.js
@@ -25,22 +25,22 @@ describe("AnimateCSS integration Test", () => {
 	const doTest = async (animationIn, animationOut) => {
 		await helpers.getDocument();
 		let elem = await helpers.waitForElement(`.compliments`);
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		let styles = window.getComputedStyle(elem);
 
 		if (animationIn && animationIn !== "") {
 			expect(styles._values["animation-name"]).toBe(animationIn);
 		} else {
-			expect(styles._values["animation-name"]).toBe(undefined);
+			expect(styles._values["animation-name"]).toBeUndefined();
 		}
 
 		if (animationOut && animationOut !== "") {
 			elem = await helpers.waitForElement(`.compliments.animate__animated.animate__${animationOut}`);
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			styles = window.getComputedStyle(elem);
 			expect(styles._values["animation-name"]).toBe(animationOut);
 		} else {
-			expect(styles._values["animation-name"]).toBe(undefined);
+			expect(styles._values["animation-name"]).toBeUndefined();
 		}
 	};
 

--- a/tests/e2e/env_spec.js
+++ b/tests/e2e/env_spec.js
@@ -21,7 +21,7 @@ describe("App environment", () => {
 
 	it("should show the title MagicMirror²", async () => {
 		const elem = await helpers.waitForElement("title");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toBe("MagicMirror²");
 	});
 });

--- a/tests/e2e/fonts_spec.js
+++ b/tests/e2e/fonts_spec.js
@@ -20,7 +20,7 @@ describe("All font files from roboto.css should be downloadable", () => {
 		await helpers.stopApplication();
 	});
 
-	test.each(fontFiles)("should return 200 HTTP code for file '%s'", async (fontFile) => {
+	it.each(fontFiles)("should return 200 HTTP code for file '%s'", async (fontFile) => {
 		const fontUrl = `http://localhost:8080/fonts/${fontFile}`;
 		const res = await fetch(fontUrl);
 		expect(res.status).toBe(200);

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -82,6 +82,6 @@ exports.waitForAllElements = (selector) => {
 
 exports.testMatch = async (element, regex) => {
 	const elem = await this.waitForElement(element);
-	expect(elem).not.toBe(null);
+	expect(elem).not.toBeNull();
 	expect(elem.textContent).toMatch(regex);
 };

--- a/tests/e2e/helpers/weather-functions.js
+++ b/tests/e2e/helpers/weather-functions.js
@@ -3,7 +3,7 @@ const helpers = require("./global-setup");
 
 exports.getText = async (element, result) => {
 	const elem = await helpers.waitForElement(element);
-	expect(elem).not.toBe(null);
+	expect(elem).not.toBeNull();
 	expect(
 		elem.textContent
 			.trim()

--- a/tests/e2e/modules/alert_spec.js
+++ b/tests/e2e/modules/alert_spec.js
@@ -11,7 +11,7 @@ describe("Alert module", () => {
 
 	it("should show the welcome message", async () => {
 		const elem = await helpers.waitForElement(".ns-box .ns-box-inner .light.bright.small");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toContain("Welcome, start was successful!");
 	});
 });

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -9,17 +9,17 @@ describe("Calendar module", () => {
 	 */
 	const testElementLength = async (element, result, not) => {
 		const elem = await helpers.waitForAllElements(element);
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		if (not === "not") {
-			expect(elem.length).not.toBe(result);
+			expect(elem).not.toHaveLength(result);
 		} else {
-			expect(elem.length).toBe(result);
+			expect(elem).toHaveLength(result);
 		}
 	};
 
 	const testTextContain = async (element, text) => {
 		const elem = await helpers.waitForElement(element, "undefinedLoading");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toContain(text);
 	};
 

--- a/tests/e2e/modules/clock_spec.js
+++ b/tests/e2e/modules/clock_spec.js
@@ -72,7 +72,7 @@ describe("Clock module", () => {
 
 		it("should not show the time when digital clock is shown", async () => {
 			const elem = document.querySelector(".clock .digital .time");
-			expect(elem).toBe(null);
+			expect(elem).toBeNull();
 		});
 	});
 
@@ -84,12 +84,12 @@ describe("Clock module", () => {
 
 		it("should show the sun times", async () => {
 			const elem = await helpers.waitForElement(".clock .digital .sun");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 		});
 
 		it("should show the moon times", async () => {
 			const elem = await helpers.waitForElement(".clock .digital .moon");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 		});
 	});
 
@@ -108,7 +108,7 @@ describe("Clock module", () => {
 			const currentWeekNumber = moment().week();
 			const weekToShow = `Week ${currentWeekNumber}`;
 			const elem = await helpers.waitForElement(".clock .week");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toBe(weekToShow);
 		});
 	});
@@ -121,7 +121,7 @@ describe("Clock module", () => {
 
 		it("should show the analog clock face", async () => {
 			const elem = helpers.waitForElement(".clock-circle");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 		});
 	});
 
@@ -133,9 +133,9 @@ describe("Clock module", () => {
 
 		it("should show the analog clock face and the date", async () => {
 			const elemClock = helpers.waitForElement(".clock-circle");
-			await expect(elemClock).not.toBe(null);
+			await expect(elemClock).not.toBeNull();
 			const elemDate = helpers.waitForElement(".clock .date");
-			await expect(elemDate).not.toBe(null);
+			await expect(elemDate).not.toBeNull();
 		});
 	});
 });

--- a/tests/e2e/modules/compliments_spec.js
+++ b/tests/e2e/modules/compliments_spec.js
@@ -7,9 +7,9 @@ describe("Compliments module", () => {
 	 */
 	const doTest = async (complimentsArray) => {
 		let elem = await helpers.waitForElement(".compliments");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		elem = await helpers.waitForElement(".module-content");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(complimentsArray).toContain(elem.textContent);
 	};
 
@@ -18,7 +18,7 @@ describe("Compliments module", () => {
 	});
 
 	describe("Feature anytime in compliments module", () => {
-		describe("Set anytime and empty compliments for morning, evening and afternoon ", () => {
+		describe("Set anytime and empty compliments for morning, evening and afternoon", () => {
 			beforeAll(async () => {
 				await helpers.startApplication("tests/configs/modules/compliments/compliments_anytime.js");
 				await helpers.getDocument();

--- a/tests/e2e/modules/helloworld_spec.js
+++ b/tests/e2e/modules/helloworld_spec.js
@@ -13,7 +13,7 @@ describe("Test helloworld module", () => {
 
 		it("Test message helloworld module", async () => {
 			const elem = await helpers.waitForElement(".helloworld");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("Test HelloWorld Module");
 		});
 	});
@@ -26,7 +26,7 @@ describe("Test helloworld module", () => {
 
 		it("Test message helloworld module", async () => {
 			const elem = await helpers.waitForElement(".helloworld");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("Hello World!");
 		});
 	});

--- a/tests/e2e/modules/newsfeed_spec.js
+++ b/tests/e2e/modules/newsfeed_spec.js
@@ -13,20 +13,20 @@ describe("Newsfeed module", () => {
 
 		it("should show the newsfeed title", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .newsfeed-source");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("Rodrigo Ramirez Blog");
 		});
 
 		it("should show the newsfeed article", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .newsfeed-title");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("QPanel");
 		});
 
 		it("should NOT show the newsfeed description", async () => {
 			await helpers.waitForElement(".newsfeed");
 			const elem = document.querySelector(".newsfeed .newsfeed-desc");
-			expect(elem).toBe(null);
+			expect(elem).toBeNull();
 		});
 	});
 
@@ -38,14 +38,14 @@ describe("Newsfeed module", () => {
 
 		it("should not show articles with prohibited words", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .newsfeed-title");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("Problema VirtualBox");
 		});
 
 		it("should show the newsfeed description", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .newsfeed-desc");
-			expect(elem).not.toBe(null);
-			expect(elem.textContent.length).not.toBe(0);
+			expect(elem).not.toBeNull();
+			expect(elem.textContent).not.toHaveLength(0);
 		});
 	});
 
@@ -57,7 +57,7 @@ describe("Newsfeed module", () => {
 
 		it("should show malformed url warning", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .small", "No news at the moment.");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("Error in the Newsfeed module. Malformed url.");
 		});
 	});
@@ -70,7 +70,7 @@ describe("Newsfeed module", () => {
 
 		it("should show empty items info message", async () => {
 			const elem = await helpers.waitForElement(".newsfeed .small");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain("No news at the moment.");
 		});
 	});

--- a/tests/e2e/modules/weather_current_spec.js
+++ b/tests/e2e/modules/weather_current_spec.js
@@ -49,7 +49,7 @@ describe("Weather module", () => {
 
 		it("should render windDirection with an arrow", async () => {
 			const elem = await helpers.waitForElement(".weather .normal.medium sup i.fa-long-arrow-alt-down");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.outerHTML).toContain("transform:rotate(250deg)");
 		});
 

--- a/tests/e2e/modules/weather_forecast_spec.js
+++ b/tests/e2e/modules/weather_forecast_spec.js
@@ -24,7 +24,7 @@ describe("Weather module: Weather Forecast", () => {
 		for (const [index, icon] of icons.entries()) {
 			it(`should render icon ${icon}`, async () => {
 				const elem = await helpers.waitForElement(`.weather table.small tr:nth-child(${index + 1}) td:nth-child(2) span.wi-${icon}`);
-				expect(elem).not.toBe(null);
+				expect(elem).not.toBeNull();
 			});
 		}
 
@@ -46,7 +46,7 @@ describe("Weather module: Weather Forecast", () => {
 		for (const [index, opacity] of opacities.entries()) {
 			it(`should render fading of rows with opacity=${opacity}`, async () => {
 				const elem = await helpers.waitForElement(`.weather table.small tr:nth-child(${index + 1})`);
-				expect(elem).not.toBe(null);
+				expect(elem).not.toBeNull();
 				expect(elem.outerHTML).toContain(`<tr style="opacity: ${opacity};">`);
 			});
 		}
@@ -72,14 +72,14 @@ describe("Weather module: Weather Forecast", () => {
 
 		it("should render custom table class", async () => {
 			const elem = await helpers.waitForElement(".weather table.myTableClass");
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 		});
 
 		it("should render colored rows", async () => {
 			const table = await helpers.waitForElement(".weather table.myTableClass");
-			expect(table).not.toBe(null);
-			expect(table.rows).not.toBe(null);
-			expect(table.rows.length).toBe(5);
+			expect(table).not.toBeNull();
+			expect(table.rows).not.toBeNull();
+			expect(table.rows).toHaveLength(5);
 		});
 
 		const precipitations = [undefined, "2.51 mm"];

--- a/tests/e2e/modules_display_spec.js
+++ b/tests/e2e/modules_display_spec.js
@@ -11,14 +11,14 @@ describe("Display of modules", () => {
 
 	it("should show the test header", async () => {
 		const elem = await helpers.waitForElement("#module_0_helloworld .module-header");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		// textContent gibt hier lowercase zurück, das uppercase wird durch css realisiert, was daher nicht in textContent landet
 		expect(elem.textContent).toBe("test_header");
 	});
 
 	it("should show no header if no header text is specified", async () => {
 		const elem = await helpers.waitForElement("#module_1_helloworld .module-header");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toBe("undefined");
 	});
 });

--- a/tests/e2e/modules_empty_spec.js
+++ b/tests/e2e/modules_empty_spec.js
@@ -11,13 +11,13 @@ describe("Check configuration without modules", () => {
 
 	it("shows the message MagicMirror² title", async () => {
 		const elem = await helpers.waitForElement("#module_1_helloworld .module-content");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toContain("MagicMirror²");
 	});
 
 	it("shows the url of michael's website", async () => {
 		const elem = await helpers.waitForElement("#module_5_helloworld .module-content");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(elem.textContent).toContain("www.michaelteeuw.nl");
 	});
 });

--- a/tests/e2e/modules_position_spec.js
+++ b/tests/e2e/modules_position_spec.js
@@ -15,7 +15,7 @@ describe("Position of modules", () => {
 		const className = position.replace("_", ".");
 		it(`should show text in ${position}`, async () => {
 			const elem = await helpers.waitForElement(`.${className}`);
-			expect(elem).not.toBe(null);
+			expect(elem).not.toBeNull();
 			expect(elem.textContent).toContain(`Text in ${position}`);
 		});
 	}

--- a/tests/e2e/translations_spec.js
+++ b/tests/e2e/translations_spec.js
@@ -55,7 +55,7 @@ describe("Translations", () => {
 
 				await MMM.loadTranslations();
 
-				expect(Translator.load.args.length).toBe(1);
+				expect(Translator.load.args).toHaveLength(1);
 				expect(Translator.load.calledWith(MMM, "translations/en.json", false)).toBe(true);
 
 				done();
@@ -72,7 +72,7 @@ describe("Translations", () => {
 
 				await MMM.loadTranslations();
 
-				expect(Translator.load.args.length).toBe(2);
+				expect(Translator.load.args).toHaveLength(2);
 				expect(Translator.load.calledWith(MMM, "translations/de.json", false)).toBe(true);
 				expect(Translator.load.calledWith(MMM, "translations/en.json", true)).toBe(true);
 
@@ -91,7 +91,7 @@ describe("Translations", () => {
 
 				await MMM.loadTranslations();
 
-				expect(Translator.load.args.length).toBe(1);
+				expect(Translator.load.args).toHaveLength(1);
 				expect(Translator.load.calledWith(MMM, "translations/en.json", true)).toBe(true);
 
 				done();

--- a/tests/electron/env_spec.js
+++ b/tests/electron/env_spec.js
@@ -12,8 +12,8 @@ describe("Electron app environment", () => {
 
 	it("should open browserwindow", async () => {
 		const module = await helpers.getElement("#module_0_helloworld");
-		expect(await module.textContent()).toContain("Test Display Header");
-		expect(global.electronApp.windows().length).toBe(1);
+		await expect(module.textContent()).resolves.toContain("Test Display Header");
+		expect(global.electronApp.windows()).toHaveLength(1);
 	});
 });
 
@@ -29,7 +29,7 @@ describe("Development console tests", () => {
 	it("should open browserwindow and dev console", async () => {
 		while (global.electronApp.windows().length < 2) await events.once(global.electronApp, "window");
 		const pageArray = await global.electronApp.windows();
-		expect(pageArray.length).toBe(2);
+		expect(pageArray).toHaveLength(2);
 		for (const page of pageArray) {
 			expect(["MagicMirror²", "DevTools"]).toContain(await page.title());
 		}

--- a/tests/electron/helpers/global-setup.js
+++ b/tests/electron/helpers/global-setup.js
@@ -37,9 +37,9 @@ exports.stopApplication = async () => {
 };
 
 exports.getElement = async (selector) => {
-	expect(global.page);
+	expect(global.page).not.toBeNull();
 	let elem = global.page.locator(selector);
 	await elem.waitFor();
-	expect(elem).not.toBe(null);
+	expect(elem).not.toBeNull();
 	return elem;
 };

--- a/tests/electron/helpers/weather-setup.js
+++ b/tests/electron/helpers/weather-setup.js
@@ -3,7 +3,7 @@ const helpers = require("./global-setup");
 
 exports.getText = async (element, result) => {
 	const elem = await helpers.getElement(element);
-	await expect(elem).not.toBe(null);
+	await expect(elem).not.toBeNull();
 	const text = await elem.textContent();
 	await expect(
 		text

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -7,7 +7,7 @@ describe("Calendar module", () => {
 	 */
 	const doTest = async (cssClass) => {
 		let elem = await helpers.getElement(`.calendar .module-content .event${cssClass}`);
-		expect(await elem.isVisible()).toBe(true);
+		await expect(elem.isVisible()).resolves.toBe(true);
 	};
 
 	afterEach(async () => {

--- a/tests/electron/modules/compliments_spec.js
+++ b/tests/electron/modules/compliments_spec.js
@@ -8,7 +8,7 @@ describe("Compliments module", () => {
 	const doTest = async (complimentsArray) => {
 		await helpers.getElement(".compliments");
 		const elem = await helpers.getElement(".module-content");
-		expect(elem).not.toBe(null);
+		expect(elem).not.toBeNull();
 		expect(complimentsArray).toContain(await elem.textContent());
 	};
 

--- a/tests/unit/classes/translator_spec.js
+++ b/tests/unit/classes/translator_spec.js
@@ -197,7 +197,7 @@ describe("Translator", () => {
 				};
 
 				await Translator.load(mmm, file, false);
-				expect(Translator.translations[mmm.name]).toBe(undefined);
+				expect(Translator.translations[mmm.name]).toBeUndefined();
 				expect(Translator.translationsFallback[mmm.name]).toEqual({
 					Hello: "Hallo"
 				});

--- a/tests/unit/functions/server_functions_spec.js
+++ b/tests/unit/functions/server_functions_spec.js
@@ -35,43 +35,43 @@ describe("server_functions tests", () => {
 			};
 		});
 
-		test("Calls correct URL once", async () => {
+		it("Calls correct URL once", async () => {
 			const urlToCall = "http://www.test.com/path?param1=value1";
 			request.url = `/cors?url=${urlToCall}`;
 
 			await cors(request, corsResponse);
 
-			expect(fetchMock.mock.calls.length).toBe(1);
+			expect(fetchMock.mock.calls).toHaveLength(1);
 			expect(fetchMock.mock.calls[0][0]).toBe(urlToCall);
 		});
 
-		test("Forewards Content-Type if json", async () => {
+		it("Forewards Content-Type if json", async () => {
 			fetchResponseHeadersGet.mockImplementation(() => "json");
 
 			await cors(request, corsResponse);
 
-			expect(fetchResponseHeadersGet.mock.calls.length).toBe(1);
+			expect(fetchResponseHeadersGet.mock.calls).toHaveLength(1);
 			expect(fetchResponseHeadersGet.mock.calls[0][0]).toBe("Content-Type");
 
-			expect(corsResponse.set.mock.calls.length).toBe(1);
+			expect(corsResponse.set.mock.calls).toHaveLength(1);
 			expect(corsResponse.set.mock.calls[0][0]).toBe("Content-Type");
 			expect(corsResponse.set.mock.calls[0][1]).toBe("json");
 		});
 
-		test("Forewards Content-Type if xml", async () => {
+		it("Forewards Content-Type if xml", async () => {
 			fetchResponseHeadersGet.mockImplementation(() => "xml");
 
 			await cors(request, corsResponse);
 
-			expect(fetchResponseHeadersGet.mock.calls.length).toBe(1);
+			expect(fetchResponseHeadersGet.mock.calls).toHaveLength(1);
 			expect(fetchResponseHeadersGet.mock.calls[0][0]).toBe("Content-Type");
 
-			expect(corsResponse.set.mock.calls.length).toBe(1);
+			expect(corsResponse.set.mock.calls).toHaveLength(1);
 			expect(corsResponse.set.mock.calls[0][0]).toBe("Content-Type");
 			expect(corsResponse.set.mock.calls[0][1]).toBe("xml");
 		});
 
-		test("Sends correct data from response", async () => {
+		it("Sends correct data from response", async () => {
 			const responseData = "some data";
 			fetchResponseHeadersText.mockImplementation(() => responseData);
 
@@ -82,11 +82,11 @@ describe("server_functions tests", () => {
 
 			await cors(request, corsResponse);
 
-			expect(fetchResponseHeadersText.mock.calls.length).toBe(1);
+			expect(fetchResponseHeadersText.mock.calls).toHaveLength(1);
 			expect(sentData).toBe(responseData);
 		});
 
-		test("Sends error data from response", async () => {
+		it("Sends error data from response", async () => {
 			const error = new Error("error data");
 			fetchResponseHeadersText.mockImplementation(() => {
 				throw error;
@@ -99,32 +99,32 @@ describe("server_functions tests", () => {
 
 			await cors(request, corsResponse);
 
-			expect(fetchResponseHeadersText.mock.calls.length).toBe(1);
+			expect(fetchResponseHeadersText.mock.calls).toHaveLength(1);
 			expect(sentData).toBe(error);
 		});
 
-		test("Fetches with user agent by default", async () => {
+		it("Fetches with user agent by default", async () => {
 			await cors(request, corsResponse);
 
-			expect(fetchMock.mock.calls.length).toBe(1);
+			expect(fetchMock.mock.calls).toHaveLength(1);
 			expect(fetchMock.mock.calls[0][1]).toHaveProperty("headers");
 			expect(fetchMock.mock.calls[0][1].headers).toHaveProperty("User-Agent");
 		});
 
-		test("Fetches with specified headers", async () => {
+		it("Fetches with specified headers", async () => {
 			const headersParam = "sendheaders=header1:value1,header2:value2";
 			const urlParam = "http://www.test.com/path?param1=value1";
 			request.url = `/cors?${headersParam}&url=${urlParam}`;
 
 			await cors(request, corsResponse);
 
-			expect(fetchMock.mock.calls.length).toBe(1);
+			expect(fetchMock.mock.calls).toHaveLength(1);
 			expect(fetchMock.mock.calls[0][1]).toHaveProperty("headers");
 			expect(fetchMock.mock.calls[0][1].headers).toHaveProperty("header1", "value1");
 			expect(fetchMock.mock.calls[0][1].headers).toHaveProperty("header2", "value2");
 		});
 
-		test("Sends specified headers", async () => {
+		it("Sends specified headers", async () => {
 			fetchResponseHeadersGet.mockImplementation((input) => input.replace("header", "value"));
 
 			const expectedheaders = "expectedheaders=header1,header2";
@@ -133,9 +133,9 @@ describe("server_functions tests", () => {
 
 			await cors(request, corsResponse);
 
-			expect(fetchMock.mock.calls.length).toBe(1);
+			expect(fetchMock.mock.calls).toHaveLength(1);
 			expect(fetchMock.mock.calls[0][1]).toHaveProperty("headers");
-			expect(corsResponse.set.mock.calls.length).toBe(3);
+			expect(corsResponse.set.mock.calls).toHaveLength(3);
 			expect(corsResponse.set.mock.calls[0][0]).toBe("Content-Type");
 			expect(corsResponse.set.mock.calls[1][0]).toBe("header1");
 			expect(corsResponse.set.mock.calls[1][1]).toBe("value1");

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -103,7 +103,7 @@ describe("Updatenotification", () => {
 			execMock.mockRejectedValueOnce(errorMessage);
 
 			const repos = await gitHelper.getRepos();
-			expect(repos.length).toBe(0);
+			expect(repos).toHaveLength(0);
 
 			const { error } = require("logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);
@@ -142,7 +142,7 @@ describe("Updatenotification", () => {
 			execMock.mockRejectedValueOnce(errorMessage);
 
 			const repos = await gitHelper.getRepos();
-			expect(repos.length).toBe(0);
+			expect(repos).toHaveLength(0);
 
 			const { error } = require("logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);
@@ -183,7 +183,7 @@ describe("Updatenotification", () => {
 			execMock.mockRejectedValueOnce(errorMessage);
 
 			const repos = await gitHelper.getRepos();
-			expect(repos.length).toBe(0);
+			expect(repos).toHaveLength(0);
 
 			const { error } = require("logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);
@@ -224,7 +224,7 @@ describe("Updatenotification", () => {
 			execMock.mockRejectedValueOnce(errorMessage);
 
 			const repos = await gitHelper.getRepos();
-			expect(repos.length).toBe(0);
+			expect(repos).toHaveLength(0);
 
 			const { error } = require("logger");
 			expect(error).toHaveBeenCalledWith(`Failed to retrieve repo info for ${moduleName}: Failed to retrieve status`);

--- a/tests/unit/global_vars/root_path_spec.js
+++ b/tests/unit/global_vars/root_path_spec.js
@@ -14,11 +14,11 @@ describe("'global.root_path' set in js/app.js", () => {
 	});
 
 	it("should not modify global.root_path for testing", () => {
-		expect(global.root_path).toBe(undefined);
+		expect(global.root_path).toBeUndefined();
 	});
 
 	it("should not modify global.version for testing", () => {
-		expect(global.version).toBe(undefined);
+		expect(global.version).toBeUndefined();
 	});
 
 	it("should expect the global.version equals package.json file", () => {

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_bad_rrule.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_bad_rrule.js
@@ -23,7 +23,7 @@ describe("Calendar fetcher utils test", () => {
 				defaultConfig
 			);
 
-			expect(filteredEvents.length).toEqual(0);
+			expect(filteredEvents).toHaveLength(0);
 		});
 	});
 });

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
@@ -26,7 +26,7 @@ describe("Calendar fetcher utils test", () => {
 				defaultConfig
 			);
 
-			expect(filteredEvents.length).toEqual(2);
+			expect(filteredEvents).toHaveLength(2);
 			expect(filteredEvents[0].title).toBe("ongoingEvent");
 			expect(filteredEvents[1].title).toBe("upcomingEvent");
 		});
@@ -45,7 +45,7 @@ describe("Calendar fetcher utils test", () => {
 				defaultConfig
 			);
 
-			expect(filteredEvents.length).toEqual(2);
+			expect(filteredEvents).toHaveLength(2);
 			expect(filteredEvents[0].title).toBe("ongoingEvent");
 			expect(filteredEvents[1].title).toBe("upcomingEvent");
 		});

--- a/tests/unit/modules/default/utils_spec.js
+++ b/tests/unit/modules/default/utils_spec.js
@@ -24,16 +24,16 @@ describe("Default modules utils tests", () => {
 				}
 			});
 
-			test("Calls correct URL once", async () => {
+			it("Calls correct URL once", async () => {
 				urlToCall = "http://www.test.com/path?param1=value1";
 
 				await performWebRequest(urlToCall, "json", true);
 
-				expect(fetchMock.mock.calls.length).toBe(1);
+				expect(fetchMock.mock.calls).toHaveLength(1);
 				expect(fetchMock.mock.calls[0][0]).toBe(`${locationProtocol}//${locationHost}/cors?url=${urlToCall}`);
 			});
 
-			test("Sends correct headers", async () => {
+			it("Sends correct headers", async () => {
 				urlToCall = "http://www.test.com/path?param1=value1";
 
 				const headers = [
@@ -43,22 +43,22 @@ describe("Default modules utils tests", () => {
 
 				await performWebRequest(urlToCall, "json", true, headers);
 
-				expect(fetchMock.mock.calls.length).toBe(1);
+				expect(fetchMock.mock.calls).toHaveLength(1);
 				expect(fetchMock.mock.calls[0][0]).toBe(`${locationProtocol}//${locationHost}/cors?sendheaders=header1:value1,header2:value2&url=${urlToCall}`);
 			});
 		});
 
 		describe("When not using cors proxy", () => {
-			test("Calls correct URL once", async () => {
+			it("Calls correct URL once", async () => {
 				urlToCall = "http://www.test.com/path?param1=value1";
 
 				await performWebRequest(urlToCall);
 
-				expect(fetchMock.mock.calls.length).toBe(1);
+				expect(fetchMock.mock.calls).toHaveLength(1);
 				expect(fetchMock.mock.calls[0][0]).toBe(urlToCall);
 			});
 
-			test("Sends correct headers", async () => {
+			it("Sends correct headers", async () => {
 				urlToCall = "http://www.test.com/path?param1=value1";
 				const headers = [
 					{ name: "header1", value: "value1" },
@@ -68,21 +68,21 @@ describe("Default modules utils tests", () => {
 				await performWebRequest(urlToCall, "json", false, headers);
 
 				const expectedHeaders = { headers: { header1: "value1", header2: "value2" } };
-				expect(fetchMock.mock.calls.length).toBe(1);
+				expect(fetchMock.mock.calls).toHaveLength(1);
 				expect(fetchMock.mock.calls[0][1]).toStrictEqual(expectedHeaders);
 			});
 		});
 
 		describe("When receiving json format", () => {
-			test("Returns undefined when no data is received", async () => {
+			it("Returns undefined when no data is received", async () => {
 				urlToCall = "www.test.com";
 
 				const response = await performWebRequest(urlToCall);
 
-				expect(response).toBe(undefined);
+				expect(response).toBeUndefined();
 			});
 
-			test("Returns object when data is received", async () => {
+			it("Returns object when data is received", async () => {
 				urlToCall = "www.test.com";
 				fetchResponse = new Response('{"body": "some content"}');
 
@@ -91,13 +91,13 @@ describe("Default modules utils tests", () => {
 				expect(response.body).toBe("some content");
 			});
 
-			test("Returns expected headers when data is received", async () => {
+			it("Returns expected headers when data is received", async () => {
 				urlToCall = "www.test.com";
 				fetchResponse = new Response('{"body": "some content"}', { headers: { header1: "value1", header2: "value2" } });
 
 				const response = await performWebRequest(urlToCall, "json", false, undefined, ["header1"]);
 
-				expect(response.headers.length).toBe(1);
+				expect(response.headers).toHaveLength(1);
 				expect(response.headers[0].name).toBe("header1");
 				expect(response.headers[0].value).toBe("value1");
 			});

--- a/tests/unit/modules/default/weather/weather_utils_spec.js
+++ b/tests/unit/modules/default/weather/weather_utils_spec.js
@@ -2,13 +2,13 @@ const weather = require("../../../../../modules/default/weather/weatherutils");
 const WeatherUtils = require("../../../../../modules/default/weather/weatherutils");
 
 describe("Weather utils tests", () => {
-	describe("windspeed conversion", () => {
+	describe("windspeed conversion to imperial", () => {
 		it("should convert temp correctly from Celsius to Fahrenheit", () => {
 			expect(Math.round(WeatherUtils.convertTemp(10, "imperial"))).toBe(50);
 		});
 	});
 
-	describe("windspeed conversion", () => {
+	describe("windspeed conversion to beaufort", () => {
 		it("should convert windspeed correctly from mps to beaufort", () => {
 			expect(Math.round(WeatherUtils.convertWind(5, "beaufort"))).toBe(3);
 			expect(Math.round(WeatherUtils.convertWind(300, "beaufort"))).toBe(12);
@@ -38,16 +38,16 @@ describe("Weather utils tests", () => {
 	describe("wind direction conversion", () => {
 		it("should convert wind direction correctly from cardinal to value", () => {
 			expect(WeatherUtils.convertWindDirection("SSE")).toBe(157);
-			expect(WeatherUtils.convertWindDirection("XXX")).toBe(null);
+			expect(WeatherUtils.convertWindDirection("XXX")).toBeNull();
 		});
 	});
 
 	describe("feelsLike calculation", () => {
-		it("should return a calculated feelsLike info", () => {
+		it("should return a calculated feelsLike info (negative value)", () => {
 			expect(WeatherUtils.calculateFeelsLike(0, 20, 40)).toBe(-9.444444444444445);
 		});
 
-		it("should return a calculated feelsLike info", () => {
+		it("should return a calculated feelsLike info (positiv value)", () => {
 			expect(WeatherUtils.calculateFeelsLike(30, 0, 60)).toBe(32.8320322777777);
 		});
 	});


### PR DESCRIPTION
Jest was in the plugin array of the ESLint configuration, but no rules were enabled. So ESLint hasn't checked any Jest rules yet.

So I activated the recommended Jest rules and added a few more. Then I fixed the issues (mostly automatically). I have deactivated the rules "jest/expect-expect" and "jest/no-done-callback" for the time being, as they would have entailed major changes. I didn't want to make the PR too big.

I'm not a Jest expert, but the changes so far look good to me. What do you think of that @khassel? :slightly_smiling_face: 