### PR TITLE
docs: add security policy and vulnerability reporting guidelines

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Scope and Deployment
+
+MagicMirror is primarily intended for trusted local/private network environments.
+Direct public exposure to the internet or other untrusted networks is not recommended.
+
+We take security seriously and encourage responsible disclosure of vulnerabilities to help us improve the software.
+
+## Reporting a Vulnerability
+
+**Please keep vulnerability details private** — do not post them in public GitHub issues.
+
+Instead, reach out privately via the MagicMirror forum to one of the core developers:
+
+- [rejas](https://forum.magicmirror.builders/user/rejas)
+- [karsten13](https://forum.magicmirror.builders/user/karsten13)
+- [sdetweil](https://forum.magicmirror.builders/user/sdetweil)
+- [Kristjan](https://forum.magicmirror.builders/user/kristjanesperanto)
+
+Please include, if possible:
+
+- Affected version(s)
+- Reproduction steps or proof-of-concept
+- What could an attacker do with this?
+- Any ideas how to fix it?
+
+## Coordinated Disclosure
+
+We will keep reported vulnerabilities private until a fix is available and coordinate the disclosure timeline with you.
+We aim to respond as quickly as possible.


### PR DESCRIPTION
Adding a SECURITY.md helps us make two things clearer:

- MagicMirror is not intended for direct public internet exposure.
- There is a clear path to report security concerns responsibly.

Related issue: #4067  

---

As always, suggestions for improvement are very welcome.