### PR TITLE
fix(updatenotification): fix ref diff parsing for fetch --dry-run

### DIFF
--- a/defaultmodules/updatenotification/git_helper.js
+++ b/defaultmodules/updatenotification/git_helper.js
@@ -10,8 +10,26 @@ class GitHelper {
 		this.gitResultList = [];
 	}
 
-	getRefRegex (branch) {
-		return new RegExp(`s*([a-z,0-9]+[.][.][a-z,0-9]+)  ${branch}`, "g");
+	/**
+	 * Extract commit range (<from>..<to>) for the current branch from `git fetch -n --dry-run` output.
+	 * Falls back to `<branch>..origin/<branch>` when no matching update line is found.
+	 * @param {string} fetchOutput fetch dry-run stderr output
+	 * @param {string} currentBranch currently checked local branch
+	 * @returns {string} commit range for rev-list
+	 */
+	getRefDiffFromFetchDryRun (fetchOutput, currentBranch) {
+		const fallbackRefDiff = `${currentBranch}..origin/${currentBranch}`;
+
+		for (const line of fetchOutput.split("\n")) {
+			const columns = line.trim().split(/\s+/);
+			const [refDiff, branchName] = columns;
+
+			if (branchName === currentBranch && refDiff?.includes("..")) {
+				return refDiff;
+			}
+		}
+
+		return fallbackRefDiff;
 	}
 
 	async execGit (moduleFolder, ...args) {
@@ -123,20 +141,10 @@ class GitHelper {
 			return gitInfo;
 		}
 
+		// Git writes fetch dry-run updates to stderr.
 		const { stderr } = await this.execGit(repo.folder, "fetch", "-n", "--dry-run");
 
-		// example output:
-		// From https://github.com/MagicMirrorOrg/MagicMirror
-		//    e40ddd4..06389e3  develop    -> origin/develop
-		// here the result is in stderr (this is a git default, don't ask why ...)
-		const matches = stderr.match(this.getRefRegex(gitInfo.current));
-
-		// this is the default if there was no match from "git fetch -n --dry-run".
-		// Its a fallback because if there was a real "git fetch", the above "git fetch -n --dry-run" would deliver nothing.
-		let refDiff = `${gitInfo.current}..origin/${gitInfo.current}`;
-		if (matches && matches[0]) {
-			refDiff = matches[0];
-		}
+		const refDiff = this.getRefDiffFromFetchDryRun(stderr, gitInfo.current);
 
 		// get behind with refs
 		try {

--- a/tests/unit/functions/updatenotification_spec.js
+++ b/tests/unit/functions/updatenotification_spec.js
@@ -103,6 +103,26 @@ describe("Updatenotification", () => {
 		vi.resetAllMocks();
 	});
 
+	describe("getRefDiffFromFetchDryRun", () => {
+		it("extracts only commit range from matching fetch line", () => {
+			const fetchOutput = "From github.com:MagicMirrorOrg/MagicMirror\n60e0377..332e429  develop          -> origin/develop\n";
+
+			expect(gitHelper.getRefDiffFromFetchDryRun(fetchOutput, "develop")).toBe("60e0377..332e429");
+		});
+
+		it("matches branch name exactly", () => {
+			const fetchOutput = "From github.com:MagicMirrorOrg/MagicMirror\n1111111..2222222  main-feature     -> origin/main-feature\n3333333..4444444  main             -> origin/main\n";
+
+			expect(gitHelper.getRefDiffFromFetchDryRun(fetchOutput, "main")).toBe("3333333..4444444");
+		});
+
+		it("returns fallback range when matching line is missing", () => {
+			const fetchOutput = "From github.com:MagicMirrorOrg/MagicMirror\n";
+
+			expect(gitHelper.getRefDiffFromFetchDryRun(fetchOutput, "develop")).toBe("develop..origin/develop");
+		});
+	});
+
 	describe("MagicMirror on develop", () => {
 		const moduleName = "MagicMirror";
 
@@ -124,7 +144,7 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  develop",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				]
 			`);
 		});
@@ -174,9 +194,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -191,9 +211,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -230,9 +250,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -247,9 +267,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -286,9 +306,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -303,9 +323,9 @@ describe("Updatenotification", () => {
 				  "rev-parse HEAD",
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 60e0377..332e429  master",
+				  "rev-list --ancestry-path --count 60e0377..332e429",
 				  "ls-remote -q --tags --refs",
-				  "rev-list --ancestry-path 60e0377..332e429  master",
+				  "rev-list --ancestry-path 60e0377..332e429",
 				]
 			`);
 		});
@@ -339,7 +359,7 @@ describe("Updatenotification", () => {
 				[
 				  "status -sb",
 				  "fetch -n --dry-run",
-				  "rev-list --ancestry-path --count 19f7faf..9d83101  master",
+				  "rev-list --ancestry-path --count 19f7faf..9d83101",
 				]
 			`);
 		});


### PR DESCRIPTION
The regex captured the full fetch output line including the branch name. Before #4115, the command was built as a shell string, so the shell split the arguments correctly. After #4115 switched to `execFile`, the range and branch name were passed as a single argument (`60e0377..332e429  develop`) - which git rejects as ambiguous.

The fix replaces the regex with column-based line parsing: find the line for the current branch, take the first column. Falls back to `<branch>..origin/<branch>` when fetch reports no changes (same behavior as before).

Also adds unit tests for the new helper and corrects existing test snapshots that encoded the broken behavior.

Fixes #4137.