### PR TITLE
[ci] Add concurrency to automated tests workflow to cancel outdated runs

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-style-check:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ planned for 2026-01-01
 - [calendar] test: remove "Recurring event per timezone" test (#3929)
 - [calendar] chore: remove `requiresVersion: "2.1.0"` (#3932)
 - [tests] migrate from `jest` to `vitest` (#3940, #3941)
+- [ci] Add concurrency to automated tests workflow to cancel outdated runs (#3943)
 
 ### Fixed
 


### PR DESCRIPTION
Add `concurrency` configuration to automatically cancel outdated test runs when new commits are pushed to the same PR/branch.

Inspired by [MagicMirrorOrg/MagicMirror-Documentation#335](https://github.com/MagicMirrorOrg/MagicMirror-Documentation/pull/335).