### PR TITLE
Remove unnecessary conditionals and fix falsy property check in imperial conversion

### DIFF
--- a/defaultmodules/compliments/compliments.js
+++ b/defaultmodules/compliments/compliments.js
@@ -147,7 +147,7 @@ Module.register("compliments", {
 			timeOfDay = "evening";
 		}
 
-		if (timeOfDay && this.config.compliments.hasOwnProperty(timeOfDay)) {
+		if (this.config.compliments.hasOwnProperty(timeOfDay)) {
 			compliments = [...this.config.compliments[timeOfDay]];
 		}
 

--- a/defaultmodules/weather/weatherutils.js
+++ b/defaultmodules/weather/weatherutils.js
@@ -187,14 +187,12 @@ const WeatherUtils = {
 
 		let imperialWeatherObject = { ...weatherObject };
 
-		if (imperialWeatherObject) {
-			if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
-			if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
-			if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
-			if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, imperialWeatherObject.precipitationUnits);
-			if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
-			if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
-		}
+		if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
+		if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
+		if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
+		if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, imperialWeatherObject.precipitationUnits);
+		if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
+		if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
 
 		return imperialWeatherObject;
 	}

--- a/defaultmodules/weather/weatherutils.js
+++ b/defaultmodules/weather/weatherutils.js
@@ -187,12 +187,12 @@ const WeatherUtils = {
 
 		let imperialWeatherObject = { ...weatherObject };
 
-		if (imperialWeatherObject.feelsLikeTemp) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
-		if (imperialWeatherObject.maxTemperature) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
-		if (imperialWeatherObject.minTemperature) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
-		if (imperialWeatherObject.precipitationAmount) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, imperialWeatherObject.precipitationUnits);
-		if (imperialWeatherObject.temperature) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
-		if (imperialWeatherObject.windSpeed) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
+		if ("feelsLikeTemp" in imperialWeatherObject) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
+		if ("maxTemperature" in imperialWeatherObject) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");
+		if ("minTemperature" in imperialWeatherObject) imperialWeatherObject.minTemperature = this.convertTemp(imperialWeatherObject.minTemperature, "imperial");
+		if ("precipitationAmount" in imperialWeatherObject) imperialWeatherObject.precipitationAmount = this.convertPrecipitationToInch(imperialWeatherObject.precipitationAmount, imperialWeatherObject.precipitationUnits);
+		if ("temperature" in imperialWeatherObject) imperialWeatherObject.temperature = this.convertTemp(imperialWeatherObject.temperature, "imperial");
+		if ("windSpeed" in imperialWeatherObject) imperialWeatherObject.windSpeed = this.convertWind(imperialWeatherObject.windSpeed, "imperial");
 
 		return imperialWeatherObject;
 	}

--- a/tests/unit/modules/default/weather/weather_utils_spec.js
+++ b/tests/unit/modules/default/weather/weather_utils_spec.js
@@ -113,4 +113,51 @@ describe("Weather utils tests", () => {
 			}
 		});
 	});
+
+	describe("convertWeatherObjectToImperial", () => {
+		it("should return null for null or empty input", () => {
+			expect(WeatherUtils.convertWeatherObjectToImperial(null)).toBeNull();
+			expect(WeatherUtils.convertWeatherObjectToImperial({})).toBeNull();
+		});
+
+		it("should convert 0°C correctly to 32°F", () => {
+			const result = WeatherUtils.convertWeatherObjectToImperial({ temperature: 0 });
+			expect(result.temperature).toBe(32);
+		});
+
+		it("should convert all temperature fields", () => {
+			const result = WeatherUtils.convertWeatherObjectToImperial({
+				temperature: 0,
+				feelsLikeTemp: 0,
+				minTemperature: -10,
+				maxTemperature: 10
+			});
+			expect(result.temperature).toBe(32);
+			expect(result.feelsLikeTemp).toBe(32);
+			expect(result.minTemperature).toBe(14);
+			expect(result.maxTemperature).toBe(50);
+		});
+
+		it("should convert windSpeed correctly", () => {
+			const result = WeatherUtils.convertWeatherObjectToImperial({ windSpeed: 10 });
+			expect(result.windSpeed).toBeCloseTo(22.369, 2);
+		});
+
+		it("should convert precipitationAmount correctly", () => {
+			const result = WeatherUtils.convertWeatherObjectToImperial({ precipitationAmount: 25.4, precipitationUnits: "mm" });
+			expect(result.precipitationAmount).toBeCloseTo(1, 5);
+		});
+
+		it("should not modify properties that are not present", () => {
+			const result = WeatherUtils.convertWeatherObjectToImperial({ temperature: 20 });
+			expect("windSpeed" in result).toBe(false);
+			expect("feelsLikeTemp" in result).toBe(false);
+		});
+
+		it("should not mutate the original object", () => {
+			const input = { temperature: 20 };
+			WeatherUtils.convertWeatherObjectToImperial(input);
+			expect(input.temperature).toBe(20);
+		});
+	});
 });


### PR DESCRIPTION
While removing unnecessary conditionals (for `compliments` reported in https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/27 and for `weather` reported in https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/28), I noticed a bug in the imperial conversion path: falsy property checks like `if (imperialWeatherObject.temperature)` silently skip the conversion when the value is `0`. So at exactly 0 °C, the result would show `0 °F` instead of the correct `32 °F`.

I wrote unit tests for `convertWeatherObjectToImperial` first, which confirmed the bug, then fixed it by replacing the falsy checks with the `in` operator. Which I also find more intuitive to read.

Weather APIs deliver floating point values, so hitting exactly `0.0` might be rare in practice - more likely `0.1` or `-0.1`, which are truthy and convert fine. That should explain why it went unnoticed by users.
