### PR TITLE
fix(updatenotification): use process.argv[0] as restart binary

### DIFF
--- a/defaultmodules/updatenotification/update_helper.js
+++ b/defaultmodules/updatenotification/update_helper.js
@@ -136,10 +136,12 @@ class Updater {
 		const out = process.stdout;
 		const err = process.stderr;
 
-		// Get the current process command line
-		const currentCommand = process.argv.slice(1).join(" ");
-		const subprocess = Spawn(`node ${currentCommand}`, { cwd: this.root_path, shell: true, detached: true, stdio: ["ignore", out, err] });
-		subprocess.unref(); // detach the newly launched process from the master process
+		// Restart with the same binary and arguments as the current process
+		const binary = process.argv[0];
+		const args = process.argv.slice(1);
+		const options = { cwd: this.root_path, detached: true, stdio: ["ignore", out, err] };
+		const subprocess = Spawn(binary, args, options);
+		subprocess.unref(); // allow the current process to exit without waiting for the subprocess
 		process.exit();
 	}
 


### PR DESCRIPTION
The restart approach I introduced in #4156 still crashes under Electron:

```
TypeError: Cannot read properties of undefined (reading 'disableHardwareAcceleration')
    at electron.js:18
```

`nodeRestart()` hardcodes `node` as the interpreter, but under Electron `process.argv[0]` is the Electron binary. Spawning `node js/electron.js` causes `require("electron")` to return a string instead of the API, so `electron.app` is `undefined`.

This uses `process.argv[0]` as the binary directly, which works for both Electron and plain Node.

I introduced more variables for more clarity.

Fixes #4154.
