### PR TITLE
config endpoint must handle functions in module configs

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -476,14 +476,15 @@ const MM = (function () {
 		try {
 			const res = await fetch(new URL("config/", `${location.origin}${config.basePath}`));
 
+			// The server tags functions as { __mmFunction: "<source>" } because
+			// JSON.stringify can't serialise live functions. This reviver turns
+			// those tagged objects back into callable functions.
 			config = JSON.parse(await res.text(), (key, value) => {
-				if (typeof value === "string") {
-					// checks for classic function OR arrow function
-					const isFunction = value.includes("function") || value.includes("=>");
-
-					if (isFunction) {
-					// eval() often needs brackets around
-						return eval(`(${value})`);
+				if (value && typeof value === "object" && typeof value.__mmFunction === "string") {
+					try {
+						return new Function(`return (${value.__mmFunction})`)();
+					} catch {
+						Log.warn(`Failed to revive function for config key "${key}".`);
 					}
 				}
 				return value;

--- a/js/main.js
+++ b/js/main.js
@@ -475,7 +475,19 @@ const MM = (function () {
 	const loadConfig = async function () {
 		try {
 			const res = await fetch(new URL("config/", `${location.origin}${config.basePath}`));
-			config = JSON.parse(await res.text());
+
+			config = JSON.parse(await res.text(), (key, value) => {
+				if (typeof value === "string") {
+					// checks for classic function OR arrow function
+					const isFunction = value.includes("function") || value.includes("=>");
+
+					if (isFunction) {
+					// eval() often needs brackets around
+						return eval(`(${value})`);
+					}
+				}
+				return value;
+			});
 		} catch (error) {
 			Log.error("Unable to retrieve config", error);
 		}

--- a/js/server.js
+++ b/js/server.js
@@ -111,15 +111,14 @@ function Server (configObj) {
 			const getStartup = (req, res) => res.send(startUp);
 
 			const getConfig = (req, res) => {
-				let obj;
-				if (config.hideConfigSecrets) {
-					obj = configObj.redactedConf;
-				} else {
-					obj = configObj.fullConf;
-				}
+				const obj = config.hideConfigSecrets ? configObj.redactedConf : configObj.fullConf;
+				// Functions can't survive JSON.stringify, so we wrap them in a
+				// tagged object { __mmFunction: "<source>" }. The client-side
+				// JSON reviver in main.js recognises this tag and reconstructs
+				// the live function from the source string.
 				const jsonString = JSON.stringify(obj, (key, value) => {
 					if (typeof value === "function") {
-						return value.toString();
+						return { __mmFunction: value.toString() };
 					}
 					return value;
 				});

--- a/js/server.js
+++ b/js/server.js
@@ -111,12 +111,22 @@ function Server (configObj) {
 			const getStartup = (req, res) => res.send(startUp);
 
 			const getConfig = (req, res) => {
+				let obj;
 				if (config.hideConfigSecrets) {
-					res.send(configObj.redactedConf);
+					obj = configObj.redactedConf;
 				} else {
-					res.send(configObj.fullConf);
+					obj = configObj.fullConf;
 				}
+				const jsonString = JSON.stringify(obj, (key, value) => {
+					if (typeof value === "function") {
+						return value.toString();
+					}
+					return value;
+				});
+				res.set("Content-Type", "application/json");
+				res.send(jsonString);
 			};
+
 			app.get("/config", (req, res) => getConfig(req, res));
 
 			app.get("/cors", async (req, res) => await cors(req, res));

--- a/tests/configs/config_functions.js
+++ b/tests/configs/config_functions.js
@@ -1,0 +1,33 @@
+/*eslint object-shorthand: ["error", "always", { "methodsIgnorePattern": "^roundToInt2$" }]*/
+
+let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+	modules: [
+		{
+			module: "clock",
+			position: "middle_center",
+			config: {
+				moduleFunctions: {
+					roundToInt1: (value) => {
+						try {
+							return Math.round(parseFloat(value));
+						} catch {
+							return value;
+						}
+					},
+					roundToInt2: function (value) {
+						try {
+							return Math.round(parseFloat(value));
+						} catch {
+							return value;
+						}
+					}
+				}
+			}
+		}
+	]
+});
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+	module.exports = config;
+}

--- a/tests/configs/config_functions.js
+++ b/tests/configs/config_functions.js
@@ -21,7 +21,9 @@ let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory(
 							return value;
 						}
 					}
-				}
+				},
+				stringWithArrow: "a => b is not a function",
+				stringWithFunction: "this function keyword is just text"
 			}
 		}
 	]

--- a/tests/e2e/config_functions_spec.js
+++ b/tests/e2e/config_functions_spec.js
@@ -13,4 +13,9 @@ describe("config with module function", () => {
 		expect(config.modules[0].config.moduleFunctions.roundToInt1(13.3)).toBe(13);
 		expect(config.modules[0].config.moduleFunctions.roundToInt2(13.3)).toBe(13);
 	});
+
+	it("config should not revive plain strings containing arrow or function keywords", () => {
+		expect(config.modules[0].config.stringWithArrow).toBe("a => b is not a function");
+		expect(config.modules[0].config.stringWithFunction).toBe("this function keyword is just text");
+	});
 });

--- a/tests/e2e/config_functions_spec.js
+++ b/tests/e2e/config_functions_spec.js
@@ -1,0 +1,16 @@
+const helpers = require("./helpers/global-setup");
+
+describe("config with module function", () => {
+	beforeAll(async () => {
+		await helpers.startApplication("tests/configs/config_functions.js");
+	});
+
+	afterAll(async () => {
+		await helpers.stopApplication();
+	});
+
+	it("config should resolve module functions", () => {
+		expect(config.modules[0].config.moduleFunctions.roundToInt1(13.3)).toBe(13);
+		expect(config.modules[0].config.moduleFunctions.roundToInt2(13.3)).toBe(13);
+	});
+});


### PR DESCRIPTION
Fixes #4105

```bash
In JavaScript, standard JSON does not support functions.
If you use JSON.stringify() on an object containing functions,
those functions will be omitted (if they are object properties)
or changed to null (if they are in an array).
```

