### PR TITLE
chore: update dependencies and adjust import path for SunCalc

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -195,7 +195,6 @@ function loadFile (fileName) {
 
 	switch (extension.toLowerCase()) {
 		case "js":
-		case "cjs":
 			return new Promise((resolve) => {
 				Log.log(`Load script: ${fileName}`);
 				script = document.createElement("script");
@@ -206,6 +205,22 @@ function loadFile (fileName) {
 				};
 				script.onerror = function () {
 					Log.error("Error on loading script:", fileName);
+					script.remove();
+					resolve();
+				};
+				document.getElementsByTagName("body")[0].appendChild(script);
+			});
+		case "mjs":
+			return new Promise((resolve) => {
+				Log.log(`Load module script: ${fileName}`);
+				script = document.createElement("script");
+				script.type = "module";
+				script.src = fileName;
+				script.onload = function () {
+					resolve();
+				};
+				script.onerror = function () {
+					Log.error("Error on loading module script:", fileName);
 					script.remove();
 					resolve();
 				};

--- a/js/loader.js
+++ b/js/loader.js
@@ -195,6 +195,7 @@ function loadFile (fileName) {
 
 	switch (extension.toLowerCase()) {
 		case "js":
+		case "cjs":
 			return new Promise((resolve) => {
 				Log.log(`Load script: ${fileName}`);
 				script = document.createElement("script");

--- a/js/server.js
+++ b/js/server.js
@@ -104,6 +104,13 @@ function Server (configObj) {
 				if (dirArr[0] === "node_modules") directories.push(`/${dirArr[0]}/${dirArr[1]}`);
 			}
 			const uniqDirs = [...new Set(directories)];
+
+			// suncalc v2 ships suncalc.cjs (UMD); serve it explicitly as JavaScript
+			// because express.static maps .cjs to application/node which browsers reject.
+			app.get("/node_modules/suncalc/suncalc.cjs", (req, res) => {
+				res.type("text/javascript").sendFile(path.resolve(global.root_path, "node_modules/suncalc/suncalc.cjs"));
+			});
+
 			for (const directory of uniqDirs) {
 				app.use(directory, express.static(path.resolve(global.root_path + directory)));
 			}

--- a/js/server.js
+++ b/js/server.js
@@ -98,18 +98,12 @@ function Server (configObj) {
 				});
 			}
 
-			let directories = ["/config", "/css", "/favicon.svg", "/defaultmodules", "/modules", "/node_modules/animate.css", "/node_modules/@fontsource", "/node_modules/@fortawesome", "/translations", "/tests/configs", "/tests/mocks"];
+			let directories = ["/config", "/css", "/favicon.svg", "/defaultmodules", "/modules", "/node_modules/animate.css", "/node_modules/@fontsource", "/node_modules/@fortawesome", "/node_modules/suncalc", "/translations", "/tests/configs", "/tests/mocks"];
 			for (const value of Object.values(vendor)) {
 				const dirArr = value.split("/");
 				if (dirArr[0] === "node_modules") directories.push(`/${dirArr[0]}/${dirArr[1]}`);
 			}
 			const uniqDirs = [...new Set(directories)];
-
-			// suncalc v2 ships suncalc.cjs (UMD); serve it explicitly as JavaScript
-			// because express.static maps .cjs to application/node which browsers reject.
-			app.get("/node_modules/suncalc/suncalc.cjs", (req, res) => {
-				res.type("text/javascript").sendFile(path.resolve(global.root_path, "node_modules/suncalc/suncalc.cjs"));
-			});
 
 			for (const directory of uniqDirs) {
 				app.use(directory, express.static(path.resolve(global.root_path + directory)));

--- a/js/suncalc-global.mjs
+++ b/js/suncalc-global.mjs
@@ -1,0 +1,8 @@
+/*
+ * Bridge for SunCalc v2 (ESM-only entry):
+ * default modules still expect a global `SunCalc` from getScripts()/vendor loading.
+ * Keep this as a tiny compatibility shim until the module loader is fully ESM-first.
+ */
+import * as SunCalc from "../node_modules/suncalc/index.js";
+
+globalThis.SunCalc = SunCalc;

--- a/js/vendor.js
+++ b/js/vendor.js
@@ -5,7 +5,7 @@ const vendor = {
 	"weather-icons-wind.css": "node_modules/weathericons/css/weather-icons-wind.css",
 	"font-awesome.css": "css/font-awesome.css",
 	"nunjucks.js": "node_modules/nunjucks/browser/nunjucks.min.js",
-	"suncalc.js": "node_modules/suncalc/suncalc.js",
+	"suncalc.js": "node_modules/suncalc/suncalc.cjs",
 	"croner.js": "node_modules/croner/dist/croner.umd.js"
 };
 

--- a/js/vendor.js
+++ b/js/vendor.js
@@ -5,7 +5,7 @@ const vendor = {
 	"weather-icons-wind.css": "node_modules/weathericons/css/weather-icons-wind.css",
 	"font-awesome.css": "css/font-awesome.css",
 	"nunjucks.js": "node_modules/nunjucks/browser/nunjucks.min.js",
-	"suncalc.js": "node_modules/suncalc/suncalc.cjs",
+	"suncalc.js": "js/suncalc-global.mjs",
 	"croner.js": "node_modules/croner/dist/croner.umd.js"
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,14 @@
 				"@fortawesome/fontawesome-free": "^7.2.0",
 				"animate.css": "^4.1.1",
 				"croner": "^10.0.1",
-				"eslint": "^10.4.1",
+				"eslint": "^10.5.0",
 				"express": "^5.2.1",
 				"feedme": "^2.0.2",
 				"globals": "^17.6.0",
 				"helmet": "^8.2.0",
 				"html-to-text": "^10.0.0",
 				"iconv-lite": "^0.7.2",
-				"ics-filter": "^1.0.2",
+				"ics-filter": "^1.0.3",
 				"ipaddr.js": "^2.4.0",
 				"moment": "^2.30.1",
 				"moment-timezone": "^0.6.2",
@@ -30,7 +30,7 @@
 				"socket.io": "^4.8.3",
 				"suncalc": "^2.0.0",
 				"systeminformation": "^5.31.7",
-				"undici": "^8.4.1",
+				"undici": "^8.5.0",
 				"weathericons": "^2.1.0"
 			},
 			"devDependencies": {
@@ -38,29 +38,29 @@
 				"@eslint/js": "^10.0.1",
 				"@eslint/markdown": "^8.0.2",
 				"@stylistic/eslint-plugin": "^5.10.0",
-				"@vitest/coverage-v8": "^4.1.8",
-				"@vitest/eslint-plugin": "^1.6.19",
-				"@vitest/ui": "^4.1.8",
+				"@vitest/coverage-v8": "^4.1.9",
+				"@vitest/eslint-plugin": "^1.6.20",
+				"@vitest/ui": "^4.1.9",
 				"cspell": "^10.0.1",
 				"eslint-plugin-import-x": "^4.16.2",
-				"eslint-plugin-jsdoc": "^63.0.2",
-				"eslint-plugin-package-json": "^1.3.0",
+				"eslint-plugin-jsdoc": "^63.0.6",
+				"eslint-plugin-package-json": "^1.4.0",
 				"eslint-plugin-playwright": "^2.10.4",
 				"express-basic-auth": "^1.2.1",
 				"husky": "^9.1.7",
 				"jsdom": "^29.1.1",
-				"lint-staged": "^17.0.7",
+				"lint-staged": "^17.0.8",
 				"msw": "^2.14.6",
-				"playwright": "^1.60.0",
+				"playwright": "^1.61.0",
 				"prettier": "^3.8.4",
 				"prettier-plugin-jinja-template": "^2.2.0",
-				"vitest": "^4.1.8"
+				"vitest": "^4.1.9"
 			},
 			"engines": {
 				"node": ">=22.21.1 <23 || >=24"
 			},
 			"optionalDependencies": {
-				"electron": "^42.4.0"
+				"electron": "^42.4.1"
 			}
 		},
 		"node_modules/@altano/repository-tools": {
@@ -868,9 +868,9 @@
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-			"integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.8.tgz",
+			"integrity": "sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==",
 			"dev": true,
 			"funding": [
 				{
@@ -964,9 +964,9 @@
 			}
 		},
 		"node_modules/@electron-internal/extract-zip": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.2.tgz",
-			"integrity": "sha512-VJuNETNPEhrmQEZezeTZO5TZMV+dobBRyJ7zHjGJWIhMS7m7W1UeClt69u4hkUxv9ZZVxuli/E9Yvc4gDNHGsg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+			"integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
 			"license": "BSD-2-Clause",
 			"optional": true,
 			"engines": {
@@ -1008,9 +1008,9 @@
 			}
 		},
 		"node_modules/@electron/get/node_modules/undici": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-			"integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -1512,14 +1512,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-			"integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+			"integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@tybys/wasm-util": "^0.10.1"
+				"@tybys/wasm-util": "^0.10.2"
 			},
 			"funding": {
 				"type": "github",
@@ -2025,9 +2025,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.13.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.1.tgz",
-			"integrity": "sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==",
+			"version": "24.13.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+			"integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.18.0"
@@ -2067,14 +2067,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-			"integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.61.0",
-				"@typescript-eslint/types": "^8.61.0",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2089,14 +2089,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-			"integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2107,9 +2107,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-			"integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2124,9 +2124,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-			"integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2138,16 +2138,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-			"integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.61.0",
-				"@typescript-eslint/tsconfig-utils": "8.61.0",
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/visitor-keys": "8.61.0",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2166,16 +2166,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
-			"integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.61.0",
-				"@typescript-eslint/types": "8.61.0",
-				"@typescript-eslint/typescript-estree": "8.61.0"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2190,13 +2190,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.61.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-			"integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.61.0",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -2564,14 +2564,14 @@
 			]
 		},
 		"node_modules/@vitest/coverage-v8": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-			"integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.9",
 				"ast-v8-to-istanbul": "^1.0.0",
 				"istanbul-lib-coverage": "^3.2.2",
 				"istanbul-lib-report": "^3.0.1",
@@ -2585,8 +2585,8 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"@vitest/browser": "4.1.8",
-				"vitest": "4.1.8"
+				"@vitest/browser": "4.1.9",
+				"vitest": "4.1.9"
 			},
 			"peerDependenciesMeta": {
 				"@vitest/browser": {
@@ -2595,9 +2595,9 @@
 			}
 		},
 		"node_modules/@vitest/eslint-plugin": {
-			"version": "1.6.19",
-			"resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.19.tgz",
-			"integrity": "sha512-zodmXRsVKFsuHxHJILuTFaaKsrsxm0YsiOX65clk+LpCW9JrVXaf6ERXr0caDs+NEk0S62Jyk0K7XYQ7gWXheA==",
+			"version": "1.6.20",
+			"resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.20.tgz",
+			"integrity": "sha512-xRwWHFG0Utp6hXtbGiWk4VdKXCGdExD8kbWrrmFEiG5dk8anOJ+vbWbeOa8EbkocKQRTsx7JAWETccZiBgFp/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2626,16 +2626,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-			"integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+			"integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.1.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"chai": "^6.2.2",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2644,13 +2644,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-			"integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+			"integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.1.8",
+				"@vitest/spy": "4.1.9",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -2671,9 +2671,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-			"integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+			"integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2684,13 +2684,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-			"integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+			"integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.9",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -2698,14 +2698,14 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-			"integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+			"integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -2714,9 +2714,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-			"integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+			"integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2724,13 +2724,13 @@
 			}
 		},
 		"node_modules/@vitest/ui": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.8.tgz",
-			"integrity": "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.9.tgz",
+			"integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.1.8",
+				"@vitest/utils": "4.1.9",
 				"fflate": "^0.8.2",
 				"flatted": "^3.4.2",
 				"pathe": "^2.0.3",
@@ -2742,17 +2742,17 @@
 				"url": "https://opencollective.com/vitest"
 			},
 			"peerDependencies": {
-				"vitest": "4.1.8"
+				"vitest": "4.1.9"
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-			"integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+			"integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.1.8",
+				"@vitest/pretty-format": "4.1.9",
 				"convert-source-map": "^2.0.0",
 				"tinyrainbow": "^3.1.0"
 			},
@@ -2780,9 +2780,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2898,9 +2898,9 @@
 			}
 		},
 		"node_modules/ast-v8-to-istanbul": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
