### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"ajv": "^8.18.0",
 				"animate.css": "^4.1.1",
 				"croner": "^10.0.1",
-				"eslint": "^10.1.0",
+				"eslint": "^10.2.0",
 				"express": "^5.2.1",
 				"feedme": "^2.0.2",
 				"globals": "^17.4.0",
@@ -26,13 +26,13 @@
 				"ipaddr.js": "^2.3.0",
 				"moment": "^2.30.1",
 				"moment-timezone": "^0.6.1",
-				"node-ical": "^0.25.6",
+				"node-ical": "^0.26.0",
 				"nunjucks": "^3.2.4",
 				"pm2": "^6.0.14",
 				"socket.io": "^4.8.3",
 				"suncalc": "^1.9.0",
 				"systeminformation": "^5.31.5",
-				"undici": "^7.24.6",
+				"undici": "^8.0.2",
 				"weathericons": "^2.1.0"
 			},
 			"devDependencies": {
@@ -43,7 +43,7 @@
 				"@vitest/ui": "^4.1.2",
 				"cspell": "^9.7.0",
 				"eslint-plugin-import-x": "^4.16.2",
-				"eslint-plugin-jsdoc": "^62.8.1",
+				"eslint-plugin-jsdoc": "^62.9.0",
 				"eslint-plugin-package-json": "^0.91.1",
 				"eslint-plugin-playwright": "^2.10.1",
 				"express-basic-auth": "^1.2.1",
@@ -52,7 +52,7 @@
 				"lint-staged": "^16.4.0",
 				"markdownlint-cli2": "^0.22.0",
 				"msw": "^2.12.14",
-				"playwright": "^1.58.2",
+				"playwright": "^1.59.1",
 				"prettier": "^3.8.1",
 				"prettier-plugin-jinja-template": "^2.1.0",
 				"stylelint": "^17.6.0",
@@ -64,7 +64,7 @@
 				"node": ">=22.21.1 <23 || >=24"
 			},
 			"optionalDependencies": {
-				"electron": "^41.1.0"
+				"electron": "^41.1.1"
 			}
 		},
 		"node_modules/@altano/repository-tools": {
@@ -75,9 +75,9 @@
 			"license": "ISC"
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.1.tgz",
-			"integrity": "sha512-iGWN8E45Ws0XWx3D44Q1t6vX2LqhCKcwfmwBYCDsFrYFS6m4q/Ks61L2veETaLv+ckDC6+dTETJoaAAb7VjLiw==",
+			"version": "5.1.5",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.5.tgz",
+			"integrity": "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -92,9 +92,9 @@
 			}
 		},
 		"node_modules/@asamuzakjp/dom-selector": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
-			"integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.6.tgz",
+			"integrity": "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1153,14 +1153,14 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-			"integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.0",
+				"@emnapi/wasi-threads": "1.2.1",
 				"tslib": "^2.4.0"
 			}
 		},
@@ -1173,9 +1173,9 @@
 			"optional": true
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-			"integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1192,9 +1192,9 @@
 			"optional": true
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-			"integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1211,30 +1211,20 @@
 			"optional": true
 		},
 		"node_modules/@es-joy/jsdoccomment": {
-			"version": "0.84.0",
-			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.84.0.tgz",
-			"integrity": "sha512-0xew1CxOam0gV5OMjh2KjFQZsKL2bByX1+q4j3E73MpYIdyUxcZb/xQct9ccUb+ve5KGUYbCUxyPnYB7RbuP+w==",
+			"version": "0.86.0",
+			"resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.86.0.tgz",
+			"integrity": "sha512-ukZmRQ81WiTpDWO6D/cTBM7XbrNtutHKvAVnZN/8pldAwLoJArGOvkNyxPTBGsPjsoaQBJxlH+tE2TNA/92Qgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.8",
-				"@typescript-eslint/types": "^8.54.0",
-				"comment-parser": "1.4.5",
+				"@typescript-eslint/types": "^8.58.0",
+				"comment-parser": "1.4.6",
 				"esquery": "^1.7.0",
-				"jsdoc-type-pratt-parser": "~7.1.1"
+				"jsdoc-type-pratt-parser": "~7.2.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
-			}
-		},
-		"node_modules/@es-joy/jsdoccomment/node_modules/comment-parser": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-			"integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/@es-joy/resolve.exports": {
@@ -1287,12 +1277,12 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-			"integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+			"version": "0.23.4",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.4.tgz",
+			"integrity": "sha512-lf19F24LSMfF8weXvW5QEtnLqW70u7kgit5e9PSx0MsHAFclGd1T9ynvWEMDT1w5J4Qt54tomGeAhdoAku1Xow==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/object-schema": "^3.0.3",
+				"@eslint/object-schema": "^3.0.4",
 				"debug": "^4.3.1",
 				"minimatch": "^10.2.4"
 			},
