### PR TITLE
update eletron to v42

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -64,9 +64,8 @@ jobs:
           npx playwright install --with-deps chromium
       - name: "Prepare environment for tests"
         run: |
-          # Fix chrome-sandbox permissions:
-          sudo chown root:root ./node_modules/electron/dist/chrome-sandbox
-          sudo chmod 4755 ./node_modules/electron/dist/chrome-sandbox
+          # Download electron binary
+          npx install-electron
           # Start labwc
           WLR_BACKENDS=headless WLR_LIBINPUT_NO_DEVICES=1 WLR_RENDERER=pixman labwc &
           touch config/custom.css

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"express-basic-auth": "^1.2.1",
 				"husky": "^9.1.7",
 				"jsdom": "^29.1.1",
-				"lint-staged": "^16.4.0",
+				"lint-staged": "^17.0.2",
 				"markdownlint-cli2": "^0.22.1",
 				"msw": "^2.14.3",
 				"playwright": "^1.59.1",
@@ -61,7 +61,7 @@
 				"node": ">=22.21.1 <23 || >=24"
 			},
 			"optionalDependencies": {
-				"electron": "^41.5.0"
+				"electron": "^42.0.0"
 			}
 		},
 		"node_modules/@altano/repository-tools": {
@@ -1118,45 +1118,47 @@
 			}
 		},
 		"node_modules/@electron/get": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-			"integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+			"integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"debug": "^4.1.1",
-				"env-paths": "^2.2.0",
-				"fs-extra": "^8.1.0",
-				"got": "^11.8.5",
+				"env-paths": "^3.0.0",
+				"graceful-fs": "^4.2.11",
 				"progress": "^2.0.3",
-				"semver": "^6.2.0",
+				"semver": "^7.6.3",
 				"sumchecker": "^3.0.1"
 			},
 			"engines": {
-				"node": ">=12"
+				"node": ">=22.12.0"
 			},
 			"optionalDependencies": {
-				"global-agent": "^3.0.0"
+				"undici": "^7.24.4"
 			}
 		},
 		"node_modules/@electron/get/node_modules/env-paths": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+			"integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
-				"node": ">=6"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@electron/get/node_modules/semver": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"license": "ISC",
+		"node_modules/@electron/get/node_modules/undici": {
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"license": "MIT",
 			"optional": true,
-			"bin": {
-				"semver": "bin/semver.js"
+			"engines": {
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -2035,19 +2037,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
 		"node_modules/@sindresorhus/merge-streams": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -2095,19 +2084,6 @@
 				"eslint": "^9.0.0 || ^10.0.0"
 			}
 		},
-		"node_modules/@szmarczak/http-timer": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"defer-to-connect": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.10.2",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -2117,19 +2093,6 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@types/cacheable-request": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/http-cache-semantics": "*",
-				"@types/keyv": "^3.1.4",
-				"@types/node": "*",
-				"@types/responselike": "^1.0.0"
 			}
 		},
 		"node_modules/@types/chai": {
@@ -2181,13 +2144,6 @@
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
-		"node_modules/@types/http-cache-semantics": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2200,16 +2156,6 @@
 			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/@types/keyv": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
-			}
 		},
 		"node_modules/@types/ms": {
 			"version": "2.1.0",
@@ -2225,16 +2171,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
-			}
-		},
-		"node_modules/@types/responselike": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/set-cookie-parser": {
@@ -3156,14 +3092,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/boolean": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-			"integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/brace-expansion": {
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -3220,35 +3148,6 @@
 				"hookified": "^1.15.0",
 				"keyv": "^5.6.0",
 				"qified": "^0.9.0"
-			}
-		},
-		"node_modules/cacheable-lookup": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10.6.0"
-			}
-		},
-		"node_modules/cacheable-request": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^4.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^6.0.1",
-				"responselike": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
@@ -3530,19 +3429,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/clone-response": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"mimic-response": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3567,13 +3453,6 @@
 			"version": "2.9.3",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
 			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/colorette": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4045,35 +3924,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decompress-response/node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4087,52 +3937,6 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=16.0.0"
