### PR TITLE
test: respect GitHub ACTIONS_STEP_DEBUG for verbose test logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ planned for 2026-01-01
 - [calendar] test: remove "Recurring event per timezone" test (#3929)
 - [calendar] chore: remove `requiresVersion: "2.1.0"` (#3932)
 - [tests] migrate from `jest` to `vitest` (#3940, #3941)
+- [test] respect GitHub ACTIONS_STEP_DEBUG for verbose test logging (#3942)
 
 ### Fixed
 

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -59,7 +59,8 @@ async function cors (req, res) {
 		}
 	} catch (error) {
 		// Only log errors in non-test environments to keep test output clean
-		if (process.env.mmTestMode !== "true") {
+		// Unless GitHub Actions step debug logging is explicitly enabled
+		if (process.env.mmTestMode !== "true" || process.env.ACTIONS_STEP_DEBUG === "true") {
 			Log.error(error);
 		}
 		res.send(error);

--- a/modules/default/updatenotification/git_helper.js
+++ b/modules/default/updatenotification/git_helper.js
@@ -184,7 +184,8 @@ class GitHelper {
 				}
 			} catch (e) {
 				// Only log errors in non-test environments to keep test output clean
-				if (process.env.mmTestMode !== "true") {
+				// Unless GitHub Actions step debug logging is explicitly enabled
+				if (process.env.mmTestMode !== "true" || process.env.ACTIONS_STEP_DEBUG === "true") {
 					Log.error(`Failed to retrieve repo info for ${repo.module}: ${e}`);
 				}
 			}

--- a/tests/utils/vitest-setup.js
+++ b/tests/utils/vitest-setup.js
@@ -22,7 +22,8 @@ Module.prototype.require = function (id) {
 		const logger = originalRequire.call(this, path.resolve(__dirname, "../../js/logger.js"));
 
 		// Suppress debug/info logs in CI to keep output clean
-		if (!logLevelApplied && process.env.CI === "true") {
+		// Unless GitHub Actions step debug logging is enabled
+		if (!logLevelApplied && process.env.CI === "true" && process.env.ACTIONS_STEP_DEBUG !== "true") {
 			logger.setLogLevel("ERROR");
 			logLevelApplied = true;
 		}


### PR DESCRIPTION
When tests failed, I clicked “Enable debug logging” several times when rerunning them and was always disappointed that I couldn't find any more logs. This should fix this.

<img width="1188" height="669" alt="image" src="https://github.com/user-attachments/assets/33e2db8b-148a-4c51-9c30-ce3616c1265e" />


