### PR TITLE
chore: migrate CI workflows to ubuntu-slim for faster startup times

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   code-style-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     steps:
       - name: "Checkout code"

--- a/.github/workflows/dep-review.yaml
+++ b/.github/workflows/dep-review.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v6

--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   rebuild:
     name: Run electron-rebuild
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       matrix:
         node-version: [22.21.1, 22.x, 24.x]

--- a/.github/workflows/enforce-pullrequest-rules.yaml
+++ b/.github/workflows/enforce-pullrequest-rules.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: github.event_name == 'pull_request'
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   release-notes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 15
     steps:
       - name: "Checkout code"

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   spellcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/stale@v10
         with:


### PR DESCRIPTION
*This type of runner is optimized for automation tasks, issue operations and short-running jobs. They are not suitable for typical heavyweight CI/CD builds.* [[1](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners)].

We are not necessarily dependent on faster startups, but that seems to be becoming the best practice now.
