### PR TITLE
fix replaceSecretPlaceholder

### DIFF
--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -22,12 +22,12 @@ function getStartup (req, res) {
  * @returns {string} the input with real variable content
  */
 function replaceSecretPlaceholder (input) {
-	if (global.config.cors === "allowWhitelist") {
+	if (global.config.cors !== "allowAll") {
 		return input.replaceAll(/\*\*(SECRET_[^*]+)\*\*/g, (match, group) => {
 			return process.env[group];
 		});
 	} else {
-		Log.error("Replacing secrets works only with CORS and `allowWhitelist`, you need to set this in `config.js`, set `cors: allowWhitelist`");
+		Log.error("Replacing secrets doesn't work with CORS `allowAll`, you need to set `cors` to `disabled` or `allowWhitelist` in `config.js`");
 		return input;
 	}
 }

--- a/js/server_functions.js
+++ b/js/server_functions.js
@@ -27,7 +27,9 @@ function replaceSecretPlaceholder (input) {
 			return process.env[group];
 		});
 	} else {
-		Log.error("Replacing secrets doesn't work with CORS `allowAll`, you need to set `cors` to `disabled` or `allowWhitelist` in `config.js`");
+		if (input.includes("**SECRET_")) {
+			Log.error("Replacing secrets doesn't work with CORS `allowAll`, you need to set `cors` to `disabled` or `allowWhitelist` in `config.js`");
+		}
 		return input;
 	}
 }


### PR DESCRIPTION
Disable secret substitution only for cors=allowAll, the last attempt in #4102 was to restrictive.

Secret substitution should also work if cors=disabled.