-			"integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+			"integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2951,21 +2951,34 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"debug": "^4.4.3",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.7.0",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.1",
-				"raw-body": "^3.0.1",
-				"type-is": "^2.0.1"
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
 			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -3811,9 +3824,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "42.4.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-42.4.0.tgz",
-			"integrity": "sha512-OXXqh9LD9KxXPv2Fe25EfU9N9AvWTuV6V81sfhQaNvTAXCd9ONA+Q4OWvMe+CmYD6xIwjFxGGtG/ZphDYYC5OQ==",
+			"version": "42.4.1",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-42.4.1.tgz",
+			"integrity": "sha512-8CYHJP5O4wFO+ycoJR98yy907MmPeo+vWXrzjxmGGgRNKqv8pOjjm+wphO0CCgQJnBU7+QUPSJS4QXhbKrO50w==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -3846,9 +3859,9 @@
 			}
 		},
 		"node_modules/engine.io": {
-			"version": "6.6.8",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.8.tgz",
-			"integrity": "sha512-2agL3ueZhqxoVrfmntO8yuVj+uNSlIOnhykYHk3Cq0ShYPdUjjUiSJrQvXjq01I9jAuI0Zl2YO8Evv5Mqytm5g==",
+			"version": "6.6.9",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.9.tgz",
+			"integrity": "sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/cors": "^2.8.12",
@@ -3860,7 +3873,7 @@
 				"cors": "~2.8.5",
 				"debug": "~4.4.1",
 				"engine.io-parser": "~5.2.1",
-				"ws": "~8.20.1"
+				"ws": "~8.21.0"
 			},
 			"engines": {
 				"node": ">=10.2.0"
@@ -4025,10 +4038,13 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
-			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+			"integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
 			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
@@ -4184,9 +4200,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
-			"version": "63.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.2.tgz",
-			"integrity": "sha512-0TchoK1uS4VxHSo3P4CyWQ31Lm+6zsT+xkHMC5KbFKwgOf8YrXPf1Bl8EP7kpgw1wfe/Ui5jz5mSX7ou8WAVuw==",
+			"version": "63.0.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.6.tgz",
+			"integrity": "sha512-qXMUdwQf+igjSLe/DZqyY1baVR0+snEJ3l/+2odJjeoAG43PrcpA0tSaLw2dC1iHvfKzo1YnZLGvgxrvAViyfQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4244,9 +4260,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-package-json": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.3.0.tgz",
-			"integrity": "sha512-YC4lXD7sZJ5Pj8NrK9npvIBzMH9WMrkXb4VaBXRqyxTriCwqFcEJMX51K3TjkzLiXS3eUQ3CzimKWNPiSpq5tA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-1.4.0.tgz",
+			"integrity": "sha512-eqDrb8U/0WYAwZ9tOmg3XTGZEC5TAfDSP21zBeQSNfeUj6pf+S3UKGlQxZ1yoJGbv1KyMF53GIloG/pxMvbK2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4260,7 +4276,7 @@
 				"package-json-validator": "^1.5.0",
 				"semver": "^7.7.3",
 				"sort-object-keys": "^2.0.0",
-				"sort-package-json": "^3.4.0"
+				"sort-package-json": "^4.0.0"
 			},
 			"engines": {
 				"node": "^22.22.2 || >=24.15.0"
@@ -5119,9 +5135,9 @@
 			}
 		},
 		"node_modules/ics-filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/ics-filter/-/ics-filter-1.0.2.tgz",
