### PR TITLE
refactor: use const instead of let for variable declarations

### DIFF
--- a/config/config.js.sample
+++ b/config/config.js.sample
@@ -8,7 +8,7 @@
  * which will be converted to `config.js` while starting. For more information
  * see https://docs.magicmirror.builders/configuration/introduction.html#enviromnent-variables
  */
-let config = {
+const config = {
 	address: "localhost",	// Address to listen on, can be:
 							// - "localhost", "127.0.0.1", "::1" to listen on loopback interface
 							// - another specific IPv4/6 to listen on a specific interface

--- a/defaultmodules/alert/notificationFx.js
+++ b/defaultmodules/alert/notificationFx.js
@@ -20,7 +20,7 @@
 	 * @returns {object} The merged object
 	 */
 	function extend (a, b) {
-		for (let key in b) {
+		for (const key in b) {
 			if (b.hasOwnProperty(key)) {
 				a[key] = b[key];
 			}

--- a/defaultmodules/calendar/calendar.js
+++ b/defaultmodules/calendar/calendar.js
@@ -215,7 +215,7 @@ Module.register("calendar", {
 				return;
 			}
 		} else if (notification === "CALENDAR_ERROR") {
-			let error_message = this.translate(payload.error_type);
+			const error_message = this.translate(payload.error_type);
 			this.error = this.translate("MODULE_CONFIG_ERROR", { MODULE_NAME: this.name, ERROR: error_message });
 			this.loaded = true;
 		}
@@ -350,8 +350,8 @@ Module.register("calendar", {
 
 			// Color events if custom color or eventClass are specified, transform title if required
 			if (this.config.customEvents.length > 0) {
-				for (let ev in this.config.customEvents) {
-					let needle = new RegExp(this.config.customEvents[ev].keyword, "gi");
+				for (const ev in this.config.customEvents) {
+					const needle = new RegExp(this.config.customEvents[ev].keyword, "gi");
 					if (needle.test(event.title)) {
 						if (typeof this.config.customEvents[ev].transform === "object") {
 							transformedTitle = CalendarUtils.titleTransform(transformedTitle, [this.config.customEvents[ev].transform]);
@@ -471,16 +471,16 @@ Module.register("calendar", {
 	 * @returns {object[]} Array with events.
 	 */
 	createEventList (limitNumberOfEntries) {
-		let now = moment();
-		let future = now.clone().startOf("day").add(this.config.maximumNumberOfDays, "days");
+		const now = moment();
+		const future = now.clone().startOf("day").add(this.config.maximumNumberOfDays, "days");
 
 		let events = [];
 
 		for (const calendarUrl in this.calendarData) {
 			const calendar = this.calendarData[calendarUrl].events;
-			let remainingEntries = this.maximumEntriesForUrl(calendarUrl);
-			let maxPastDaysCompare = now.clone().subtract(this.maximumPastDaysForUrl(calendarUrl), "days");
-			let by_url_calevents = [];
+			const remainingEntries = this.maximumEntriesForUrl(calendarUrl);
+			const maxPastDaysCompare = now.clone().subtract(this.maximumPastDaysForUrl(calendarUrl), "days");
+			const by_url_calevents = [];
 			for (const e in calendar) {
 				const event = JSON.parse(JSON.stringify(calendar[e])); // clone object
 				const eventStartDateMoment = this.timestampToMoment(event.startDate);
@@ -541,7 +541,7 @@ Module.register("calendar", {
 					event.tomorrow = this.timestampToMoment(event.startDate).isSame(now.clone().add(1, "days"), "d");
 					splitEvents.push(event);
 
-					for (let splitEvent of splitEvents) {
+					for (const splitEvent of splitEvents) {
 						if (this.timestampToMoment(splitEvent.endDate).isAfter(now) && this.timestampToMoment(splitEvent.endDate).isSameOrBefore(future)) {
 							by_url_calevents.push(splitEvent);
 						}
@@ -579,7 +579,7 @@ Module.register("calendar", {
 			// Group all events by date, events on the same date will be in a list with the key being the date.
 			const eventsByDate = Object.groupBy(events, (ev) => this.timestampToMoment(ev.startDate).format("YYYY-MM-DD"));
 			const newEvents = [];
-			let currentDate = moment();
+			const currentDate = moment();
 			let daysCollected = 0;
 
 			while (daysCollected < this.config.limitDays) {
@@ -650,9 +650,9 @@ Module.register("calendar", {
 		}
 
 		// If custom symbol is set, replace event symbol
-		for (let ev of this.config.customEvents) {
+		for (const ev of this.config.customEvents) {
 			if (typeof ev.symbol !== "undefined" && ev.symbol !== "") {
-				let needle = new RegExp(ev.keyword, "gi");
+				const needle = new RegExp(ev.keyword, "gi");
 				if (needle.test(event.title)) {
 					// Get the default prefix for this class name and add to the custom symbol provided
 					const className = this.getCalendarProperty(event.url, "symbolClassName", this.config.defaultSymbolClassName);
@@ -988,7 +988,7 @@ Module.register("calendar", {
 		if (property === "symbol" || property === "recurringSymbol" || property === "fullDaySymbol") {
 			const className = this.getCalendarProperty(url, "symbolClassName", this.config.defaultSymbolClassName);
 			if (p instanceof Array) {
-				let t = [];
+				const t = [];
 				p.forEach((n) => { t.push(className + n); });
 				p = t;
 			}

--- a/defaultmodules/calendar/calendarutils.js
+++ b/defaultmodules/calendar/calendarutils.js
@@ -95,11 +95,11 @@ const CalendarUtils = {
 	 */
 	titleTransform (title, titleReplace) {
 		let transformedTitle = title;
-		for (let tr in titleReplace) {
-			let transform = titleReplace[tr];
+		for (const tr in titleReplace) {
+			const transform = titleReplace[tr];
 			if (typeof transform === "object") {
 				if (typeof transform.search !== "undefined" && transform.search !== "" && typeof transform.replace !== "undefined") {
-					let regParts = transform.search.match(/^\/(.+)\/([gim]*)$/);
+					const regParts = transform.search.match(/^\/(.+)\/([gim]*)$/);
 					let needle = new RegExp(transform.search, "g");
 					if (regParts) {
 						// the parsed pattern is a regexp with flags.
@@ -110,8 +110,8 @@ const CalendarUtils = {
 					if (typeof transform.yearmatchgroup !== "undefined" && transform.yearmatchgroup !== "") {
 						const yearmatch = [...title.matchAll(needle)];
 						if (yearmatch[0].length >= transform.yearmatchgroup + 1 && yearmatch[0][transform.yearmatchgroup] * 1 >= 1900) {
-							let calcage = new Date().getFullYear() - yearmatch[0][transform.yearmatchgroup] * 1;
-							let searchstr = `$${transform.yearmatchgroup}`;
+							const calcage = new Date().getFullYear() - yearmatch[0][transform.yearmatchgroup] * 1;
+							const searchstr = `$${transform.yearmatchgroup}`;
 							replacement = replacement.replace(searchstr, calcage);
 						}
 					}

--- a/defaultmodules/compliments/compliments.js
+++ b/defaultmodules/compliments/compliments.js
@@ -63,7 +63,7 @@ Module.register("compliments", {
 		}
 		let minute_sync_delay = 1;
 		// loop thru all the configured when events
-		for (let m of Object.keys(this.config.compliments)) {
+		for (const m of Object.keys(this.config.compliments)) {
 			// if it is a cron entry
 			if (this.isCronEntry(m)) {
 				// we need to synch our interval cycle to the minute
@@ -165,14 +165,14 @@ Module.register("compliments", {
 		Array.prototype.push.apply(compliments, this.config.compliments.anytime);
 
 		// get the list of just date entry keys
-		let temp_list = Object.keys(this.config.compliments).filter((k) => {
+		const temp_list = Object.keys(this.config.compliments).filter((k) => {
 			if (this.pre_defined_types.includes(k)) return false;
 			else return true;
 		});
 
-		let date_compliments = [];
+		const date_compliments = [];
 		// Add compliments for special day/times
-		for (let entry of temp_list) {
+		for (const entry of temp_list) {
 			// check if this could be a cron type entry
 			if (this.isCronEntry(entry)) {
 				// make sure the regex is valid

--- a/defaultmodules/newsfeed/newsfeed.js
+++ b/defaultmodules/newsfeed/newsfeed.js
@@ -212,7 +212,7 @@ Module.register("newsfeed", {
 	 * Registers the feeds to be used by the backend.
 	 */
 	registerFeeds () {
-		for (let feed of this.config.feeds) {
+		for (const feed of this.config.feeds) {
 			this.sendSocketNotification("ADD_FEED", {
 				feed: feed,
 				config: this.config
@@ -239,10 +239,10 @@ Module.register("newsfeed", {
 	 */
 	generateFeed (feeds) {
 		let newsItems = [];
-		for (let feed in feeds) {
+		for (const feed in feeds) {
 			const feedItems = feeds[feed];
 			if (this.subscribedToFeed(feed)) {
-				for (let item of feedItems) {
+				for (const item of feedItems) {
 					item.sourceTitle = this.titleForFeed(feed);
 					if (!(this.getFeedProperty(feed, "ignoreOldItems") && Date.now() - new Date(item.pubdate) > this.getFeedProperty(feed, "ignoreOlderThan"))) {
 						newsItems.push(item);
@@ -262,7 +262,7 @@ Module.register("newsfeed", {
 
 		if (this.config.prohibitedWords.length > 0) {
 			newsItems = newsItems.filter(function (item) {
-				for (let word of this.config.prohibitedWords) {
+				for (const word of this.config.prohibitedWords) {
 					if (item.title.toLowerCase().indexOf(word.toLowerCase()) > -1) {
 						return false;
 					}
@@ -273,7 +273,7 @@ Module.register("newsfeed", {
 		newsItems.forEach((item) => {
 			//Remove selected tags from the beginning of rss feed items (title or description)
 			if (this.config.removeStartTags === "title" || this.config.removeStartTags === "both") {
-				for (let startTag of this.config.startTags) {
+				for (const startTag of this.config.startTags) {
 					if (item.title.slice(0, startTag.length) === startTag) {
 						item.title = item.title.slice(startTag.length, item.title.length);
 					}
@@ -282,7 +282,7 @@ Module.register("newsfeed", {
 
 			if (this.config.removeStartTags === "description" || this.config.removeStartTags === "both") {
 				if (this.isShowingDescription) {
-					for (let startTag of this.config.startTags) {
+					for (const startTag of this.config.startTags) {
 						if (item.description.slice(0, startTag.length) === startTag) {
 							item.description = item.description.slice(startTag.length, item.description.length);
 						}
@@ -292,14 +292,14 @@ Module.register("newsfeed", {
 
 			//Remove selected tags from the end of rss feed items (title or description)
 			if (this.config.removeEndTags) {
-				for (let endTag of this.config.endTags) {
+				for (const endTag of this.config.endTags) {
 					if (item.title.slice(-endTag.length) === endTag) {
 						item.title = item.title.slice(0, -endTag.length);
 					}
 				}
 
 				if (this.isShowingDescription) {
-					for (let endTag of this.config.endTags) {
+					for (const endTag of this.config.endTags) {
 						if (item.description.slice(-endTag.length) === endTag) {
 							item.description = item.description.slice(0, -endTag.length);
 						}
@@ -331,7 +331,7 @@ Module.register("newsfeed", {
 	 * @returns {boolean} True if it is subscribed, false otherwise
 	 */
 	subscribedToFeed (feedUrl) {
-		for (let feed of this.config.feeds) {
+		for (const feed of this.config.feeds) {
 			if (feed.url === feedUrl) {
 				return true;
 			}
@@ -345,7 +345,7 @@ Module.register("newsfeed", {
 	 * @returns {string} The title of the feed
 	 */
 	titleForFeed (feedUrl) {
-		for (let feed of this.config.feeds) {
+		for (const feed of this.config.feeds) {
 			if (feed.url === feedUrl) {
 				return feed.title || "";
 			}

--- a/defaultmodules/updatenotification/git_helper.js
+++ b/defaultmodules/updatenotification/git_helper.js
@@ -76,7 +76,7 @@ class GitHelper {
 	}
 
 	async getStatusInfo (repo) {
-		let gitInfo = {
+		const gitInfo = {
 			module: repo.module,
 			behind: 0, // commits behind
 			current: "", // branch name

--- a/defaultmodules/updatenotification/update_helper.js
+++ b/defaultmodules/updatenotification/update_helper.js
@@ -77,7 +77,7 @@ class Updater {
 		});
 
 		await Promise.all(parser);
-		let updater = Object.values(this.moduleList);
+		const updater = Object.values(this.moduleList);
 		Log.debug("Update Result:", updater);
 		return updater;
 	}
@@ -92,7 +92,7 @@ class Updater {
 	 * };
 	 */
 	updateProcess (module) {
-		let Result = {
+		const Result = {
 			error: false,
 			updated: false,
 			needRestart: false

--- a/defaultmodules/weather/providers/envcanada.js
+++ b/defaultmodules/weather/providers/envcanada.js
@@ -252,7 +252,7 @@ class EnvCanadaProvider {
 		// Check if first forecast is Today or Tonight
 		const isToday = forecasts[0].includes("textForecastName=\"Today\"");
 
-		let nextDay = isToday ? 2 : 1;
+		const nextDay = isToday ? 2 : 1;
 		const lastDay = isToday ? 12 : 11;
 
 		// Process first day

--- a/defaultmodules/weather/weather.js
+++ b/defaultmodules/weather/weather.js
@@ -144,7 +144,7 @@ Module.register("weather", {
 			const senderClasses = sender.data.classes.toLowerCase().split(" ");
 			if (senderClasses.indexOf(this.config.calendarClass.toLowerCase()) !== -1) {
 				this.firstEvent = null;
-				for (let event of payload) {
+				for (const event of payload) {
 					if (event.location || event.geo) {
 						this.firstEvent = event;
 						Log.debug("[weather] First upcoming event with location: ", event);

--- a/defaultmodules/weather/weatherobject.js
+++ b/defaultmodules/weather/weatherobject.js
@@ -119,7 +119,7 @@ class WeatherObject {
 	 */
 	simpleClone () {
 		const toFlat = ["date", "sunrise", "sunset"];
-		let clone = { ...this };
+		const clone = { ...this };
 		for (const prop of toFlat) {
 			clone[prop] = clone?.[prop]?.valueOf() ?? clone?.[prop];
 		}

--- a/defaultmodules/weather/weatherutils.js
+++ b/defaultmodules/weather/weatherutils.js
@@ -185,7 +185,7 @@ const WeatherUtils = {
 	convertWeatherObjectToImperial (weatherObject) {
 		if (!weatherObject || Object.keys(weatherObject).length === 0) return null;
 
-		let imperialWeatherObject = { ...weatherObject };
+		const imperialWeatherObject = { ...weatherObject };
 
 		if ("feelsLikeTemp" in imperialWeatherObject) imperialWeatherObject.feelsLikeTemp = this.convertTemp(imperialWeatherObject.feelsLikeTemp, "imperial");
 		if ("maxTemperature" in imperialWeatherObject) imperialWeatherObject.maxTemperature = this.convertTemp(imperialWeatherObject.maxTemperature, "imperial");

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,6 +93,7 @@ export default defineConfig([
 			"no-warning-comments": "off",
 			"object-shorthand": ["error", "methods"],
 			"one-var": "off",
+			"prefer-const": "error",
 			"prefer-template": "error",
 			"require-await": "error",
 			"sort-keys": "off"

--- a/js/app.js
+++ b/js/app.js
@@ -65,7 +65,7 @@ process.on("uncaughtException", function (err) {
  * @class
  */
 function App () {
-	let nodeHelpers = [];
+	const nodeHelpers = [];
 	let httpServer;
 	let defaultModules;
 	let env;
@@ -118,7 +118,7 @@ function App () {
 				Log.error(`Error when loading ${moduleName}:`, e.message);
 				return;
 			}
-			let m = new Module();
+			const m = new Module();
 
 			if (m.requiresVersion) {
 				Log.log(`Check MagicMirror² version for node helper '${moduleName}' - Minimum version: ${m.requiresVersion} - Current version: ${global.version}`);
@@ -146,7 +146,7 @@ function App () {
 	async function loadModules (modules) {
 		Log.log("Loading module helpers ...");
 
-		for (let module of modules) {
+		for (const module of modules) {
 			await loadModule(module);
 		}
 
@@ -211,7 +211,7 @@ function App () {
 			// get the used module positions
 			Utils.getModulePositions();
 
-			let modules = [];
+			const modules = [];
 			for (const module of config.modules) {
 				if (module.disabled) continue;
 				if (module.module) {
@@ -237,7 +237,7 @@ function App () {
 			Log.log("Server started ...");
 
 			const nodePromises = [];
-			for (let nodeHelper of nodeHelpers) {
+			for (const nodeHelper of nodeHelpers) {
 				nodeHelper.setExpressApp(app);
 				nodeHelper.setSocketIO(io);
 
@@ -284,7 +284,7 @@ function App () {
 	 */
 	this.stop = async function () {
 		const nodePromises = [];
-		for (let nodeHelper of nodeHelpers) {
+		for (const nodeHelper of nodeHelpers) {
 			try {
 				if (typeof nodeHelper.stop === "function") {
 					nodePromises.push(nodeHelper.stop());

--- a/js/electron.js
+++ b/js/electron.js
@@ -45,7 +45,7 @@ function createWindow () {
 	}
 
 	applyElectronSwitches(app.commandLine, config.electronSwitches);
-	let electronOptionsDefaults = {
+	const electronOptionsDefaults = {
 		width: electronSize.width,
 		height: electronSize.height,
 		icon: "favicon.svg",
@@ -100,7 +100,7 @@ function createWindow () {
 		prefix = "http://";
 	}
 
-	let address = (config.address === void 0) | (config.address === "") | (config.address === "0.0.0.0") | (config.address === "::") ? (config.address = "localhost") : config.address;
+	const address = (config.address === void 0) | (config.address === "") | (config.address === "0.0.0.0") | (config.address === "::") ? (config.address = "localhost") : config.address;
 	const port = process.env.MM_PORT || config.port;
 	mainWindow.loadURL(`${prefix}${address}:${port}`);
 

--- a/js/main.js
+++ b/js/main.js
@@ -196,7 +196,6 @@ function moduleNeedsUpdate (module, newHeader, newContent) {
 	const headerWrapper = moduleWrapper.getElementsByClassName("module-header");
 
 	let headerNeedsUpdate = false;
-	let contentNeedsUpdate;
 
 	if (headerWrapper.length > 0) {
 		headerNeedsUpdate = newHeader !== headerWrapper[0].innerHTML;
@@ -204,7 +203,7 @@ function moduleNeedsUpdate (module, newHeader, newContent) {
 
 	const tempContentWrapper = document.createElement("div");
 	tempContentWrapper.appendChild(newContent);
-	contentNeedsUpdate = tempContentWrapper.innerHTML !== contentWrapper[0].innerHTML;
+	const contentNeedsUpdate = tempContentWrapper.innerHTML !== contentWrapper[0].innerHTML;
 
 	return headerNeedsUpdate || contentNeedsUpdate;
 }

--- a/js/module.js
+++ b/js/module.js
@@ -520,7 +520,7 @@ export function cmpVersions (a, b) {
 	const l = Math.min(segmentsA.length, segmentsB.length);
 
 	for (let i = 0; i < l; i++) {
-		let diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10);
+		const diff = parseInt(segmentsA[i], 10) - parseInt(segmentsB[i], 10);
 		if (diff) {
 			return diff;
 		}

--- a/js/server.js
+++ b/js/server.js
@@ -98,7 +98,7 @@ function Server (configObj) {
 				});
 			}
 
-			let directories = ["/config", "/css", "/favicon.svg", "/defaultmodules", "/modules", "/node_modules/animate.css", "/node_modules/@fontsource", "/node_modules/@fortawesome", "/node_modules/suncalc", "/translations", "/tests/configs", "/tests/mocks"];
+			const directories = ["/config", "/css", "/favicon.svg", "/defaultmodules", "/modules", "/node_modules/animate.css", "/node_modules/@fontsource", "/node_modules/@fortawesome", "/node_modules/suncalc", "/translations", "/tests/configs", "/tests/mocks"];
 			for (const value of Object.values(vendor)) {
 				const dirArr = value.split("/");
 				if (dirArr[0] === "node_modules") directories.push(`/${dirArr[0]}/${dirArr[1]}`);

--- a/js/systeminformation.js
+++ b/js/systeminformation.js
@@ -25,7 +25,7 @@ const logSystemInformation = async () => {
 		const freeRam = (os.freemem() / 1024 / 1024).toFixed(2);
 		const usedRam = ((os.totalmem() - os.freemem()) / 1024 / 1024).toFixed(2);
 
-		let systemDataString = [
+		const systemDataString = [
 			"\n####  System Information  ####",
 			`- MM:       version: v${mmVersion}${mmGitHash ? `; git: ${mmGitHash}` : ""}${mmGitBranch ? `; branch: ${mmGitBranch}` : ""}`,
 			`- SYSTEM:   manufacturer: ${system.manufacturer}; model: ${system.model}; virtual: ${system.virtual}`,

--- a/js/translator.js
+++ b/js/translator.js
@@ -117,7 +117,7 @@ const Translator = (function () {
 		 * The first language defined in translations.js will be used.
 		 */
 		async loadCoreTranslationsFallback () {
-			let first = Object.keys(translations)[0];
+			const first = Object.keys(translations)[0];
 			if (first) {
 				Log.log(`[translator] Loading core translation fallback file: ${translations[first]}`);
 				this.coreTranslationsFallback = await loadJSON(translations[first]);

--- a/js/utils.js
+++ b/js/utils.js
@@ -110,7 +110,7 @@ const loadConfig = () => {
 	// For this check proposed to TestSuite
 	// https://forum.magicmirror.builders/topic/1456/test-suite-for-magicmirror/8
 	const configFilename = getConfigFilePath();
-	let templateFile = `${configFilename}.template`;
+	const templateFile = `${configFilename}.template`;
 
 	// check if templateFile exists
 	try {
@@ -133,7 +133,7 @@ const loadConfig = () => {
 
 	// Load config.js and catch errors if not accessible
 	try {
-		let configContent = fs.readFileSync(configFilename, "utf-8");
+		const configContent = fs.readFileSync(configFilename, "utf-8");
 		const hideConfigSecrets = configContent.match(/^\s*hideConfigSecrets: true.*$/m);
 		let configContentFull = configContent;
 		let configContentRedacted = hideConfigSecrets ? configContent : undefined;

--- a/tests/configs/config_functions.js
+++ b/tests/configs/config_functions.js
@@ -1,6 +1,6 @@
 /*eslint object-shorthand: ["error", "always", { "methodsIgnorePattern": "^roundToInt2$" }]*/
 
-let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+const config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	modules: [
 		{
 			module: "clock",

--- a/tests/configs/config_variables.js
+++ b/tests/configs/config_variables.js
@@ -1,4 +1,4 @@
-let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+const config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	language: "${MM_LANGUAGE}",
 	logLevel: ["${MM_LOG_ERROR}", "LOG", "WARN", "${MM_LOG_INFO}"],
 	timeFormat: ${MM_TIME_FORMAT},

--- a/tests/configs/customregions.js
+++ b/tests/configs/customregions.js
@@ -1,12 +1,12 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules:
 		// Using exotic content. This is why don't accept go to JSON configuration file
 		(() => {
-			let positions = ["row3_left", "top3_left1"];
-			let modules = Array();
-			for (let idx in positions) {
+			const positions = ["row3_left", "top3_left1"];
+			const modules = Array();
+			for (const idx in positions) {
 				modules.push({
 					module: "helloworld",
 					position: positions[idx],

--- a/tests/configs/empty_ipWhiteList.js
+++ b/tests/configs/empty_ipWhiteList.js
@@ -1,4 +1,4 @@
-let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+const config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	ipWhitelist: [],
 	port: 8282
 });

--- a/tests/configs/modules/alert/welcome_false.js
+++ b/tests/configs/modules/alert/welcome_false.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/alert/welcome_string.js
+++ b/tests/configs/modules/alert/welcome_string.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/alert/welcome_true.js
+++ b/tests/configs/modules/alert/welcome_true.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/calendar/3_move_first_allday_repeating_event.js
+++ b/tests/configs/modules/calendar/3_move_first_allday_repeating_event.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/auth-default.js
+++ b/tests/configs/modules/calendar/auth-default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/bad_rrule.js
+++ b/tests/configs/modules/calendar/bad_rrule.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/basic-auth.js
+++ b/tests/configs/modules/calendar/basic-auth.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/berlin_end_of_day_repeating.js
+++ b/tests/configs/modules/calendar/berlin_end_of_day_repeating.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/berlin_multi.js
+++ b/tests/configs/modules/calendar/berlin_multi.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/berlin_whole_day_event_moved_over_dst_change.js
+++ b/tests/configs/modules/calendar/berlin_whole_day_event_moved_over_dst_change.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/changed-port.js
+++ b/tests/configs/modules/calendar/changed-port.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/chicago-looking-at-ny-recurring.js
+++ b/tests/configs/modules/calendar/chicago-looking-at-ny-recurring.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/chicago_late_in_timezone.js
+++ b/tests/configs/modules/calendar/chicago_late_in_timezone.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/countCalendarEvents.js
+++ b/tests/configs/modules/calendar/countCalendarEvents.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/custom.js
+++ b/tests/configs/modules/calendar/custom.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/default.js
+++ b/tests/configs/modules/calendar/default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/diff_tz_start_end.js
+++ b/tests/configs/modules/calendar/diff_tz_start_end.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/end_of_day_berlin_moved.js
+++ b/tests/configs/modules/calendar/end_of_day_berlin_moved.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/exdate_and_recurrence_together.js
+++ b/tests/configs/modules/calendar/exdate_and_recurrence_together.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/exdate_la_at_midnight_dst.js
+++ b/tests/configs/modules/calendar/exdate_la_at_midnight_dst.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/exdate_la_at_midnight_std.js
+++ b/tests/configs/modules/calendar/exdate_la_at_midnight_std.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/exdate_la_before_midnight.js
+++ b/tests/configs/modules/calendar/exdate_la_before_midnight.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/exdate_syd_at_midnight_dst.js
+++ b/tests/configs/modules/calendar/exdate_syd_at_midnight_dst.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/exdate_syd_at_midnight_std.js
+++ b/tests/configs/modules/calendar/exdate_syd_at_midnight_std.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/exdate_syd_before_midnight.js
+++ b/tests/configs/modules/calendar/exdate_syd_before_midnight.js
@@ -7,7 +7,7 @@
  * See issue #3250
  * See tests/electron/modules/calendar_spec.js
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/fail-basic-auth.js
+++ b/tests/configs/modules/calendar/fail-basic-auth.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/fullday_event_over_multiple_days_nonrepeating.js
+++ b/tests/configs/modules/calendar/fullday_event_over_multiple_days_nonrepeating.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/fullday_until.js
+++ b/tests/configs/modules/calendar/fullday_until.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/germany_at_end_of_day_repeating.js
+++ b/tests/configs/modules/calendar/germany_at_end_of_day_repeating.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 

--- a/tests/configs/modules/calendar/long-fullday-event.js
+++ b/tests/configs/modules/calendar/long-fullday-event.js
@@ -4,7 +4,7 @@
  * By Paranoid93 https://github.com/Paranoid93/
  * MIT Licensed.
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/old-basic-auth.js
+++ b/tests/configs/modules/calendar/old-basic-auth.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/recurring.js
+++ b/tests/configs/modules/calendar/recurring.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/rrule_until.js
+++ b/tests/configs/modules/calendar/rrule_until.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/show-duplicates-in-calendar.js
+++ b/tests/configs/modules/calendar/show-duplicates-in-calendar.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/single-fullday-event.js
+++ b/tests/configs/modules/calendar/single-fullday-event.js
@@ -4,7 +4,7 @@
  * By Paranoid93 https://github.com/Paranoid93/
  * MIT Licensed.
  */
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/sliceMultiDayEvents.js
+++ b/tests/configs/modules/calendar/sliceMultiDayEvents.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/calendar/symboltest.js
+++ b/tests/configs/modules/calendar/symboltest.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_12hr.js
+++ b/tests/configs/modules/clock/clock_12hr.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_24hr.js
+++ b/tests/configs/modules/clock/clock_24hr.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/clock/clock_analog.js
+++ b/tests/configs/modules/clock/clock_analog.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/clock/clock_displaySeconds_false.js
+++ b/tests/configs/modules/clock/clock_displaySeconds_false.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showDateAnalog.js
+++ b/tests/configs/modules/clock/clock_showDateAnalog.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/clock_showPeriodUpper.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showSunMoon.js
+++ b/tests/configs/modules/clock/clock_showSunMoon.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showSunNoEvent.js
+++ b/tests/configs/modules/clock/clock_showSunNoEvent.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showTime.js
+++ b/tests/configs/modules/clock/clock_showTime.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showWeek.js
+++ b/tests/configs/modules/clock/clock_showWeek.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/clock_showWeek_short.js
+++ b/tests/configs/modules/clock/clock_showWeek_short.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/clock/de/clock_showWeek.js
+++ b/tests/configs/modules/clock/de/clock_showWeek.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "de",

--- a/tests/configs/modules/clock/de/clock_showWeek_short.js
+++ b/tests/configs/modules/clock/de/clock_showWeek_short.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "de",

--- a/tests/configs/modules/clock/es/clock_12hr.js
+++ b/tests/configs/modules/clock/es/clock_12hr.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "es",

--- a/tests/configs/modules/clock/es/clock_24hr.js
+++ b/tests/configs/modules/clock/es/clock_24hr.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "es",

--- a/tests/configs/modules/clock/es/clock_showPeriodUpper.js
+++ b/tests/configs/modules/clock/es/clock_showPeriodUpper.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "es",

--- a/tests/configs/modules/clock/es/clock_showWeek.js
+++ b/tests/configs/modules/clock/es/clock_showWeek.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "es",

--- a/tests/configs/modules/clock/es/clock_showWeek_short.js
+++ b/tests/configs/modules/clock/es/clock_showWeek_short.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	language: "es",

--- a/tests/configs/modules/compliments/compliments_animateCSS.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_animateCSS_fallbackToDefault.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS_fallbackToDefault.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_animateCSS_invertedAnimationName.js
+++ b/tests/configs/modules/compliments/compliments_animateCSS_invertedAnimationName.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_anytime.js
+++ b/tests/configs/modules/compliments/compliments_anytime.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_cron_entry.js
+++ b/tests/configs/modules/compliments/compliments_cron_entry.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_date.js
+++ b/tests/configs/modules/compliments/compliments_date.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_e2e_cron_entry.js
+++ b/tests/configs/modules/compliments/compliments_e2e_cron_entry.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_evening.js
+++ b/tests/configs/modules/compliments/compliments_evening.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_file.js
+++ b/tests/configs/modules/compliments/compliments_file.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_file_change.js
+++ b/tests/configs/modules/compliments/compliments_file_change.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_only_anytime.js
+++ b/tests/configs/modules/compliments/compliments_only_anytime.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_parts_day.js
+++ b/tests/configs/modules/compliments/compliments_parts_day.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/compliments/compliments_remote.js
+++ b/tests/configs/modules/compliments/compliments_remote.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_false.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
+++ b/tests/configs/modules/compliments/compliments_specialDayUnique_true.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/display.js
+++ b/tests/configs/modules/display.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/helloworld/helloworld.js
+++ b/tests/configs/modules/helloworld/helloworld.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/helloworld/helloworld_default.js
+++ b/tests/configs/modules/helloworld/helloworld_default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/newsfeed/basic_html.js
+++ b/tests/configs/modules/newsfeed/basic_html.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/newsfeed/default.js
+++ b/tests/configs/modules/newsfeed/default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/newsfeed/ignore_items.js
+++ b/tests/configs/modules/newsfeed/ignore_items.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/newsfeed/incorrect_url.js
+++ b/tests/configs/modules/newsfeed/incorrect_url.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/newsfeed/notifications.js
+++ b/tests/configs/modules/newsfeed/notifications.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/newsfeed/prohibited_words.js
+++ b/tests/configs/modules/newsfeed/prohibited_words.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/positions.js
+++ b/tests/configs/modules/positions.js
@@ -1,12 +1,12 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules:
 		// Using exotic content. This is why don't accept go to JSON configuration file
 		(() => {
-			let positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
-			let modules = Array();
-			for (let idx in positions) {
+			const positions = ["top_bar", "top_left", "top_center", "top_right", "upper_third", "middle_center", "lower_third", "bottom_left", "bottom_center", "bottom_right", "bottom_bar", "fullscreen_above", "fullscreen_below"];
+			const modules = Array();
+			for (const idx in positions) {
 				modules.push({
 					module: "helloworld",
 					position: positions[idx],

--- a/tests/configs/modules/weather/currentweather_compliments.js
+++ b/tests/configs/modules/weather/currentweather_compliments.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/weather/currentweather_default.js
+++ b/tests/configs/modules/weather/currentweather_default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/currentweather_options.js
+++ b/tests/configs/modules/weather/currentweather_options.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	modules: [

--- a/tests/configs/modules/weather/currentweather_units.js
+++ b/tests/configs/modules/weather/currentweather_units.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	units: "imperial",

--- a/tests/configs/modules/weather/forecastweather_absolute.js
+++ b/tests/configs/modules/weather/forecastweather_absolute.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/forecastweather_default.js
+++ b/tests/configs/modules/weather/forecastweather_default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/forecastweather_options.js
+++ b/tests/configs/modules/weather/forecastweather_options.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/forecastweather_units.js
+++ b/tests/configs/modules/weather/forecastweather_units.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	units: "imperial",

--- a/tests/configs/modules/weather/hourlyweather_default.js
+++ b/tests/configs/modules/weather/hourlyweather_default.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/hourlyweather_options.js
+++ b/tests/configs/modules/weather/hourlyweather_options.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/modules/weather/hourlyweather_showPrecipitation.js
+++ b/tests/configs/modules/weather/hourlyweather_showPrecipitation.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: [],
 	timeFormat: 12,

--- a/tests/configs/noIpWhiteList.js
+++ b/tests/configs/noIpWhiteList.js
@@ -1,4 +1,4 @@
-let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+const config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	ipWhitelist: ["x.x.x.x"],
 	port: 8181
 });

--- a/tests/configs/port_8090.js
+++ b/tests/configs/port_8090.js
@@ -1,4 +1,4 @@
-let config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
+const config = require(`${process.cwd()}/tests/configs/default.js`).configFactory({
 	port: 8090
 });
 

--- a/tests/configs/without_modules.js
+++ b/tests/configs/without_modules.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
 	address: "0.0.0.0",
 	ipWhitelist: []
 };

--- a/tests/e2e/custom_module_regions_spec.js
+++ b/tests/e2e/custom_module_regions_spec.js
@@ -19,13 +19,13 @@ describe("Custom Position of modules", () => {
 	const positions = ["row3_left", "top3_left1"];
 	let i = 0;
 	const className1 = positions[i].replace("_", ".");
-	let message1 = positions[i];
+	const message1 = positions[i];
 	it(`should show text in ${message1}`, async () => {
 		await expect(page.locator(`.${className1} .module-content`)).toContainText(`Text in ${message1}`);
 	});
 	i = 1;
 	const className2 = positions[i].replace("_", ".");
-	let message2 = positions[i];
+	const message2 = positions[i];
 	it(`should NOT show text in ${message2}`, async () => {
 		await expect(page.locator(`.${className2} .module-content`)).toHaveCount(0);
 	});

--- a/tests/e2e/helpers/basic-auth.js
+++ b/tests/e2e/helpers/basic-auth.js
@@ -14,7 +14,7 @@ app.use(basicAuth);
 // Set available directories
 const directories = ["/tests/configs", "/tests/mocks"];
 
-for (let directory of directories) {
+for (const directory of directories) {
 	app.use(directory, express.static(path.resolve(`${global.root_path}/${directory}`)));
 }
 

--- a/tests/e2e/helpers/global-setup.js
+++ b/tests/e2e/helpers/global-setup.js
@@ -162,7 +162,7 @@ exports.fixupIndex = async () => {
 	// make lines of the content
 	const workIndexLines = indexData.split(os.EOL);
 	// loop thru the lines to find place to insert new region
-	for (let l in workIndexLines) {
+	for (const l in workIndexLines) {
 		if (workIndexLines[l].includes("region top right")) {
 			// insert a new line with new region definition
 			workIndexLines.splice(l, 0, "      <div class=\"region row3 left\"><div class=\"container\"></div></div>");

--- a/tests/mocks/testNotification/testNotification.js
+++ b/tests/mocks/testNotification/testNotification.js
@@ -29,17 +29,17 @@ Module.register("testNotification", {
 		}
 	},
 	maketd (row, info) {
-		let td = document.createElement("td");
+		const td = document.createElement("td");
 		row.appendChild(td);
 		if (info !== null) {
-			let colinfo = info.toString().split(":");
+			const colinfo = info.toString().split(":");
 			if (colinfo.length === 2) td.className = colinfo[1];
 			td.innerText = colinfo[0];
 		}
 		return td;
 	},
 	addTableRow (table, col1 = null, col2 = null, col3 = null) {
-		let tableRow = document.createElement("tr");
+		const tableRow = document.createElement("tr");
 		table.appendChild(tableRow);
 
 		this.maketd(tableRow, col1);
@@ -49,7 +49,7 @@ Module.register("testNotification", {
 		return tableRow;
 	},
 	getDom () {
-		let wrapper = document.createElement("div");
+		const wrapper = document.createElement("div");
 		if (this.table) {
 			wrapper.appendChild(this.table);
 		}

--- a/tests/unit/classes/deprecated_spec.js
+++ b/tests/unit/classes/deprecated_spec.js
@@ -7,7 +7,7 @@ describe("Deprecated", () => {
 
 	it("should contain clock array with deprecated options as strings", () => {
 		expect(Array.isArray(["deprecated.clock"])).toBe(true);
-		for (let option of deprecated.configs) {
+		for (const option of deprecated.configs) {
 			expect(typeof option).toBe("string");
 		}
 		expect(deprecated.clock).toEqual(expect.arrayContaining(["secondsColor"]));

--- a/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
+++ b/tests/unit/modules/default/calendar/calendar_fetcher_utils_spec.js
@@ -135,11 +135,11 @@ END:VEVENT`);
 			const januaryFirst = filteredEvents.filter((event) => moment(event.startDate, "x").format("MM-DD") === "01-01");
 			const julyFirst = filteredEvents.filter((event) => moment(event.startDate, "x").format("MM-DD") === "07-01");
 
-			let januaryMoment = moment(`${moment(januaryFirst[0].startDate, "x").format("YYYY")}-01-01T09:00:00`)
+			const januaryMoment = moment(`${moment(januaryFirst[0].startDate, "x").format("YYYY")}-01-01T09:00:00`)
 				.tz("Europe/Amsterdam", true) // Convert to Europe/Amsterdam timezone (see event ical) but keep 9 o'clock
 				.tz(moment.tz.guess()); // Convert to guessed timezone as that is used in the filterEvents
 
-			let julyMoment = moment(`${moment(julyFirst[0].startDate, "x").format("YYYY")}-07-01T09:00:00`)
+			const julyMoment = moment(`${moment(julyFirst[0].startDate, "x").format("YYYY")}-07-01T09:00:00`)
 				.tz("Europe/Amsterdam", true) // Convert to Europe/Amsterdam timezone (see event ical) but keep 9 o'clock
 				.tz(moment.tz.guess()); // Convert to guessed timezone as that is used in the filterEvents
 

--- a/tests/unit/modules/default/weather/weather_object_spec.js
+++ b/tests/unit/modules/default/weather/weather_object_spec.js
@@ -29,13 +29,13 @@ describe("WeatherObject", () => {
 
 	it("should return sunrise as the next sunaction", () => {
 		weatherobject.updateSunTime(-6.774877582342688, 37.63345667023327);
-		let midnight = moment("00:00", "HH:mm");
+		const midnight = moment("00:00", "HH:mm");
 		expect(weatherobject.nextSunAction(midnight)).toBe("sunrise");
 	});
 
 	it("should return sunset as the next sunaction", () => {
 		weatherobject.updateSunTime(-6.774877582342688, 37.63345667023327);
-		let noon = moment(weatherobject.sunrise).hour(14);
+		const noon = moment(weatherobject.sunrise).hour(14);
 		expect(weatherobject.nextSunAction(noon)).toBe("sunset");
 	});
 

--- a/translations/translations.js
+++ b/translations/translations.js
@@ -1,4 +1,4 @@
-let translations = {
+const translations = {
 	en: "translations/en.json", // English
 	af: "translations/af.json", // Afrikaans
 	bg: "translations/bg.json", // Bulgarian


### PR DESCRIPTION
This replaces `let` with `const` for variable declarations where it was possible. Using `const` [is considered best practice](https://www.xjavascript.com/blog/in-javascript-why-should-i-usually-prefer-const-to-let/#5-best-practices-const-first-let-second).

I have enabled the corresponding ESLint rule and let the ESLint auto-fix the "wrong" usages of `let`.