### PR TITLE
[core] fix: restore `--ozone-platform=wayland` flag for reliable Wayland support

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"server:watch": "node ./serveronly/watcher.js",
 		"start": "node --run start:x11",
 		"start:dev": "node --run start:x11 -- dev",
-		"start:wayland": "WAYLAND_DISPLAY=\"${WAYLAND_DISPLAY:=wayland-1}\" ./node_modules/.bin/electron js/electron.js",
+		"start:wayland": "WAYLAND_DISPLAY=\"${WAYLAND_DISPLAY:=wayland-1}\" ./node_modules/.bin/electron js/electron.js --ozone-platform=wayland",
 		"start:wayland:dev": "node --run start:wayland -- dev",
 		"start:windows": ".\\node_modules\\.bin\\electron js\\electron.js",
 		"start:windows:dev": "node --run start:windows -- dev",


### PR DESCRIPTION
The Electron 38+ auto-detection of ozone-platform does not work reliably in all environments (e.g., Docker containers) because it depends on environment variables like XDG_SESSION_TYPE which may not be set.

Since `start:wayland` is explicitly called for Wayland sessions, it makes sense to explicitly specify the platform flag for maximum reliability.

The `--enable-features=UseOzonePlatform` flag remains removed as it is no longer needed since Electron 38.

Fixes Docker compatibility issue reported in MagicMirrorOrg/MagicMirror#3974