### PR TITLE
refactor(module): simplify and fix configMerge

### DIFF
--- a/js/module.js
+++ b/js/module.js
@@ -422,48 +422,31 @@ export class Module {
 globalThis.Module = Module;
 
 /**
- * Merging MagicMirror² (or other) default/config script by `@bugsounet`
- * Merge 2 objects or/with array
- *
- * Usage:
- * -------
- * this.config = configMerge({}, this.defaults, this.config)
- * -------
- * arg1: initial object
- * arg2: config model
- * arg3: config to merge
- * -------
- * why using it ?
- * Object.assign() function don't to all job
- * it don't merge all thing in deep
- * -> object in object and array is not merging
- * -------
- *
- * Todo: idea of Mich determinate what do you want to merge or not
- * @param {object} result the initial object
- * @returns {object} the merged config
+ * Deep-merge module defaults with the user config.
+ * Used by Module.setConfig when configDeepMerge is enabled.
+ * Nested plain objects are merged recursively.
+ * All other values (strings, numbers, arrays, …) are overwritten.
+ * Sources are applied left to right; later values win.
+ * @param {object} target The object to merge into (mutated and returned).
+ * @param {...object} sources Objects whose properties are merged into target.
+ * @returns {object} The merged target object.
  */
-function configMerge (result) {
-	const stack = Array.prototype.slice.call(arguments, 1);
-	let item, key;
+function configMerge (target, ...sources) {
+	const isPlainObject = (value) => value?.constructor === Object;
 
-	while (stack.length) {
-		item = stack.shift();
-		for (key in item) {
-			if (item.hasOwnProperty(key)) {
-				if (typeof result[key] === "object" && result[key] && Object.prototype.toString.call(result[key]) !== "[object Array]") {
-					if (typeof item[key] === "object" && item[key] !== null) {
-						result[key] = configMerge({}, result[key], item[key]);
-					} else {
-						result[key] = item[key];
-					}
-				} else {
-					result[key] = item[key];
-				}
-			}
+	for (const source of sources) {
+		for (const [key, sourceValue] of Object.entries(source ?? {})) {
+			const targetValue = target[key];
+			const canDeepMerge = isPlainObject(targetValue) && isPlainObject(sourceValue);
+
+			// Recurse into a fresh object so the shared defaults stay untouched; otherwise overwrite.
+			target[key] = canDeepMerge
+				? configMerge({}, targetValue, sourceValue)
+				: sourceValue;
 		}
 	}
-	return result;
+
+	return target;
 }
 
 Module.definitions = {};

--- a/tests/unit/classes/module_spec.js
+++ b/tests/unit/classes/module_spec.js
@@ -245,6 +245,20 @@ describe("File js/module (cloneObject)", () => {
 				expect(moduleInstance.config).toEqual({ nested: { value: 1 } });
 			});
 
+			it("should overwrite object defaults with arrays in deep merge mode", () => {
+				const moduleName = "MMM-TestDeepMergeArrayOverwrite";
+				Module.register(moduleName, {
+					defaults: {
+						nested: { keep: true }
+					}
+				});
+
+				const moduleInstance = Module.create(moduleName);
+				moduleInstance.setConfig({ nested: [1, 2] }, true);
+
+				expect(moduleInstance.config).toEqual({ nested: [1, 2] });
+			});
+
 			it("should initialize lifecycle fields in setData", () => {
 				const moduleName = "MMM-TestSetData";
 				Module.register(moduleName, {


### PR DESCRIPTION
I had a hard time understanding `configMerge` - the old `arguments` slicing and nested loops took me a while. The jsdoc didn't help much. After it finally clicked, I rewrote it to be readable: rest param + a simple `for...of` instead of the `while`-stack.

And there's one real behavior fix. With this default and user config:

```js
defaults: { foo: { a: 1 } }
config:   { foo: [10, 20] }
```

the old code merged them into `{ foo: { 0: 10, 1: 20, a: 1 } }`. Now the array just replaces the object -> `{ foo: [10, 20] }`.
I added a small test for that case.

Only affects modules using `configDeepMerge: true` that override an object default with an array, so the impact is tiny.