### PR TITLE
fix(newsfeed): prevent duplicate parse error callback when using pipeline

### DIFF
--- a/defaultmodules/newsfeed/newsfeedfetcher.js
+++ b/defaultmodules/newsfeed/newsfeedfetcher.js
@@ -40,7 +40,7 @@ class NewsfeedFetcher {
 		});
 
 		// Wire up HTTPFetcher events
-		this.httpFetcher.on("response", (response) => this.#handleResponse(response));
+		this.httpFetcher.on("response", (response) => void this.#handleResponse(response));
 		this.httpFetcher.on("error", (errorInfo) => this.fetchFailedCallback(this, errorInfo));
 	}
 
@@ -67,7 +67,7 @@ class NewsfeedFetcher {
 	 * Handles successful HTTP response
 	 * @param {Response} response - The fetch Response object
 	 */
-	#handleResponse (response) {
+	async #handleResponse (response) {
 		this.items = [];
 		const parser = new FeedMe();
 
@@ -106,11 +106,6 @@ class NewsfeedFetcher {
 
 		parser.on("end", () => this.broadcastItems());
 
-		parser.on("error", (error) => {
-			Log.error(`${this.url} - Feed parsing failed: ${error.message}`);
-			this.fetchFailedCallback(this, this.#createParseError(`Feed parsing failed: ${error.message}`, error));
-		});
-
 		parser.on("ttl", (minutes) => {
 			const ttlms = Math.min(minutes * 60 * 1000, 86400000);
 			if (ttlms > this.httpFetcher.reloadInterval) {
@@ -123,7 +118,7 @@ class NewsfeedFetcher {
 			const nodeStream = response.body instanceof stream.Readable
 				? response.body
 				: stream.Readable.fromWeb(response.body);
-			nodeStream.pipe(iconv.decodeStream(this.encoding)).pipe(parser);
+			await stream.promises.pipeline(nodeStream, iconv.decodeStream(this.encoding), parser);
 		} catch (error) {
 			Log.error(`${this.url} - Stream processing failed: ${error.message}`);
 			this.fetchFailedCallback(this, this.#createParseError(`Stream processing failed: ${error.message}`, error));


### PR DESCRIPTION
In PR #4072 GitHub Bot complained that `newsfeedfetcher.js` used the old `.pipe()` method to connect streams (HTTP body → iconv decoding → RSS parser). `.pipe()` has a weakness: errors in one stream are **not** automatically forwarded to downstream streams. An I/O or decoding error would silently disappear.

## Solution

Replaced `.pipe()` with `await stream.promises.pipeline()`. The `pipeline()` API is designed to propagate errors correctly through the entire chain and to clean up all streams on failure. Errors now reliably land in the `catch` block and call `fetchFailedCallback` exactly once. The redundant `parser.on("error")` handler was removed, as it would have caught the same error again and called the callback a second time.

## Why not the bot's suggested fix?

The GitHub Bot suggested the older callback-based `stream.pipeline(callback)` variant:

```js
stream.pipeline(nodeStream, iconv.decodeStream(...), parser, (error) => {
    if (!error) return;
    // error handling...
});
```

This has two drawbacks compared to my approach:

1. It uses the older callback style — `stream.promises.pipeline()` with `async/await` is the modern, more readable API.
2. The bot's suggestion kept both the `parser.on("error")` handler **and** the `catch` block, which would not have fixed the double-callback problem.

----

Related to #4073