### PR TITLE
refactor: simplify internal `require()` calls

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -9,11 +9,12 @@ const Log = require("logger");
 // global absolute root path
 global.root_path = path.resolve(`${__dirname}/../`);
 
-const Server = require(`${__dirname}/server`);
-const Utils = require(`${__dirname}/utils`);
-
 // used to control fetch timeout for node_helpers
 const { setGlobalDispatcher, Agent } = require("undici");
+
+const Server = require("./server");
+const Utils = require("./utils");
+
 const { getEnvVarsAsObj } = require("#server_functions");
 // common timeout value, provide environment override in case
 const fetch_timeout = process.env.mmFetchTimeout !== undefined ? process.env.mmFetchTimeout : 30000;

--- a/js/server.js
+++ b/js/server.js
@@ -6,11 +6,12 @@ const express = require("express");
 const helmet = require("helmet");
 const socketio = require("socket.io");
 const Log = require("logger");
+
+const { ipAccessControl } = require("./ip_access_control");
+
+const vendor = require("./vendor");
+
 const { getHtml, getVersion, getEnvVars, cors } = require("#server_functions");
-
-const { ipAccessControl } = require(`${__dirname}/ip_access_control`);
-
-const vendor = require(`${__dirname}/vendor`);
 
 /**
  * Server

--- a/js/utils.js
+++ b/js/utils.js
@@ -96,7 +96,7 @@ const checkDeprecatedOptions = (userConfig) => {
  */
 const loadConfig = () => {
 	Log.log("Loading config ...");
-	const defaults = require(`${__dirname}/defaults`);
+	const defaults = require("./defaults");
 	if (global.mmTestMode) {
 		// if we are running in test mode
 		defaults.address = "0.0.0.0";


### PR DESCRIPTION
Remove unnecessary `__dirname` template-literal prefix from relative `require()` paths. Node.js resolves relative require() paths correctly without it.

While this may look like nitpicking: `require("./server")` is transparent to static analysis tools - IDEs can resolve the path and support go-to-definition. Template literals with `__dirname` are opaque to them. It also removes another usage of `__dirname`, which has no native equivalent in ESM and would need to be replaced there anyway (when we switch to ESM anytime in the future).

The import reordering is a side effect: `import-x/order` treats template-literal `require()` calls differently from plain strings, so the previous order was no longer valid.