### PR TITLE
fix: prevent crash when config is undefined in socket handler

### DIFF
--- a/js/node_helper.js
+++ b/js/node_helper.js
@@ -89,7 +89,7 @@ const NodeHelper = Class.extend({
 		io.of(this.name).on("connection", (socket) => {
 			// register catch all.
 			socket.onAny((notification, payload) => {
-				if (config.hideConfigSecrets && payload && typeof payload === "object") {
+				if (config?.hideConfigSecrets && payload && typeof payload === "object") {
 					try {
 						const payloadStr = replaceSecretPlaceholder(JSON.stringify(payload));
 						this.socketNotificationReceived(notification, JSON.parse(payloadStr));


### PR DESCRIPTION
If a module uses this.io.of() to register a custom socket.io namespace, connections on that namespace trigger the onAny handler in setSocketIO before config is set, causing a TypeError.

Fixes #4089