### PR TITLE
weather: add possibility to override njk's and css

### DIFF
--- a/defaultmodules/weather/weather.js
+++ b/defaultmodules/weather/weather.js
@@ -104,7 +104,7 @@ Module.register("weather", {
 		// All providers run server-side: generate unique instance ID and initialize via node_helper
 		this.instanceId = `${this.identifier}_${Date.now()}`;
 
-		if (window.initWeatherTheme) window.initWeatherTheme();
+		if (window.initWeatherTheme) window.initWeatherTheme(this);
 
 		Log.log(`[weather] Initializing server-side provider with instance ID: ${this.instanceId}`);
 
@@ -254,7 +254,7 @@ Module.register("weather", {
 			window.updateWeatherTheme(this);
 		} else {
 			this.updateDom(300);
-		};
+		}
 
 		const currentWeather = this.currentWeatherObject;
 


### PR DESCRIPTION
This is an approach for #2909

It adds 2 values to the config:

```js
		themeDir: "./",
		themeCustomScripts: []
```

`themeDir` must be specified relative to the weather dir.

Example config:

```js
		{
			module: "weather",
			position: "top_center",
			config: {
				weatherProvider: "openmeteo",
				type: "current",
				lat: 40.776676,
				lon: -73.971321,
				themeDir: "../../../modules/MyWeatherTemplate/",
				themeCustomScripts: [ "skycons.js", "weathertheme.js" ],
			}
		},
```

The `themeDir` must contain the 4 files
- current.njk
- forecast.njk
- hourly.njk
- weather.css

You can add more files (if needed) and add them to the `themeCustomScripts` so they are loaded as script.

There are 2 methods inserted which are called if defined:
- initWeatherTheme: For doing special things when starting the module
- updateWeatherTheme: For doing special things before updating the dom

I see this as a simple approach for overriding the default njk templates and css. I did already convert my [MMM-WeatherBridge](https://gitlab.com/khassel/MMM-WeatherBridge) into a template.