### PR TITLE
fix systeminformation thread not ending

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -328,6 +328,20 @@ function App () {
 		await this.stop();
 		process.exit(0);
 	});
+
+	/**
+	 *
+	 * @param {number} ms milliseconds to wait
+	 */
+	function blockingSleep (ms) {
+		const int32 = new Int32Array(new SharedArrayBuffer(4));
+		Atomics.wait(int32, 0, 0, ms);
+	}
+
+	process.on("exit", () => {
+		// wait before exiting so that child processes (e.g. systeminformation) have some additional time
+		blockingSleep(1000);
+	});
 }
 
 module.exports = new App();


### PR DESCRIPTION
This was introduced when running systeminformation in an own thread.

If the main thread ends before (e.g. when config has errors) the systeminformation thread never ends.

As this can have side effects under pm2 or docker (because the app never exits) this PR restores the old behavior.