### PR TITLE
[gitignore] restoring the old Git behavior for the CSS directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,12 @@ Temporary Items
 modules
 !modules/default
 
-# Ignore changes to the custom css files but keep others.
-css/custom.css
+# Ignore changes to the custom css files but keep the sample and main.
+/css/*
+!/css/custom.css.sample
+!/css/font-awesome.css
+!/css/main.css
+!/css/roboto.css
 
 # Ignore users config file but keep the sample.
 config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ planned for 2026-01-01
 
 ### Removed
 
-- [weather] Removed deprecated ukmetoffice datapoint provider (#3842, #3952)
+- [weather] Removed deprecated `ukmetoffice` datapoint provider (#3842, #3952)
 
 ### Changed
 


### PR DESCRIPTION
The advantage of the old behavior is that users can keep backups, copies or any other CSS files with different names in the directory without Git interfering.

I suspect that this was not taken into account during the cleanup in PR #3952 :slightly_smiling_face: 
