### PR TITLE
fix(calendar): correct day-of-week for full-day recurring events across all timezones

### DIFF
--- a/modules/default/calendar/calendarfetcherutils.js
+++ b/modules/default/calendar/calendarfetcherutils.js
@@ -82,8 +82,12 @@ const CalendarFetcherUtils = {
 		// rrule.js returns UTC dates with tzid cleared, so we interpret them in the event's original timezone
 		return dates.map((date) => {
 			if (isFullDayEvent) {
-				// For all-day events, anchor to calendar day in event's timezone
-				return moment.tz(date, eventTimezone).startOf("day");
+				// For all-day events, extract UTC date components and interpret as local calendar date
+				// This prevents timezone offsets from shifting the date to the previous/next day
+				const utcYear = date.getUTCFullYear();
+				const utcMonth = date.getUTCMonth();
+				const utcDate = date.getUTCDate();
+				return moment.tz([utcYear, utcMonth, utcDate], eventTimezone);
 			}
 			// For timed events, preserve the time in the event's original timezone
 			return moment.tz(date, "UTC").tz(eventTimezone, true);


### PR DESCRIPTION
Fixes **full-day recurring events showing on wrong day** in timezones west of UTC (reported in #4003).

**Root cause**: `moment.tz(date, eventTimezone).startOf("day")` interprets UTC midnight as local time:
- `2025-11-03T00:00:00.000Z` in America/Chicago (UTC-6)
- → Converts to `2025-11-02 18:00:00` (6 hours back)
- → `.startOf("day")` → `2025-11-02 00:00:00` ❌ **Wrong day!**

**Impact**: The bug affects:
- All timezones west of UTC (UTC-1 through UTC-12): Americas, Pacific
- Timezones east of UTC (UTC+1 through UTC+12): Europe, Asia, Africa - work correctly
- UTC itself - works correctly

The issue was introduced with commit c2ec6fc2 (#3976), which fixed the time but broke the date. This PR fixes both.

| | Result | Day | Time | Notes |
|----------|--------|-----|------|-------|
| **Before c2ec6fc2** | `2025-11-03 05:00:00 Monday` | ✅ | ❌ | Wrong time, but correct day |
| **Current (c2ec6fc2)** | `2025-11-02 00:00:00 Sunday` | ❌ (west of UTC)<br>✅ (east of UTC) | ✅ | Wrong day - visible bug! |
| **This fix** | `2025-11-03 00:00:00 Monday` | ✅ | ✅ | Correct in all timezones |

Note: While the old logic had incorrect timing, it produced the correct calendar day due to how it handled UTC offsets. The current logic fixed the timing issue but introduced the more visible calendar day bug.

### Solution

Extract UTC date components and interpret as local calendar dates:

```javascript
const utcYear = date.getUTCFullYear();
const utcMonth = date.getUTCMonth();
const utcDate = date.getUTCDate();
return moment.tz([utcYear, utcMonth, utcDate], eventTimezone);
```

### Testing

To prevent this from happening again in future refactorings, I wrote a test for it.

```bash
npm test -- tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
```
