### PR TITLE
[core] fix: allow browser globals in config files

### DIFF
--- a/js/check_config.js
+++ b/js/check_config.js
@@ -57,6 +57,7 @@ function checkConfigFile () {
 			languageOptions: {
 				ecmaVersion: "latest",
 				globals: {
+					...globals.browser,
 					...globals.node
 				}
 			},


### PR DESCRIPTION
The config checker previously only allowed Node.js globals, but since the config file runs also in the browser context, users should be able to access browser APIs like `document` or `window` when needed.

This was incorrectly flagged as an error by the `no-undef` ESLint rule. The fix adds browser globals to the allowed globals in the linter config.

Fixes #3990.
