### PR TITLE
testing: update "Enforce Pull-Request Rules" workflow

### DIFF
--- a/.github/workflows/enforce-pullrequest-rules.yaml
+++ b/.github/workflows/enforce-pullrequest-rules.yaml
@@ -1,22 +1,26 @@
 # This workflow enforces on every pull request that the PR is not based against master,
-# taken from https://github.com/oppia/oppia-android/pull/2832/files
+# taken from https://github.com/oppia/oppia-android/blob/develop/.github/workflows/static_checks.yml
 
 name: "Enforce Pull-Request Rules"
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+  pull_request:
+  push:
+    branches-ignore:
+      - develop
+      - master
 
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     timeout-minutes: 10
     steps:
-      - name: "Enforce develop branch"
-        if: ${{ github.event.pull_request.base.ref == 'master' && !contains(github.event.pull_request.labels.*.name, 'mastermerge') }}
+      - name: "Branch is not based on develop"
+        if: ${{ github.base_ref != 'develop' && !contains(github.event.pull_request.labels.*.name, 'mastermerge') }}
         run: |
-          echo "This PR is based against the master branch and not a release or hotfix."
-          echo "Please don't do this. Switch the branch to 'develop'."
+          echo "Current base branch: $BASE_BRANCH"
+          echo "Note: PRs should only ever be merged into develop so please rebase your branch on develop and try again."
           exit 1
         env:
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          BASE_BRANCH: ${{ github.base_ref }}


### PR DESCRIPTION
With this update the workflow file from inside the feature branch is used, not the old stuff coming from `master` as before. This does not help for the currently failing job which still comes from `master` (we have to live with this until next release), but this will help in the future to prevent such errors.

Tested this on my fork:
- base against `develop`: workflow is skipped
- base against `master`: workflow fails
- base against `master` with label `mastermerge`: workflow is skipped

I took this new workflow from the same repo where the previous workflows was taken (see diff for the link) so this is the further development.