-			"integrity": "sha512-RwOyxGssy6PEpDx6OfPfqadkJQtIE29Huq6MFZ4PkZWyMtuyHRPAb4J6BpT9IzEwis6a4Lk5DAIsFrM2HBPP6A==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/ics-filter/-/ics-filter-1.0.3.tgz",
+			"integrity": "sha512-8v81GGkml7QZ5JZwH2DNbebyBdd96wHa4HaM8MnfzE7zY9PwP1veDnem8R/Qa6wHWMfbXv2V93RrXZt8L5v/WA==",
 			"license": "MIT"
 		},
 		"node_modules/ignore": {
@@ -5384,9 +5400,9 @@
 			}
 		},
 		"node_modules/jsdom/node_modules/undici": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-			"integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5774,9 +5790,9 @@
 			}
 		},
 		"node_modules/lint-staged": {
-			"version": "17.0.7",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
-			"integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
+			"version": "17.0.8",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+			"integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7070,9 +7086,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.14",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+			"integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -7211,9 +7227,9 @@
 			}
 		},
 		"node_modules/obug": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-			"integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+			"integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -7458,13 +7474,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.60.0"
+				"playwright-core": "1.61.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -7477,9 +7493,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.60.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -7844,9 +7860,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-			"integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"devOptional": true,
 			"license": "ISC",
 			"bin": {
@@ -8091,13 +8107,13 @@
 			}
 		},
 		"node_modules/socket.io-adapter": {
-			"version": "2.5.7",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.7.tgz",
-			"integrity": "sha512-e0LyK91f3cUxTmv95/KzoLg47+zF+s/sbxRGDNsyG4dmIP8ZSX8ax6byOxfJXeNNtS/8AZlfD+uP7gBeR7DLlg==",
+			"version": "2.5.8",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.8.tgz",
+			"integrity": "sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "~4.4.1",
-				"ws": "~8.20.1"
+				"ws": "~8.21.0"
 			}
 		},
 		"node_modules/socket.io-parser": {
@@ -8164,9 +8180,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sort-package-json": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-3.7.1.tgz",
-			"integrity": "sha512-ssk1HG7whF8N/T1IsNAQrtHG5Cbdi0rAgRJZXYBr9hF5xaHnBNzUx/W6LcthEW7FhOwvZssbESZuO+GxssqAyA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-4.0.0.tgz",
+			"integrity": "sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8182,7 +8198,7 @@
 				"sort-package-json": "cli.js"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -8462,22 +8478,22 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-			"integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+			"integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"tldts-core": "^7.4.2"
+				"tldts-core": "^7.4.3"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-			"integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+			"integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8639,9 +8655,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-8.4.1.tgz",
-			"integrity": "sha512-RNHlB4fxZK0IrkhBsxhlbx7s8kFWwr7rzzOqj5nvZugw3ig3RsB7KW3zVlV0eu8POl+rx5d1hmL7rRg0z1owow==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+			"integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22.19.0"
@@ -8928,19 +8944,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.1.8",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-			"integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.1.8",
-				"@vitest/mocker": "4.1.8",
-				"@vitest/pretty-format": "4.1.8",
-				"@vitest/runner": "4.1.8",
-				"@vitest/snapshot": "4.1.8",
-				"@vitest/spy": "4.1.8",
-				"@vitest/utils": "4.1.8",
+				"@vitest/expect": "4.1.9",
+				"@vitest/mocker": "4.1.9",
+				"@vitest/pretty-format": "4.1.9",
+				"@vitest/runner": "4.1.9",
+				"@vitest/snapshot": "4.1.9",
+				"@vitest/spy": "4.1.9",
+				"@vitest/utils": "4.1.9",
 				"es-module-lexer": "^2.0.0",
 				"expect-type": "^1.3.0",
 				"magic-string": "^0.30.21",
@@ -8968,12 +8984,12 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.1.8",
-				"@vitest/browser-preview": "4.1.8",
-				"@vitest/browser-webdriverio": "4.1.8",
-				"@vitest/coverage-istanbul": "4.1.8",
-				"@vitest/coverage-v8": "4.1.8",
-				"@vitest/ui": "4.1.8",
+				"@vitest/browser-playwright": "4.1.9",
+				"@vitest/browser-preview": "4.1.9",
+				"@vitest/browser-webdriverio": "4.1.9",
+				"@vitest/coverage-istanbul": "4.1.9",
+				"@vitest/coverage-v8": "4.1.9",
+				"@vitest/ui": "4.1.9",
 				"happy-dom": "*",
 				"jsdom": "*",
 				"vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -9151,9 +9167,9 @@
 			"license": "ISC"
 		},
 		"node_modules/ws": {
-			"version": "8.20.1",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -9228,9 +9244,9 @@
 			}
 		},
 		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"version": "17.7.3",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+			"integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"node-ical": "^0.26.1",
 				"nunjucks": "^3.2.4",
 				"socket.io": "^4.8.3",
