### PR TITLE
replace `console` with `Log` in calendar `debug.js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Thanks to: @dathbe.
 - [refactor] Add new file `js/module_functions.js` to move code used in several modules to one place (#3837)
 - [tests] refactor: simplify jest config file (#3844)
 - [tests] refactor: extract constants for weather electron tests (#3845)
+- [tests] replace `console` with `Log` in calendar `debug.js` to avoid exception in eslint config (#3846)
 
 ### Updated
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -88,7 +88,6 @@ export default defineConfig([
 		files: ["**/*.js"],
 		ignores: [
 			"clientonly/index.js",
-			"modules/default/calendar/debug.js",
 			"js/logger.js",
 			"tests/**/*.js"
 		],

--- a/modules/default/calendar/debug.js
+++ b/modules/default/calendar/debug.js
@@ -5,6 +5,7 @@
  */
 // Alias modules mentioned in package.js under _moduleAliases.
 require("module-alias/register");
+const Log = require("../../../js/logger");
 
 const CalendarFetcher = require("./calendarfetcher");
 
@@ -20,22 +21,22 @@ const auth = {
 	pass: pass
 };
 
-console.log("Create fetcher ...");
+Log.log("Create fetcher ...");
 
 const fetcher = new CalendarFetcher(url, fetchInterval, [], maximumEntries, maximumNumberOfDays, auth);
 
 fetcher.onReceive(function (fetcher) {
-	console.log(fetcher.events());
-	console.log("------------------------------------------------------------");
+	Log.log(fetcher.events());
+	Log.log("------------------------------------------------------------");
 	process.exit(0);
 });
 
 fetcher.onError(function (fetcher, error) {
-	console.log("Fetcher error:");
-	console.log(error);
+	Log.log("Fetcher error:");
+	Log.log(error);
 	process.exit(1);
 });
 
 fetcher.startFetch();
 
-console.log("Create fetcher done! ");
+Log.log("Create fetcher done! ");


### PR DESCRIPTION
 to avoid exception in eslint config.

Background: If someone has a copy of the `modules` folder in his setup eslint fails because the file `debug.js` uses `console` statements. I need the `modules` folder renamed in my docker setup so this test always fails. I think this is a simple solution which has no impact.

(Alternative could be to exclude `**/debug.js` in eslint config).