### PR TITLE
[calendar] chore: remove `requiresVersion: "2.1.0"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ planned for 2026-01-01
 - [core] refactor: replace `module-alias` dependency with internal alias resolver (#3893)
 - [check_config] refactor: improve error handling (#3927)
 - [calendar] test: remove "Recurring event per timezone" test (#3929)
+- [calendar] chore: remove `requiresVersion: "2.1.0"` (#3932)
 
 ### Fixed
 

--- a/modules/default/calendar/calendar.js
+++ b/modules/default/calendar/calendar.js
@@ -68,8 +68,6 @@ Module.register("calendar", {
 		updateOnFetch: true
 	},
 
-	requiresVersion: "2.1.0",
-
 	// Define required scripts.
 	getStyles () {
 		return ["calendar.css", "font-awesome.css"];


### PR DESCRIPTION
This is just to reduce a little noise in the dev console. The following line will not appear with this change:

```shell
module.js:480 Check MagicMirror² version for module 'calendar' - Minimum version:  2.1.0 - Current version: 2.34.0-
```

Since version 2.1.0 is so old, we can surely throw it out without concern.