@@ -1301,21 +1291,21 @@
 			}
 		},
 		"node_modules/@eslint/config-helpers": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-			"integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.4.tgz",
+			"integrity": "sha512-jJhqiY3wPMlWWO3370M86CPJ7pt8GmEwSLglMfQhjXal07RCvhmU0as4IuUEW5SJeunfItiEetHmSxCCe9lDBg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1"
+				"@eslint/core": "^1.2.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-			"integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.0.tgz",
+			"integrity": "sha512-8FTGbNzTvmSlc4cZBaShkC6YvFMG0riksYWRFKXztqVdXaQbcZLXlFbSpC05s70sGEsXAw0qwhx69JiW7hQS7A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
@@ -1346,21 +1336,21 @@
 			}
 		},
 		"node_modules/@eslint/object-schema": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-			"integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.4.tgz",
+			"integrity": "sha512-55lO/7+Yp0ISKRP0PsPtNTeNGapXaO085aELZmWCVc5SH3jfrqpuU6YgOdIxMS99ZHkQN1cXKE+cdIqwww9ptw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^20.19.0 || ^22.13.0 || >=24"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-			"integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.0.tgz",
+			"integrity": "sha512-ejvBr8MQCbVsWNZnCwDXjUKq40MDmHalq7cJ6e9s/qzTUFIIo/afzt1Vui9T97FM/V/pN4YsFVoed5NIa96RDg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@eslint/core": "^1.1.1",
+				"@eslint/core": "^1.2.0",
 				"levn": "^0.4.1"
 			},
 			"engines": {
@@ -2566,9 +2556,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-			"integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+			"version": "24.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+			"integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -4850,9 +4840,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "41.1.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.1.0.tgz",
-			"integrity": "sha512-0XRFyxRqetmqtkkBvV++wGbHYJ7bD++f6EgJW8y9kX4pPRagwlmKDtzqXZhKiu0DIQppm3sXxzHWK9GYP91OKQ==",
+			"version": "41.1.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-41.1.1.tgz",
+			"integrity": "sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -5145,17 +5135,17 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.1.0.tgz",
-			"integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
+			"integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
-				"@eslint/config-array": "^0.23.3",
-				"@eslint/config-helpers": "^0.5.3",
-				"@eslint/core": "^1.1.1",
-				"@eslint/plugin-kit": "^0.6.1",
+				"@eslint/config-array": "^0.23.4",
+				"@eslint/config-helpers": "^0.5.4",
+				"@eslint/core": "^1.2.0",
+				"@eslint/plugin-kit": "^0.7.0",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -5282,19 +5272,19 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "62.8.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.8.1.tgz",
-			"integrity": "sha512-e9358PdHgvcMF98foNd3L7hVCw70Lt+YcSL7JzlJebB8eT5oRJtW6bHMQKoAwJtw6q0q0w/fRIr2kwnHdFDI6A==",
+			"version": "62.9.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.9.0.tgz",
+			"integrity": "sha512-PY7/X4jrVgoIDncUmITlUqK546Ltmx/Pd4Hdsu4CvSjryQZJI2mEV4vrdMufyTetMiZ5taNSqvK//BTgVUlNkA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@es-joy/jsdoccomment": "~0.84.0",
+				"@es-joy/jsdoccomment": "~0.86.0",
 				"@es-joy/resolve.exports": "1.2.0",
 				"are-docs-informative": "^0.0.2",
-				"comment-parser": "1.4.5",
+				"comment-parser": "1.4.6",
 				"debug": "^4.4.3",
 				"escape-string-regexp": "^4.0.0",
-				"espree": "^11.1.0",
+				"espree": "^11.2.0",
 				"esquery": "^1.7.0",
 				"html-entities": "^2.6.0",
 				"object-deep-merge": "^2.0.0",
@@ -5308,16 +5298,6 @@
 			},
 			"peerDependencies": {
 				"eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-jsdoc/node_modules/comment-parser": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
-			"integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
@@ -6990,9 +6970,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.1.1.tgz",
-			"integrity": "sha512-/2uqY7x6bsrpi3i9LVU6J89352C0rpMk0as8trXxCtvd4kPk1ke/Eyif6wqfSLvoNJqcDG9Vk4UsXgygzCt2xA==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+			"integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7038,6 +7018,16 @@
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/jsdom/node_modules/undici": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+			"integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -7548,9 +7538,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.truncate": {
@@ -8706,16 +8696,16 @@
 			}
 		},
 		"node_modules/node-ical": {
-			"version": "0.25.6",
-			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.25.6.tgz",
-			"integrity": "sha512-Wo3GSBGYUNkcxOjHhevKTGa/+eB7ZwNLCq50h/eTX/YHSDZz1nT4KzXArO455CGHLD68gc5vw3nevqWQpOjjLQ==",
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.26.0.tgz",
+			"integrity": "sha512-tJZY2fMb38Gbj0P05zHMWBr90MslhGZ1qEbOWYnokBYPPX/lYskL/0NnWoeiXTBNod+kRRcTOjxAeB20kfvKyw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"rrule-temporal": "^1.4.7",
-				"temporal-polyfill": "^0.3.0"
+				"rrule-temporal": "^1.5.1",
+				"temporal-polyfill": "^0.3.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -9201,13 +9191,13 @@
 			"license": "MIT"
 		},
 		"node_modules/playwright": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.58.2"
