### PR TITLE
refactor(core): remove old Object.assign polyfill

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -735,28 +735,4 @@ const MM = (function () {
 	};
 }());
 
-// Add polyfill for Object.assign.
-if (typeof Object.assign !== "function") {
-	(function () {
-		Object.assign = function (target) {
-			"use strict";
-			if (target === undefined || target === null) {
-				throw new TypeError("Cannot convert undefined or null to object");
-			}
-			const output = Object(target);
-			for (let index = 1; index < arguments.length; index++) {
-				const source = arguments[index];
-				if (source !== undefined && source !== null) {
-					for (const nextKey in source) {
-						if (source.hasOwnProperty(nextKey)) {
-							output[nextKey] = source[nextKey];
-						}
-					}
-				}
-			}
-			return output;
-		};
-	}());
-}
-
 MM.init();


### PR DESCRIPTION
Object.assign has been standard since ES2015, and all runtimes we support already provide it.

Removing this keeps the client code a little cleaner.