### PR TITLE
[calendar] test: remove "Recurring event per timezone" test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ planned for 2026-01-01
 ### Changed
 
 - [core] refactor: replace `module-alias` dependency with internal alias resolver (#3893)
+- [calendar] test: remove "Recurring event per timezone" test (#3929)
 
 ### Fixed
 

--- a/tests/e2e/modules/calendar_spec.js
+++ b/tests/e2e/modules/calendar_spec.js
@@ -119,22 +119,6 @@ describe("Calendar module", () => {
 		});
 	});
 
-	for (let i = -12; i < 12; i++) {
-		describe("Recurring event per timezone", () => {
-			beforeAll(async () => {
-				Date.prototype.getTimezoneOffset = () => {
-					return i * 60;
-				};
-				await helpers.startApplication("tests/configs/modules/calendar/recurring.js");
-				await helpers.getDocument();
-			});
-
-			it(`should contain text "Mar 25th" in timezone UTC ${-i}`, async () => {
-				await expect(testTextContain(".calendar", "Mar 25th")).resolves.toBe(true);
-			});
-		});
-	}
-
 	describe("Changed port", () => {
 		beforeAll(async () => {
 			await helpers.startApplication("tests/configs/modules/calendar/changed-port.js");


### PR DESCRIPTION
Remove the "Recurring event per timezone" test that manipulated Date.prototype.getTimezoneOffset to simulate 24 different timezones for testing all-day recurring events.

Reasons for removal:
1. The test approach is incompatible with node-ical 0.22.0's Intl-based timezone handling (which replaced moment-timezone). Manipulating Date.prototype.getTimezoneOffset no longer affects Intl.DateTimeFormat, which reads the system timezone directly.

2. node-ical 0.22.0 handles all-day events (VALUE=DATE) correctly by preserving the calendar date without timezone conversions, making cross-timezone testing unnecessary. The library includes comprehensive tests for this behavior, particularly "keeps whole-day recurrence across DST" in [test/advanced.test.js](https://github.com/jens-maus/node-ical/blob/master/test/advanced.test.js).

3. The existing "Recurring event" test already verifies that recurring events from the same ICS file are displayed correctly, so a simplified version of "Recurring event per timezone" is not necessary.

The old test attempted to work around timezone conversion issues in node-ical 0.21.0 that are now properly resolved upstream.

Closes #3928