### PR TITLE
remove warning in unit tests (for nodejs >= v25)

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.x]
+        node-version: [22.x, 24.x, 26.0.0]
     steps:
       - name: Install electron dependencies and labwc
         run: |

--- a/tests/utils/vitest-setup.js
+++ b/tests/utils/vitest-setup.js
@@ -9,6 +9,10 @@ const path = require("node:path");
 // Set test mode flag for application code to detect test environment
 process.env.mmTestMode = "true";
 
+// overrides native implementation (Nodejs >= v25) to avoid warnings in tests
+// "ExperimentalWarning: localStorage is not available because --localstorage-file was not provided."
+Object.defineProperty(globalThis, "localStorage", { value: undefined, writable: true });
+
 // Store the original require
 const originalRequire = Module.prototype.require;
 


### PR DESCRIPTION
The unit tests were full of warnings `ExperimentalWarning: localStorage is not available because --localstorage-file was not provided.` for node versions >=25.

Additionally this PR nails node to `v26.0.0` in the automated-tests workflow until the [playwright issue](https://github.com/microsoft/playwright/issues/40724) is fixed. Will revert this after fixed playwright version is available.