### PR TITLE
ci(actions): set explicit token permissions

### DIFF
--- a/.github/workflows/electron-rebuild.yaml
+++ b/.github/workflows/electron-rebuild.yaml
@@ -1,5 +1,8 @@
 name: "Electron Rebuild Testing"
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Add minimal GITHUB_TOKEN permissions to electron-rebuild workflow to enforce least privilege and satisfy CodeQL alert [#14](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/14).