### PR TITLE
start electron with --disable-gpu flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Review ESLint config (#3269)
 - Updated dependencies
 - Clock module: optionally display current moon phase in addition to rise/set times
+- electron is now per default started without gpu, if needed it must be enabled with new env var `ELECTRON_ENABLE_GPU=1` on startup (#3226)
 
 ### Fixed
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -8,9 +8,10 @@ const Log = require("./logger");
 let config = process.env.config ? JSON.parse(process.env.config) : {};
 // Module to control application life.
 const app = electron.app;
-// If ELECTRON_DISABLE_GPU is set electron is started with --disable-gpu flag.
+// Per default electron is started with --disable-gpu flag, if you want the gpu enabled,
+// you must set the env var ELECTRON_ENABLE_GPU=1 on startup.
 // See https://www.electronjs.org/docs/latest/tutorial/offscreen-rendering for more info.
-if (process.env.ELECTRON_DISABLE_GPU !== undefined) {
+if (process.env.ELECTRON_ENABLE_GPU !== "1") {
 	app.disableHardwareAcceleration();
 }
 


### PR DESCRIPTION
can be overriden with env var ELECTRON_ENABLE_GPU=1.

see #3226 

Tests will fail as long as https://github.com/MichMich/MagicMirror/pull/3289 is not merged.