### PR TITLE
bump minimal node version to v22.18.0

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [22.14.0, 22.x, 24.x]
+        node-version: [22.18.0, 22.x, 24.x]
     steps:
       - name: Install electron dependencies and labwc
         run: |

--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22.14.0, 22.x, 24.x]
+        node-version: [22.18.0, 22.x, 24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ planned for 2025-10-01
 
 Thanks to: @dathbe.
 
+> ⚠️ This release needs nodejs version `v22.18.0 or higher`
+
 ### Added
 
 - Added configuration option for `User-Agent`, used by calendar & news module (#3255)

--- a/Collaboration.md
+++ b/Collaboration.md
@@ -35,7 +35,7 @@ Are done by
   - [ ] test `prep-release` branch
   - [ ] update `CHANGELOG.md`
     - [ ] add all contributor names: `...`
-    - [ ] add min. node version: > ⚠️ This release needs nodejs version `v22.14.0` or higher
+    - [ ] add min. node version: > ⚠️ This release needs nodejs version `v22.18.0` or higher
     - [ ] check release link at the bottom of the file
   - [ ] commit and push all changes
   - [ ] create pull request from `prep-release` to `develop` branch with title `Prepare Release 2.xx.0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
 				"stylelint-prettier": "^5.0.3"
 			},
 			"engines": {
-				"node": ">=22.14.0"
+				"node": ">=22.18.0"
 			},
 			"optionalDependencies": {
 				"electron": "^38.0.0"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
 		"electron": "^38.0.0"
 	},
 	"engines": {
-		"node": ">=22.14.0"
+		"node": ">=22.18.0"
 	},
 	"_moduleAliases": {
 		"node_helper": "js/node_helper.js",


### PR DESCRIPTION
electron uses node v22.18 in its [current releases](https://releases.electronjs.org/), so we should go hand in hand and use that as the minimal node version