### PR TITLE
[core] chore: simplify Wayland start script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ planned for 2026-01-01
 - [tests] migrate e2e tests to Playwright (#3950)
 - [calendar] refactor: migrate CalendarFetcher to ES6 class and improve error handling (#3958)
 - [gitignore] cleanup/simplify .gitignore (#3952, #3954, #3968, #3969)
-- refactor(compliments): optimize `loadComplimentFile` method and add unit tests(#3969)
+- [compliments] refactor: optimize `loadComplimentFile` method and add unit tests(#3969)
+- [core] chore: simplify Wayland start script (#3974)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"server:watch": "node ./serveronly/watcher.js",
 		"start": "node --run start:x11",
 		"start:dev": "node --run start:x11 -- dev",
-		"start:wayland": "WAYLAND_DISPLAY=\"${WAYLAND_DISPLAY:=wayland-1}\" ./node_modules/.bin/electron js/electron.js --enable-features=UseOzonePlatform --ozone-platform=wayland",
+		"start:wayland": "WAYLAND_DISPLAY=\"${WAYLAND_DISPLAY:=wayland-1}\" ./node_modules/.bin/electron js/electron.js",
 		"start:wayland:dev": "node --run start:wayland -- dev",
 		"start:windows": ".\\node_modules\\.bin\\electron js\\electron.js",
 		"start:windows:dev": "node --run start:windows -- dev",


### PR DESCRIPTION
Remove `--enable-features=UseOzonePlatform` and `--ozone-platform=wayland` flags as Electron 38+ changed the default `--ozone-platform` to `auto`, which automatically detects and uses Wayland when running in a Wayland session.

Source: https://www.electronjs.org/blog/electron-38-0#removed-electron_ozone_platform_hint-environment-variable.