### PR TITLE
[gitignore] restore the old Git behavior for the default modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ Temporary Items
 .Trash-*
 
 # Ignore all modules except the default modules.
-modules
+modules/*
 !modules/default
 
 # Ignore changes to the custom css files but keep the sample and main.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ planned for 2026-01-01
 - [core] refactor: replace `XMLHttpRequest` with `fetch` in `translator.js` (#3950)
 - [tests] migrate e2e tests to Playwright (#3950)
 - [calendar] refactor: migrate CalendarFetcher to ES6 class and improve error handling (#3958)
+- [gitignore] cleanup/simplify .gitignore (#3952, #3954, #3968)
 
 ### Fixed
 


### PR DESCRIPTION
The pattern `modules` was too broad and prevented tracking files in `modules/default/` despite the negation pattern. Changed to `modules/*` to properly exclude only the content of the modules directory while allowing the default modules to be tracked.

This issue was likely introduced during the cleanup in #3952.

Without this change there are now warn messages like this:

```bash
kristjan@debian:~/MagicMirror$ git add modules/default/compliments/compliments.js
The following paths are ignored by one of your .gitignore files:
modules
hint: Use -f if you really want to add them.
hint: Disable this message with "git config advice.addIgnoredFile false"
```