### PR TITLE
perf(calendar): use async ICS parsing to avoid blocking event loop

### DIFF
--- a/defaultmodules/calendar/calendarfetcher.js
+++ b/defaultmodules/calendar/calendarfetcher.js
@@ -52,7 +52,7 @@ class CalendarFetcher {
 	async #handleResponse (response) {
 		try {
 			const responseData = await response.text();
-			const parsed = ical.parseICS(responseData);
+			const parsed = await ical.async.parseICS(responseData);
 
 			Log.debug(`Parsed iCal data from ${this.url} with ${Object.keys(parsed).length} entries.`);
 


### PR DESCRIPTION
This switches the calendar fetcher from synchronous to asynchronous ICS parsing.

It does not necessarily make parsing faster overall, but it avoids long event-loop stalls with large calendar files (especially on slower devices and with multiple feeds).

So this does not fully solve #4103 on its own, but it clearly mitigates it.

It should also combine well with a future pre-filter approach discussed in the issue:
- with pre-filter = less data to parse (future PR)
- with async parsing = less blocking while parsing (this PR)

Together, that is likely the strongest path to fully address #4103.