-			}
-		},
-		"node_modules/defer-to-connect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/define-data-property": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/depd": {
@@ -4189,13 +3993,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/detect-node": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-			"integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/devlop": {
 			"version": "1.1.0",
@@ -4287,22 +4084,22 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "41.5.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-41.5.0.tgz",
-			"integrity": "sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==",
-			"hasInstallScript": true,
+			"version": "42.0.0",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-42.0.0.tgz",
+			"integrity": "sha512-in5jnW/Ywy3Rh3FPr4MR80exPEkywKYAmDJRZ/gIKlr8VXEi3zXgiAZbf0Si7KRccHTF2y8euVMRz7M6HqTjMA==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@electron/get": "^2.0.0",
+				"@electron/get": "^5.0.0",
 				"@types/node": "^24.9.0",
 				"extract-zip": "^2.0.1"
 			},
 			"bin": {
-				"electron": "cli.js"
+				"electron": "cli.js",
+				"install-electron": "install.js"
 			},
 			"engines": {
-				"node": ">= 12.20.55"
+				"node": ">= 22.12.0"
 			}
 		},
 		"node_modules/emoji-regex": {
@@ -4491,13 +4288,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/es6-error": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"license": "MIT",
-			"optional": true
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -5308,21 +5098,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/fs-extra": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6 <7 || >=8"
-			}
-		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -5468,24 +5243,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/global-agent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-			"integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"es6-error": "^4.1.1",
-				"matcher": "^3.0.0",
-				"roarr": "^2.15.3",
-				"semver": "^7.3.2",
-				"serialize-error": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=10.0"
-			}
-		},
 		"node_modules/global-directory": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/global-directory/-/global-directory-5.0.0.tgz",
@@ -5562,23 +5319,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/globalthis": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"define-properties": "^1.2.1",
-				"gopd": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/globby": {
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
@@ -5629,32 +5369,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/got": {
-			"version": "11.8.6",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@sindresorhus/is": "^4.0.0",
-				"@szmarczak/http-timer": "^4.0.5",
-				"@types/cacheable-request": "^6.0.1",
-				"@types/responselike": "^1.0.0",
-				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.2",
-				"decompress-response": "^6.0.0",
-				"http2-wrapper": "^1.0.0-beta.5.2",
-				"lowercase-keys": "^2.0.0",
-				"p-cancelable": "^2.0.0",
-				"responselike": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
-			}
-		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5663,9 +5377,9 @@
 			"optional": true
 		},
 		"node_modules/graphql": {
-			"version": "16.13.2",
-			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
-			"integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+			"version": "16.14.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+			"integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5680,19 +5394,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/has-property-descriptors": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -5872,13 +5573,6 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
-		"node_modules/http-cache-semantics": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-			"license": "BSD-2-Clause",
-			"optional": true
-		},
 		"node_modules/http-errors": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -5897,20 +5591,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/http2-wrapper": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/husky": {
@@ -6341,13 +6021,6 @@
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"license": "MIT"
 		},
-		"node_modules/json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-			"license": "ISC",
-			"optional": true
-		},
 		"node_modules/jsonc-eslint-parser": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-3.1.0.tgz",
@@ -6387,16 +6060,6 @@
 			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/jsonfile": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-			"integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-			"license": "MIT",
-			"optional": true,
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
 		},
 		"node_modules/jsonpointer": {
 			"version": "5.0.1",
@@ -6767,45 +6430,45 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "16.4.0",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
-			"integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.2.tgz",
+			"integrity": "sha512-Rbr6rdmbCn1fIDHBZpn0madg0hEkdlh+QwajnL3Qq0ZUq/icAJfLGj9BVBajAXi7657ZzKQ7kobGP9S5XOHYRw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"commander": "^14.0.3",
-				"listr2": "^9.0.5",
-				"picomatch": "^4.0.3",
+				"listr2": "^10.2.1",
+				"picomatch": "^4.0.4",
 				"string-argv": "^0.3.2",
-				"tinyexec": "^1.0.4",
-				"yaml": "^2.8.2"
+				"tinyexec": "^1.1.2"
 			},
 			"bin": {
 				"lint-staged": "bin/lint-staged.js"
 			},
 			"engines": {
-				"node": ">=20.17"
+				"node": ">=22.22.1"
 			},
 			"funding": {
 				"url": "https://opencollective.com/lint-staged"
+			},
+			"optionalDependencies": {
+				"yaml": "^2.8.4"
 			}
 		},
 		"node_modules/listr2": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
