### PR TITLE
refactor: replace implicit global config with explicit global.config

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -174,7 +174,8 @@ function App () {
 	 */
 	this.start = async function () {
 		const configObj = Utils.loadConfig();
-		config = configObj.fullConf;
+		global.config = configObj.fullConf;
+		const config = global.config;
 		Utils.checkConfigFile(configObj);
 
 		global.defaultModulesDir = config.defaultModulesDir;
@@ -245,7 +246,7 @@ function App () {
 
 		Log.log("Sockets connected & modules started ...");
 
-		return config;
+		return global.config;
 	};
 
 	/**

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -46,7 +46,7 @@ async function cors (req, res) {
 			return res.status(400).send(url);
 		} else {
 			url = match[1];
-			if (typeof config !== "undefined") {
+			if (typeof global.config !== "undefined") {
 				if (config.hideConfigSecrets) {
 					url = replaceSecretPlaceholder(url);
 				}
@@ -144,15 +144,15 @@ function getVersion (req, res) {
 function getUserAgent () {
 	const defaultUserAgent = `Mozilla/5.0 (Node.js ${Number(process.version.match(/^v(\d+\.\d+)/)[1])}) MagicMirror/${global.version}`;
 
-	if (typeof config === "undefined") {
+	if (typeof global.config === "undefined") {
 		return defaultUserAgent;
 	}
 
-	switch (typeof config.userAgent) {
+	switch (typeof global.config.userAgent) {
 		case "function":
-			return config.userAgent();
+			return global.config.userAgent();
 		case "string":
-			return config.userAgent;
+			return global.config.userAgent;
 		default:
 			return defaultUserAgent;
 	}
@@ -163,7 +163,7 @@ function getUserAgent () {
  * @returns {object} environment variables key: values
  */
 function getEnvVarsAsObj () {
-	const obj = { modulesDir: `${config.foreignModulesDir}`, defaultModulesDir: `${config.defaultModulesDir}`, customCss: `${config.customCss}` };
+	const obj = { modulesDir: `${global.config.foreignModulesDir}`, defaultModulesDir: `${global.config.defaultModulesDir}`, customCss: `${global.config.customCss}` };
 	if (process.env.MM_MODULES_DIR) {
 		obj.modulesDir = process.env.MM_MODULES_DIR.replace(`${global.root_path}/`, "");
 	}


### PR DESCRIPTION
In PR #4072 the GitHub bot complained about a missing variable declaration for `config` in `app.js` and suggested adding `let config`. Applying that suggestion broke the app because `server_functions.js` was accessing `config` as an implicit global variable - the `let` declaration made it unreachable from there.

So instead of the `let` declaration, I replaced all bare `config` references with explicit `global.config`. This makes the dependency on the global variable visible without changing runtime behavior, consistent with how other globals like `global.root_path` and `global.version` are already handled throughout the codebase.

Related to #4073