### PR TITLE
CodeQL cleanup for alerts #18, #19, #20

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -1,6 +1,5 @@
 /* global defaultModules, vendor */
 
-// eslint-disable-next-line no-unused-vars
 const Loader = (function () {
 
 	/* Create helper variables */
@@ -295,3 +294,5 @@ const Loader = (function () {
 		}
 	};
 }());
+
+globalThis.Loader = Loader;

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -1,6 +1,5 @@
 /* global io */
 
-// eslint-disable-next-line no-unused-vars
 const MMSocket = function (moduleName) {
 	if (typeof moduleName !== "string") {
 		throw new Error("Please set the module name for the MMSocket.");
@@ -45,3 +44,5 @@ const MMSocket = function (moduleName) {
 		this.socket.emit(notification, payload);
 	};
 };
+
+globalThis.MMSocket = MMSocket;

--- a/tests/e2e/port_spec.js
+++ b/tests/e2e/port_spec.js
@@ -24,6 +24,7 @@ describe("port directive configuration", () => {
 
 		afterAll(async () => {
 			await helpers.stopApplication();
+			delete process.env.MM_PORT;
 		});
 
 		it("should return 200", async () => {

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -22,20 +22,6 @@ describe("Calendar module", () => {
 		return await loc.count();
 	};
 
-	/**
-	 * Use this for debugging broken tests, it will console log the text of the calendar module
-	 * @returns {Promise<void>}
-	 */
-	// eslint-disable-next-line no-unused-vars
-	const logAllText = async () => {
-		expect(global.page).not.toBeNull();
-		const loc = await global.page.locator(".calendar .event");
-		const elem = loc.first();
-		await elem.waitFor();
-		expect(elem).not.toBeNull();
-		console.log(await loc.allInnerTexts());
-	};
-
 	const first = 0;
 	const second = 1;
 	const third = 2;


### PR DESCRIPTION
Small cleanup PR to close three CodeQL alerts, without changing app behavior.

- [#18](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/18) in `js/loader.js`
- [#19](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/19) in `js/socketclient.js`
- [#20](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning/20) in `tests/electron/modules/calendar_spec.js`

For `Loader` and `MMSocket`, make the global export explicit via `globalThis` (instead of suppressing `no-unused-vars`).
For calendar tests, remove the unused debug helper `logAllText`.
Also includes a tiny e2e cleanup: `MM_PORT` is cleared in `afterAll`.

Outcome: Three open CodeQL alerts are addressed with small, low-risk changes. The global intent for `Loader` and `MMSocket` is explicit, dead test helper code is removed, and e2e test state is cleaned up more reliably between runs.

With this, all current [code scanning issues](https://github.com/MagicMirrorOrg/MagicMirror/security/code-scanning) should be resolved in the develop branch :balloon: 
