### PR TITLE
fix(electron): map IPv6 :: wildcard to localhost

### DIFF
--- a/js/electron.js
+++ b/js/electron.js
@@ -100,7 +100,7 @@ function createWindow () {
 		prefix = "http://";
 	}
 
-	let address = (config.address === void 0) | (config.address === "") | (config.address === "0.0.0.0") ? (config.address = "localhost") : config.address;
+	let address = (config.address === void 0) | (config.address === "") | (config.address === "0.0.0.0") | (config.address === "::") ? (config.address = "localhost") : config.address;
 	const port = process.env.MM_PORT || config.port;
 	mainWindow.loadURL(`${prefix}${address}:${port}`);
 


### PR DESCRIPTION
## Problem

When `config.address` is set to `"::"` (listen on all interfaces), the Electron window tries to load `http://:::8080` instead of `http://localhost:8080`, resulting in a blank local display.

## Root cause

`electron.js` remaps wildcard bind addresses to `"localhost"` for the Electron `loadURL` call so the local display always connects to the server on the loopback interface. This remap already handled `undefined`, `""`, and `"0.0.0.0"`, but `"::"` was missing.

Note: `core.start()` is not affected — at the time that check runs, `config` is initialised from `process.env.config` (empty `{}` in normal operation), so `config.address` is always `undefined` and the server always starts correctly.

## Fix

One line: add `(config.address === "::")` to the existing wildcard remap in `createWindow()`.