### PR TITLE
refactor: further logger clean-up

### DIFF
--- a/js/logger.js
+++ b/js/logger.js
@@ -83,13 +83,12 @@
 				timeStamp: console.timeStamp.bind(console)
 			};
 
+			// Only these methods are affected by setLogLevel.
+			// Utility methods (group, time, etc.) are always active.
 			logLevel.setLogLevel = function (newLevel) {
-				if (newLevel) {
-					Object.keys(logLevel).forEach(function (key) {
-						if (!newLevel.includes(key.toLocaleUpperCase())) {
-							logLevel[key] = function () {};
-						}
-					});
+				for (const key of ["debug", "log", "info", "warn", "error"]) {
+					const disabled = newLevel && !newLevel.includes(key.toUpperCase());
+					logLevel[key] = disabled ? function () {} : console[key].bind(console);
 				}
 			};
 		} else {


### PR DESCRIPTION
After #4049 here are two small follow-up improvements to `js/logger.js`.

**1. Simpler bind syntax** — `Function.prototype.bind.call(console.debug, console)` is an archaic pattern. The equivalent `console.debug.bind(console)` works fine in all supported engines (Node.js ≥ 22, modern browsers) and is much easier to read. Also: `console.timeStamp` exists in all supported environments, so the conditional fallback to an empty function is no longer needed.

**2. Simpler `setLogLevel`** — instead of iterating over all keys in the logger object and permanently overwriting them, the method now loops over the five log-level keys explicitly and rebinds from `console[key]`. This makes the filtered set obvious at a glance and ensures utility methods like `group`, `time`, and `timeStamp` are never accidentally silenced — they're structural helpers, not log levels.
