### PR TITLE
Allow HTTPFetcher to pass through 304 responses

### DIFF
--- a/js/http_fetcher.js
+++ b/js/http_fetcher.js
@@ -273,7 +273,9 @@ class HTTPFetcher extends EventEmitter {
 				signal: controller.signal
 			});
 
-			if (!response.ok) {
+			const isSuccessfulResponse = response.ok || response.status === 304;
+
+			if (!isSuccessfulResponse) {
 				const { delay, errorInfo } = this.#getDelayForResponse(response);
 				nextDelay = delay;
 				this.emit("error", errorInfo);

--- a/tests/unit/functions/http_fetcher_spec.js
+++ b/tests/unit/functions/http_fetcher_spec.js
@@ -51,6 +51,31 @@ describe("HTTPFetcher", () => {
 			expect(text).toBe(responseData);
 		});
 
+		it("should treat 304 responses as successful and reset error counters", async () => {
+			server.use(
+				http.get(TEST_URL, () => {
+					return new HttpResponse(null, { status: 304 });
+				})
+			);
+
+			fetcher = new HTTPFetcher(TEST_URL, { reloadInterval: 60000 });
+			fetcher.serverErrorCount = 2;
+			fetcher.networkErrorCount = 3;
+
+			const responsePromise = new Promise((resolve) => {
+				fetcher.on("response", (response) => {
+					resolve(response);
+				});
+			});
+
+			fetcher.startPeriodicFetch();
+			const response = await responsePromise;
+
+			expect(response.status).toBe(304);
+			expect(fetcher.serverErrorCount).toBe(0);
+			expect(fetcher.networkErrorCount).toBe(0);
+		});
+
 		it("should emit error event on network failure", async () => {
 			server.use(
 				http.get(TEST_URL, () => {


### PR DESCRIPTION
## Summary

This updates `js/http_fetcher.js` so HTTP `304 Not Modified` responses are emitted through the normal `response` event instead of being treated as errors.

That aligns the core fetcher with the built-in `yr` weather provider in `v2.35.0`, which already includes explicit logic to handle `304` and reuse cached data.

Closes #4119.

## Root cause

`HTTPFetcher` currently treats all non-OK responses as errors. Since `304` is not an OK response, it never reaches providers listening on the `response` event.

At the same time, `defaultmodules/weather/providers/yr.js` expects to receive `304` and handle it by reusing cached data.

## What changed

- special-case HTTP `304` in `HTTPFetcher`
- emit `304` through the normal `response` event
- preserve the existing error path for other non-OK statuses

## Validation

- confirmed `defaultmodules/weather/providers/yr.js` already expects `response.status === 304`
- compared the unpatched `v2.35.0` `HTTPFetcher` behavior to the provider logic
- ran `node --check js/http_fetcher.js`
