### PR TITLE
feat(systeminfo): include Git hash and branch in system information log

### DIFF
--- a/.github/workflows/automated-tests.yaml
+++ b/.github/workflows/automated-tests.yaml
@@ -39,7 +39,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        node-version: [22.x, 24.x, 26.0.0]
+        node-version: [22.x, 24.15.0, 26.0.0]
     steps:
       - name: Install electron dependencies and labwc
         run: |

--- a/js/systeminformation.js
+++ b/js/systeminformation.js
@@ -1,8 +1,18 @@
 const os = require("node:os");
+const { execFileSync } = require("node:child_process");
 const si = require("systeminformation");
 // needed with relative path because logSystemInformation is called in an own process in app.js:
 const mmVersion = require("../package").version;
 const Log = require("./logger");
+
+let mmGitHash = "";
+let mmGitBranch = "";
+try {
+	mmGitHash = execFileSync("git", ["rev-parse", "--short", "HEAD"], { encoding: "utf8" }).trim();
+	mmGitBranch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" }).trim();
+} catch {
+	// not a git repo or git not available
+}
 
 const logSystemInformation = async () => {
 	try {
@@ -17,7 +27,8 @@ const logSystemInformation = async () => {
 
 		let systemDataString = [
 			"\n####  System Information  ####",
-			`- SYSTEM:   manufacturer: ${system.manufacturer}; model: ${system.model}; virtual: ${system.virtual}; MM: v${mmVersion}`,
+			`- MM:       version: v${mmVersion}${mmGitHash ? `; git: ${mmGitHash}` : ""}${mmGitBranch ? `; branch: ${mmGitBranch}` : ""}`,
+			`- SYSTEM:   manufacturer: ${system.manufacturer}; model: ${system.model}; virtual: ${system.virtual}`,
 			`- OS:       platform: ${osInfo.platform}; distro: ${osInfo.distro}; release: ${osInfo.release}; arch: ${osInfo.arch}; kernel: ${versions.kernel}`,
 			`- VERSIONS: electron: ${process.env.ELECTRON_VERSION}; used node: ${process.env.USED_NODE_VERSION}; installed node: ${installedNodeVersion}; npm: ${versions.npm}; pm2: ${versions.pm2}`,
 			`- ENV:      XDG_SESSION_TYPE: ${process.env.XDG_SESSION_TYPE}; MM_CONFIG_FILE: ${process.env.MM_CONFIG_FILE}`,


### PR DESCRIPTION
I suggest to add the commit hash and branch to the system information. This should help trouble shooting issues from developers. Like in #4165.

### before

```
####  System Information  ####
- SYSTEM:   manufacturer: Micro-Star International Co., Ltd.; model: MS-7D75; virtual: false; MM: v2.37.0-develop
- OS:       ...
...
```

### after

```
####  System Information  ####
- MM:       version: v2.37.0-develop; git: 03e4eef3d; branch: develop
- SYSTEM:   manufacturer: Micro-Star International Co., Ltd.; model: MS-7D75; virtual: false
- OS:       ...
...
```