-			"integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+			"version": "10.2.1",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.1.tgz",
+			"integrity": "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cli-truncate": "^5.0.0",
-				"colorette": "^2.0.20",
-				"eventemitter3": "^5.0.1",
+				"cli-truncate": "^5.2.0",
+				"eventemitter3": "^5.0.4",
 				"log-update": "^6.1.0",
 				"rfdc": "^1.4.1",
-				"wrap-ansi": "^9.0.0"
+				"wrap-ansi": "^10.0.0"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.13.0"
 			}
 		},
 		"node_modules/locate-path": {
@@ -6850,6 +6513,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/log-update/node_modules/emoji-regex": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/log-update/node_modules/slice-ansi": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
@@ -6867,14 +6537,40 @@
 				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
 			}
 		},
-		"node_modules/lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+		"node_modules/log-update/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
 			"license": "MIT",
-			"optional": true,
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/wrap-ansi": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -7022,19 +6718,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/matcher": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-			"integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"escape-string-regexp": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -7716,16 +7399,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "10.2.5",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -7920,19 +7593,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/normalize-url": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/npm-package-arg": {
 			"version": "13.0.2",
 			"resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
@@ -8011,16 +7671,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -8092,16 +7742,6 @@
 			"integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
@@ -8619,19 +8259,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8689,13 +8316,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/resolve-alpn": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8714,19 +8334,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-			}
-		},
-		"node_modules/responselike": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"lowercase-keys": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/restore-cursor": {
@@ -8770,24 +8377,6 @@
 			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/roarr": {
-			"version": "2.15.4",
-			"resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-			"integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-			"license": "BSD-3-Clause",
-			"optional": true,
-			"dependencies": {
-				"boolean": "^3.0.1",
-				"detect-node": "^2.0.4",
-				"globalthis": "^1.0.1",
-				"json-stringify-safe": "^5.0.1",
-				"semver-compare": "^1.0.0",
-				"sprintf-js": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
 		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-rc.17",
@@ -8942,13 +8531,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/semver-compare": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/send": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -8973,35 +8555,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/serialize-error": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-			"integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"type-fest": "^0.13.1"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/serialize-error/node_modules/type-fest": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-			"integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-			"license": "(MIT OR CC0-1.0)",
-			"optional": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/serve-static": {
@@ -9376,13 +8929,6 @@
 			"integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
 			"dev": true,
 			"license": "CC0-1.0"
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-			"license": "BSD-3-Clause",
-			"optional": true
 		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
@@ -10118,16 +9664,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/universalify": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">= 4.0.0"
-			}
-		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -10532,46 +10068,21 @@
 			}
 		},
 		"node_modules/wrap-ansi": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+			"integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
+				"ansi-styles": "^6.2.3",
+				"string-width": "^8.2.0",
+				"strip-ansi": "^7.1.2"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi/node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"express-basic-auth": "^1.2.1",
 		"husky": "^9.1.7",
 		"jsdom": "^29.1.1",
-		"lint-staged": "^16.4.0",
+		"lint-staged": "^17.0.2",
 		"markdownlint-cli2": "^0.22.1",
 		"msw": "^2.14.3",
 		"playwright": "^1.59.1",
@@ -135,7 +135,7 @@
 		"vitest": "^4.1.5"
 	},
 	"optionalDependencies": {
-		"electron": "^41.5.0"
+		"electron": "^42.0.0"
 	},
 	"engines": {
 		"node": ">=22.21.1 <23 || >=24"


### PR DESCRIPTION
additional things:
- removed fix chrome-sandbox permissions (runs without)
- added `npx install-electron` which downloads the electron binaries

new in v42: 

> Electron now downloads its binary into node_modules dynamically on first launch instead of running a postinstall script. Added the install-electron script to manually trigger the download as well. https://github.com/electron/electron/pull/49328