### PR TITLE
change rule exceptions in .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,7 +66,7 @@
 	},
 	"overrides": [
 		{
-			"files": ["config/config.js.sample"],
+			"files": ["config/config.js*"],
 			"rules": {
 				"@stylistic/comma-dangle": "off",
 				"@stylistic/indent": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ _This release is scheduled to be released on 2024-01-01._
 - Updated dependencies
 - Clock module: optionally display current moon phase in addition to rise/set times
 - electron is now per default started without gpu, if needed it must be enabled with new env var `ELECTRON_ENABLE_GPU=1` on startup (#3226)
-- Replace prettier by stylistic in ESLint config to lint JavaScript
+- Replace prettier by stylistic in ESLint config to lint JavaScript (and disable some rules for `config/config.js*` files)
 
 ### Fixed
 


### PR DESCRIPTION
for all files beginning with `config/config.js` so e.g. `config.js` and `config.js.template` are included.

Otherwise the test will always fail locally if someone has renamed `config.js.sample` to `config.js`.