### PR TITLE
Fix missing typeof in calendar module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Fix calendar events sometimes not respecting deleted events (#3250)
 - Fix electron loadurl locally on Windows when address "0.0.0.0" (#2550)
 - Fix updatanotification (update_helper.js): catch error if reponse is not an JSON format (check PM2)
+- Fix missing typeof in calendar module
 
 ## [2.25.0] - 2023-10-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -130,13 +130,13 @@ Module.register("calendar", {
 				selfSignedCert: calendar.selfSignedCert
 			};
 
-			if (calendar.symbolClass === "undefined" || calendar.symbolClass === null) {
+			if (typeof calendar.symbolClass === "undefined" || calendar.symbolClass === null) {
 				calendarConfig.symbolClass = "";
 			}
-			if (calendar.titleClass === "undefined" || calendar.titleClass === null) {
+			if (typeof calendar.titleClass === "undefined" || calendar.titleClass === null) {
 				calendarConfig.titleClass = "";
 			}
-			if (calendar.timeClass === "undefined" || calendar.timeClass === null) {
+			if (typeof calendar.timeClass === "undefined" || calendar.timeClass === null) {
 				calendarConfig.timeClass = "";
 			}
 


### PR DESCRIPTION
I think comparing here with "undefined" (as a string) makes only sense with typeof.