### PR TITLE
fix calendar config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Fix missing typeof in calendar module
 - Fix style issues after prettier update
 - Fix calendar test (#3291) by moving "Exdate check" from e2e to electron to run on a Thursday
+- Fix calendar config params `fetchInterval` and `excludedEvents` were never used from single calendar config (#3297)
 
 ## [2.25.0] - 2023-10-01
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -127,7 +127,9 @@ Module.register("calendar", {
 				maximumNumberOfDays: calendar.maximumNumberOfDays,
 				pastDaysCount: calendar.pastDaysCount,
 				broadcastPastEvents: calendar.broadcastPastEvents,
-				selfSignedCert: calendar.selfSignedCert
+				selfSignedCert: calendar.selfSignedCert,
+				excludedEvents: calendar.excludedEvents,
+				fetchInterval: calendar.fetchInterval
 			};
 
 			if (typeof calendar.symbolClass === "undefined" || calendar.symbolClass === null) {


### PR DESCRIPTION
params `fetchInterval` and `excludedEvents` were never used from single calendar config.

Fixes #3297 
