### PR TITLE
[weather] feat: add configurable forecast date format option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ planned for 2026-01-01
 
 ### Added
 
+- [weather] feat: add configurable forecast date format option (#3918)
+
 ### Changed
 
 - [core] refactor: replace `module-alias` dependency with internal alias resolver (#3893)

--- a/modules/default/weather/forecast.njk
+++ b/modules/default/weather/forecast.njk
@@ -16,7 +16,7 @@
         {% elif (currentStep == 1) and config.ignoreToday == false and config.absoluteDates == false %}
           <td class="day">{{ "TOMORROW" | translate }}</td>
         {% else %}
-          <td class="day">{{ f.date.format("ddd") }}</td>
+          <td class="day">{{ f.date.format(config.forecastDateFormat) }}</td>
         {% endif %}
         <td class="bright weather-icon">
           <span class="wi weathericon wi-{{ f.weatherType }}"></span>

--- a/modules/default/weather/weather.js
+++ b/modules/default/weather/weather.js
@@ -41,6 +41,7 @@ Module.register("weather", {
 		onlyTemp: false,
 		colored: false,
 		absoluteDates: false,
+		forecastDateFormat: "ddd", // format for forecast date display, e.g., "ddd" = Mon, "dddd" = Monday, "D MMM" = 18 Oct
 		hourlyForecastIncrements: 1
 	},
 


### PR DESCRIPTION
I was a little disappointed that I couldn't change the date format in the forecast because it was hard-coded. This PR introduces a new option (`forecastDateFormat`) that allows the user to specify the format themselves. The default remains `ddd`.

## Before

<img width="483" height="524" alt="Screenshot From 2025-10-18 18-26-13" src="https://github.com/user-attachments/assets/2de6af55-e73c-42e8-a3fe-7386ef5f90e0" />

## After (examples)

### `forecastDateFormat: "dddd"`
<img width="483" height="524" alt="Screenshot From 2025-10-18 18-26-27" src="https://github.com/user-attachments/assets/cd86c798-f1e4-4d75-adf9-c4e549aa2a51" />

### `forecastDateFormat: "ddd, D MMM"`
<img width="483" height="524" alt="Screenshot From 2025-10-18 18-28-02" src="https://github.com/user-attachments/assets/79aaa7b3-810a-4ab1-833c-09dfab7f457a" />