-				"suncalc": "^1.9.0",
+				"suncalc": "^2.0.0",
 				"systeminformation": "^5.31.7",
 				"undici": "^8.4.1",
 				"weathericons": "^2.1.0"
@@ -8339,9 +8339,9 @@
 			}
 		},
 		"node_modules/suncalc": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
-			"integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/suncalc/-/suncalc-2.0.0.tgz",
+			"integrity": "sha512-RcO28GOMXNnB+sr+c7/+zv5UPMa9wxIsUVGE3HddjQykqCVEC2rc4t4IjBB7qaa7K7dx5Cxp8UZwexyXrX8JkA=="
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -86,14 +86,14 @@
 		"@fortawesome/fontawesome-free": "^7.2.0",
 		"animate.css": "^4.1.1",
 		"croner": "^10.0.1",
-		"eslint": "^10.4.1",
+		"eslint": "^10.5.0",
 		"express": "^5.2.1",
 		"feedme": "^2.0.2",
 		"globals": "^17.6.0",
 		"helmet": "^8.2.0",
 		"html-to-text": "^10.0.0",
 		"iconv-lite": "^0.7.2",
-		"ics-filter": "^1.0.2",
+		"ics-filter": "^1.0.3",
 		"ipaddr.js": "^2.4.0",
 		"moment": "^2.30.1",
 		"moment-timezone": "^0.6.2",
