### PR TITLE
ci(codeql): also scan develop branch on push and PR

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+    branches: [develop]
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - uses: github/codeql-action/autobuild@v4
+
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Previously only master was scanned via the default CodeQL setup. Since development happens on develop, this PR replaces the default setup with a custom workflow that covers both branches. This gives an overview of the security status across the current release (master) and the development branch (develop).

As a result we should also see issues in the develop branch here: https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning