### PR TITLE
refactor: replace Loader object with named exports

### DIFF
--- a/js/loader.js
+++ b/js/loader.js
@@ -249,60 +249,57 @@ function loadFile (fileName) {
 
 /* Public Methods */
 
-export const Loader = {
+/**
+ * Load all modules as defined in the config.
+ */
+export async function loadModules () {
+	const moduleData = await getModuleData();
+	const envVars = await getEnvVars();
+	const customCss = envVars.customCss;
 
-	/**
-	 * Load all modules as defined in the config.
-	 */
-	async loadModules () {
-		const moduleData = await getModuleData();
-		const envVars = await getEnvVars();
-		const customCss = envVars.customCss;
-
-		// Load all modules
-		for (const module of moduleData) {
-			await loadModule(module);
-		}
-
-		// Load custom.css
-		// Since this happens after loading the modules,
-		// it overwrites the default styles.
-		await loadFile(customCss);
-
-		// Start all modules.
-		await startModules();
-	},
-
-	/**
-	 * Load a file (script or stylesheet).
-	 * Prevent double loading and search for files defined in js/vendor.js.
-	 * @param {string} fileName Path of the file we want to load.
-	 * @param {Module} module The module that calls the loadFile function.
-	 * @returns {Promise} resolved when the file is loaded
-	 */
-	loadFileForModule (fileName, module) {
-		if (loadedFiles.indexOf(fileName.toLowerCase()) !== -1) {
-			Log.log(`File already loaded: ${fileName}`);
-			return Promise.resolve();
-		}
-
-		if (fileName.indexOf("http://") === 0 || fileName.indexOf("https://") === 0 || fileName.indexOf("/") !== -1) {
-			// This is an absolute or relative path.
-			// Load it and then return.
-			loadedFiles.push(fileName.toLowerCase());
-			return loadFile(fileName);
-		}
-
-		if (vendor[fileName] !== undefined) {
-			// This file is defined in js/vendor.js.
-			// Load it from its location.
-			loadedFiles.push(fileName.toLowerCase());
-			return loadFile(`${vendor[fileName]}`);
-		}
-
-		// File not loaded yet.
-		// Load it based on the module path.
-		loadedFiles.push(fileName.toLowerCase());
-		return loadFile(module.file(fileName));
+	// Load all modules
+	for (const module of moduleData) {
+		await loadModule(module);
 	}
-};
+
+	// Load custom.css
+	// Since this happens after loading the modules,
+	// it overwrites the default styles.
+	await loadFile(customCss);
+
+	// Start all modules.
+	await startModules();
+}
+
+/**
+ * Load a file (script or stylesheet).
+ * Prevent double loading and search for files defined in js/vendor.js.
+ * @param {string} fileName Path of the file we want to load.
+ * @param {Module} module The module that calls the loadFile function.
+ * @returns {Promise} resolved when the file is loaded
+ */
+export function loadFileForModule (fileName, module) {
+	if (loadedFiles.indexOf(fileName.toLowerCase()) !== -1) {
+		Log.log(`File already loaded: ${fileName}`);
+		return Promise.resolve();
+	}
+
+	if (fileName.indexOf("http://") === 0 || fileName.indexOf("https://") === 0 || fileName.indexOf("/") !== -1) {
+		// This is an absolute or relative path.
+		// Load it and then return.
+		loadedFiles.push(fileName.toLowerCase());
+		return loadFile(fileName);
+	}
+
+	if (vendor[fileName] !== undefined) {
+		// This file is defined in js/vendor.js.
+		// Load it from its location.
+		loadedFiles.push(fileName.toLowerCase());
+		return loadFile(`${vendor[fileName]}`);
+	}
+
+	// File not loaded yet.
+	// Load it based on the module path.
+	loadedFiles.push(fileName.toLowerCase());
+	return loadFile(module.file(fileName));
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,7 @@
 /* global addAnimateCSS, removeAnimateCSS, AnimateCSSIn, AnimateCSSOut, modulePositions, io */
 
 // eslint-disable-next-line import-x/extensions
-import { Loader } from "./loader.js";
+import { loadModules } from "./loader.js";
 
 let modules = [];
 
@@ -573,7 +573,7 @@ export const MM = {
 		Log.setLogLevel(config.logLevel);
 
 		await globalThis.Translator.loadCoreTranslations(config.language);
-		await Loader.loadModules();
+		await loadModules();
 	},
 
 	/**

--- a/js/module.js
+++ b/js/module.js
@@ -1,7 +1,7 @@
 /* global nunjucks */
 
 // eslint-disable-next-line import-x/extensions
-import { Loader } from "./loader.js";
+import { loadFileForModule } from "./loader.js";
 // eslint-disable-next-line import-x/extensions
 import { MMSocket } from "./socketclient.js";
 
@@ -282,7 +282,7 @@ export class Module {
 		const loadNextDependency = async () => {
 			if (dependencies.length > 0) {
 				const nextDependency = dependencies[0];
-				await Loader.loadFileForModule(nextDependency, this);
+				await loadFileForModule(nextDependency, this);
 				dependencies = dependencies.slice(1);
 				await loadNextDependency();
 			} else {


### PR DESCRIPTION
This PR removes the Loader wrapper object and switches to direct named exports (`loadModules`, `loadFileForModule`).  
It keeps behavior the same, but makes the API simpler and more idiomatic for ESM.  

This was reported in a PR comment by **github-code-quality** here https://github.com/MagicMirrorOrg/MagicMirror/pull/4194#pullrequestreview-4612392191.