+				"playwright-core": "1.59.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -9220,9 +9210,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -9984,9 +9974,9 @@
 			}
 		},
 		"node_modules/router/node_modules/path-to-regexp": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
-			"integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -9994,9 +9984,9 @@
 			}
 		},
 		"node_modules/rrule-temporal": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.5.1.tgz",
-			"integrity": "sha512-mV82lZ7OzMOXX5g+SCR8FWRMSvhTnPSznjQ2Vguezjz1nEPEv/Ap/Z/FsIZ/AxA15M9X99m05911/MCXFY+FsA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.5.2.tgz",
+			"integrity": "sha512-I5rAiZfRlMh0vuG23HrGBMLZOSiQO7H1Uq8l9qyfA6oTD5j+UMRwpRs4aVU4XdaFhgN1p3K+cHelG8KvLTTm+g==",
 			"license": "MIT",
 			"dependencies": {
 				"@js-temporal/polyfill": "^0.5.1"
@@ -11367,12 +11357,12 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-			"integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.0.2.tgz",
+			"integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=20.18.1"
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"ajv": "^8.18.0",
 		"animate.css": "^4.1.1",
 		"croner": "^10.0.1",
-		"eslint": "^10.1.0",
+		"eslint": "^10.2.0",
 		"express": "^5.2.1",
 		"feedme": "^2.0.2",
 		"globals": "^17.4.0",
@@ -103,13 +103,13 @@
 		"ipaddr.js": "^2.3.0",
 		"moment": "^2.30.1",
 		"moment-timezone": "^0.6.1",
-		"node-ical": "^0.25.6",
+		"node-ical": "^0.26.0",
 		"nunjucks": "^3.2.4",
 		"pm2": "^6.0.14",
 		"socket.io": "^4.8.3",
 		"suncalc": "^1.9.0",
 		"systeminformation": "^5.31.5",
-		"undici": "^7.24.6",
+		"undici": "^8.0.2",
 		"weathericons": "^2.1.0"
 	},
 	"devDependencies": {
@@ -120,7 +120,7 @@
 		"@vitest/ui": "^4.1.2",
 		"cspell": "^9.7.0",
 		"eslint-plugin-import-x": "^4.16.2",
-		"eslint-plugin-jsdoc": "^62.8.1",
+		"eslint-plugin-jsdoc": "^62.9.0",
 		"eslint-plugin-package-json": "^0.91.1",
 		"eslint-plugin-playwright": "^2.10.1",
 		"express-basic-auth": "^1.2.1",
@@ -129,7 +129,7 @@
 		"lint-staged": "^16.4.0",
 		"markdownlint-cli2": "^0.22.0",
 		"msw": "^2.12.14",
-		"playwright": "^1.58.2",
+		"playwright": "^1.59.1",
 		"prettier": "^3.8.1",
 		"prettier-plugin-jinja-template": "^2.1.0",
 		"stylelint": "^17.6.0",
@@ -138,7 +138,7 @@
 		"vitest": "^4.1.2"
 	},
 	"optionalDependencies": {
-		"electron": "^41.1.0"
+		"electron": "^41.1.1"
 	},
 	"engines": {
 		"node": ">=22.21.1 <23 || >=24"


### PR DESCRIPTION
`node-ical` has released a new version that fixes an issue reported by one of our users (https://github.com/jens-maus/node-ical/issues/495). I'd like to have that in the develop branch. Instead of just updating that, I think it would make sense to include the others as well.

`undici` had a major release but according to the release notes we are not affected.