### PR TITLE
feat: add ESlint rule `no-sparse-arrays` for config check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ planned for 2026-01-01
 
 ### Fixed
 
+- feat: add ESlint rule `no-sparse-arrays` for config check to fix #3910 (#3911)
+
 ### Updated
 
 - [core] Update dependencies (#3909)

--- a/js/check_config.js
+++ b/js/check_config.js
@@ -58,7 +58,10 @@ function checkConfigFile () {
 					...globals.node
 				}
 			},
-			rules: { "no-undef": "error" }
+			rules: {
+				"no-sparse-arrays": "error",
+				"no-undef": "error"
+			}
 		},
 		configFileName
 	);


### PR DESCRIPTION
Adding a rule to the config checker config so that unexpected commas in the middle of arrays (reported in issue #3910) are better detected.

Two commas in a row inside the modules array create an empty entry (`undefined`). JavaScript accepts that syntax, but MagicMirror would later try to load that “module” and fail.

Alternatively, we could filter out undefined entries, but with this PR, the user receives a clear message indicating where the error lies, can easily fix it, and thus has a cleaner configuration.

## Before

```
[2025-10-10 19:33:30.874] [INFO]  Checking config file /home/kristjan/MagicMirror/config/config.js ... 
[2025-10-10 19:33:30.944] [INFO]  Your configuration file doesn't contain syntax errors :) 
[2025-10-10 19:33:30.945] [INFO]  Checking modules structure configuration ... 
[2025-10-10 19:33:31.027] [ERROR] This module configuration contains errors:
undefinedmust be object
```

## After

```
[2025-10-10 19:41:20.030] [INFO]  Checking config file /home/kristjan/MagicMirror/config/config.js ... 
[2025-10-10 19:41:20.107] [ERROR] Your configuration file contains syntax errors :(
Line 91 column 1: Unexpected comma in middle of array.
```