### PR TITLE
fix(systeminformation): output right 'used node' version (from parent process)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -24,8 +24,18 @@ global.version = require(`${global.root_path}/package.json`).version;
 global.mmTestMode = process.env.mmTestMode === "true";
 Log.log(`Starting MagicMirror: v${global.version}`);
 
-// Log system information.
-Spawn("node ./js/systeminformation.js", { env: { ...process.env, ELECTRON_VERSION: `${process.versions.electron}` }, cwd: this.root_path, shell: true, detached: true, stdio: "inherit" });
+// Log system information in a subprocess so it is shown even on early startup failures.
+Spawn("node ./js/systeminformation.js", {
+	env: {
+		...process.env,
+		ELECTRON_VERSION: `${process.versions.electron}`,
+		USED_NODE_VERSION: `${process.versions.node}`
+	},
+	cwd: this.root_path,
+	shell: true,
+	detached: true,
+	stdio: "inherit"
+});
 
 if (process.env.MM_CONFIG_FILE) {
 	global.configuration_file = process.env.MM_CONFIG_FILE.replace(`${global.root_path}/`, "");

--- a/js/systeminformation.js
+++ b/js/systeminformation.js
@@ -10,7 +10,6 @@ const logSystemInformation = async () => {
 		const osInfo = await si.osInfo();
 		const versions = await si.versions();
 
-		const usedNodeVersion = process.version.replace("v", "");
 		const installedNodeVersion = versions.node;
 		const totalRam = (os.totalmem() / 1024 / 1024).toFixed(2);
 		const freeRam = (os.freemem() / 1024 / 1024).toFixed(2);
@@ -20,7 +19,7 @@ const logSystemInformation = async () => {
 			"\n####  System Information  ####",
 			`- SYSTEM:   manufacturer: ${system.manufacturer}; model: ${system.model}; virtual: ${system.virtual}; MM: v${mmVersion}`,
 			`- OS:       platform: ${osInfo.platform}; distro: ${osInfo.distro}; release: ${osInfo.release}; arch: ${osInfo.arch}; kernel: ${versions.kernel}`,
-			`- VERSIONS: electron: ${process.env.ELECTRON_VERSION}; used node: ${usedNodeVersion}; installed node: ${installedNodeVersion}; npm: ${versions.npm}; pm2: ${versions.pm2}`,
+			`- VERSIONS: electron: ${process.env.ELECTRON_VERSION}; used node: ${process.env.USED_NODE_VERSION}; installed node: ${installedNodeVersion}; npm: ${versions.npm}; pm2: ${versions.pm2}`,
 			`- ENV:      XDG_SESSION_TYPE: ${process.env.XDG_SESSION_TYPE}; MM_CONFIG_FILE: ${process.env.MM_CONFIG_FILE}`,
 			`            WAYLAND_DISPLAY:  ${process.env.WAYLAND_DISPLAY}; DISPLAY: ${process.env.DISPLAY}; ELECTRON_ENABLE_GPU: ${process.env.ELECTRON_ENABLE_GPU}`,
 			`- RAM:      total: ${totalRam} MB; free: ${freeRam} MB; used: ${usedRam} MB`,


### PR DESCRIPTION
I noticed that in the System Information output, `used node` and `installed node` were always identical when starting via Electron. That usually shouldn't be the case. After digging into it, I found that since PR #4002, `used node` in the subprocess effectively reported the system Node version, not the parent process (which runs in Electron) version.

This PR fixes that by passing `used node` from the parent process and logging it correctly.

**Before:**

`VERSIONS: electron: 41.3.0; used node: 26.0.0; installed node: 26.0.0; ...`

**After:**

`VERSIONS: electron: 41.3.0; used node: 24.15.0; installed node: 26.0.0; ...`

