### PR TITLE
fix(electron): resolve CodeQL alerts #22 and #25 in electron.js

### DIFF
--- a/js/electron.js
+++ b/js/electron.js
@@ -43,8 +43,10 @@ function createWindow () {
 		Log.warn("Could not get display size, using defaults ...");
 	}
 
-	let electronSwitchesDefaults = ["autoplay-policy", "no-user-gesture-required"];
-	app.commandLine.appendSwitch(...new Set(electronSwitchesDefaults, config.electronSwitches));
+	app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
+	for (const electronSwitch of (config.electronSwitches || [])) {
+		app.commandLine.appendSwitch(electronSwitch);
+	}
 	let electronOptionsDefaults = {
 		width: electronSize.width,
 		height: electronSize.height,

--- a/js/electron.js
+++ b/js/electron.js
@@ -36,7 +36,7 @@ function createWindow () {
 	 * see https://www.electronjs.org/docs/latest/api/screen
 	 * Create a window that fills the screen's available work area.
 	 */
-	let electronSize = (800, 600);
+	let electronSize = { width: 800, height: 600 };
 	try {
 		electronSize = electron.screen.getPrimaryDisplay().workAreaSize;
 	} catch {


### PR DESCRIPTION
I reviewed the CodeQL alerts for `js/electron.js`:

- [#25](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/25) https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/25
- [#22](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/22) https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/22

Both point to real bugs.

- [#25](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/25): The window size fallback was written as a comma expression (`(800, 600)`), so it did not produce the expected object structure `{ width, height }`. I am not surprised it went unnoticed because it sits in a fallback path.
- [#22](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/22): `...new Set(electronSwitchesDefaults, config.electronSwitches)` silently ignored the second parameter. As a result, custom `electronSwitches` were never applied. I am wondering: this has been broken since PR #2643 introduced it, so I'm quite sure it could not have worked as intended in that form. Why didn't anyone (not even @eouia) notice that? 🤔

## Changes

- Fix for [#25](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/25):
  - Corrects the fallback from `(800, 600)` to a valid size object `{ width: 800, height: 600 }`.
- Fix for [#22](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/22):
  - Sets the default switch explicitly as a correct key-value pair:
    - `app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required")`
  - Applies custom `config.electronSwitches` individually afterward.