### PR TITLE
fix(tests): correct import path for git_helper module in updatenotification tests

### DIFF
--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -20,7 +20,7 @@ async function createGitHelper (fsStatSyncMockRef, loggerMockRef, execShellSpyRe
 	vi.doMock("logger", () => loggerMockRef.current);
 
 	const defaults = await import("../../../js/defaults");
-	const gitHelperModule = await import(`../../../${defaults.defaultModulesDir}/updatenotification/git_helper`);
+	const gitHelperModule = await import(`../../../${defaults.defaultModulesDir}/updatenotification/git_helper.js`);
 	const GitHelper = gitHelperModule.default || gitHelperModule;
 	const instance = new GitHelper();
 	execShellSpyRef.current = vi.spyOn(instance, "execShell");


### PR DESCRIPTION
This removes a warning which appeared running a test:

```bash
$ npx vitest --run tests/unit/functions/updatenotification_spec.js

 RUN  v4.1.2

7:46:46 PM [vite] (ssr) warning: invalid import "../../../${defaults.defaultModulesDir}/updatenotification/git_helper". A file extension must be included in the static part of the import. For example: import(`./foo/${bar}.js`).
```

Related to #4073