@@ -102,7 +102,7 @@
 		"socket.io": "^4.8.3",
 		"suncalc": "^2.0.0",
 		"systeminformation": "^5.31.7",
-		"undici": "^8.4.1",
+		"undici": "^8.5.0",
 		"weathericons": "^2.1.0"
 	},
 	"devDependencies": {
@@ -110,26 +110,26 @@
 		"@eslint/js": "^10.0.1",
 		"@eslint/markdown": "^8.0.2",
 		"@stylistic/eslint-plugin": "^5.10.0",
-		"@vitest/coverage-v8": "^4.1.8",
-		"@vitest/eslint-plugin": "^1.6.19",
-		"@vitest/ui": "^4.1.8",
+		"@vitest/coverage-v8": "^4.1.9",
+		"@vitest/eslint-plugin": "^1.6.20",
+		"@vitest/ui": "^4.1.9",
 		"cspell": "^10.0.1",
 		"eslint-plugin-import-x": "^4.16.2",
-		"eslint-plugin-jsdoc": "^63.0.2",
-		"eslint-plugin-package-json": "^1.3.0",
+		"eslint-plugin-jsdoc": "^63.0.6",
+		"eslint-plugin-package-json": "^1.4.0",
 		"eslint-plugin-playwright": "^2.10.4",
 		"express-basic-auth": "^1.2.1",
 		"husky": "^9.1.7",
 		"jsdom": "^29.1.1",
-		"lint-staged": "^17.0.7",
+		"lint-staged": "^17.0.8",
 		"msw": "^2.14.6",
-		"playwright": "^1.60.0",
+		"playwright": "^1.61.0",
 		"prettier": "^3.8.4",
 		"prettier-plugin-jinja-template": "^2.2.0",
-		"vitest": "^4.1.8"
+		"vitest": "^4.1.9"
 	},
 	"optionalDependencies": {
-		"electron": "^42.4.0"
+		"electron": "^42.4.1"
 	},
 	"engines": {
 		"node": ">=22.21.1 <23 || >=24"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"node-ical": "^0.26.1",
 		"nunjucks": "^3.2.4",
 		"socket.io": "^4.8.3",
-		"suncalc": "^1.9.0",
+		"suncalc": "^2.0.0",
 		"systeminformation": "^5.31.7",
 		"undici": "^8.4.1",
 		"weathericons": "^2.1.0"


### PR DESCRIPTION
With SunCalc v2 we have to point the browser vendor mapping to the new CJS bundle.