### PR TITLE
[linter] Enable ESLint rule `no-console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ planned for 2025-07-01
   - Removed as many of the date conversions as possible
   - Use `moment-timezone` when calculating recurring events, this will fix problems from the past with offsets and DST not being handled properly
   - Added some tests to test the behavior of the refactored methods to make sure the correct event dates are returned
+- [linter] Enable ESLint rule `no-console` and replace `console` with `Log` in some files
 
 ### Fixed
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -85,6 +85,16 @@ export default defineConfig([
 		}
 	},
 	{
+		files: ["**/*.js"],
+		ignores: [
+			"clientonly/index.js",
+			"modules/default/calendar/debug.js",
+			"js/logger.js",
+			"tests/**/*.js"
+		],
+		rules: {"no-console": "error"}
+	},
+	{
 		files: ["**/package.json"],
 		plugins: {packageJson},
 		extends: ["packageJson/recommended"]

--- a/js/app.js
+++ b/js/app.js
@@ -364,7 +364,7 @@ function App () {
 				}
 			} catch (error) {
 				Log.error(`Error when stopping node_helper for module ${nodeHelper.name}:`);
-				console.error(error);
+				Log.error(error);
 			}
 		}
 

--- a/js/main.js
+++ b/js/main.js
@@ -617,7 +617,7 @@ const MM = (function () {
 						if (startUp !== curr) {
 							startUp = "";
 							window.location.reload(true);
-							console.warn("Refreshing Website because server was restarted");
+							Log.warn("Refreshing Website because server was restarted");
 						}
 					} catch (err) {
 						Log.error(`MagicMirror not reachable: ${err}`);

--- a/js/utils.js
+++ b/js/utils.js
@@ -70,7 +70,7 @@ module.exports = {
 				fs.writeFileSync(discoveredPositionsJSFilename, `const modulePositions=${JSON.stringify(modulePositions)}`);
 			}
 			catch (error) {
-				console.error("unable to write js/positions.js with the discovered module positions\nmake the MagicMirror/js folder writeable by the user starting MagicMirror");
+				Log.error("unable to write js/positions.js with the discovered module positions\nmake the MagicMirror/js folder writeable by the user starting MagicMirror");
 			}
 		}
 		// return the list to the caller


### PR DESCRIPTION
In PR #3806 I noticed that ESLint did not complain about the use of `console`. Then I realised that the rule `no-console` was not activated. I have now changed this and replaced a few places where `console` was used.

We can't apply the rule to all .js files because not all of them use our logger. Therefore I had to add an extra config block for it.