### PR TITLE
Add Halifax Transit real-time arrivals module

### DIFF
--- a/.claude/skills/devlog/SKILL.md
+++ b/.claude/skills/devlog/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: devlog
+description: Append a decision entry to DEVLOG.md capturing the rationale for a non-trivial change made this session.
+---
+
+# Devlog
+
+Review the decisions made in the current session, then append ONE entry to the
+top of `DEVLOG.md` at the repo root.
+
+Rules:
+
+- Capture WHY, not a diff. Rationale, rejected alternatives, consequences — never
+  a restatement of the code changes or a commit list.
+- If nothing decision-worthy happened this session, say so and write nothing.
+- Use exactly this schema:
+
+## YYYY-MM-DD — <short title>
+
+**Context:** <the problem or situation that prompted this>
+**Decision:** <what was chosen>
+**Alternatives rejected:** <options considered and why not>
+**Consequences:** <what this now requires or affects>
+**Refs:** <commit SHAs / PR / files>
+
+- After writing, show me the entry you added.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project intent
+
+This is a personal fork of MagicMirror² for custom improvements and new features. Deployment target is a **Raspberry Pi connected to a monitor**. Keep Pi constraints in mind: ARM architecture, limited RAM, and Raspberry Pi OS (Wayland by default on modern versions, X11 on older).
+
+## Commands
+
+All scripts can be run with either `node --run <script>` or `npm run <script>`.
+
+```bash
+# Install (production)
+npm run install-mm
+
+# Install (development, also installs Playwright)
+npm run install-mm:dev
+
+# Start (Electron, Wayland)
+node --run start
+
+# Start (server-only, no Electron)
+node --run server
+
+# Validate config
+node --run config:check
+
+# Lint & format check
+node --run test:lint
+
+# Lint & format fix
+node --run lint:fix
+
+# Run all tests
+node --run test
+
+# Run specific test suites
+node --run test:unit
+node --run test:e2e
+node --run test:electron
+
+# Run a single test file
+npx vitest run tests/e2e/env_spec.js
+
+# Watch mode
+node --run test:watch
+```
+
+## Architecture
+
+MagicMirror² is a modular smart mirror platform built on **Electron** (optional) + **Express** + **Socket.io**. There is a hard split between server-side and browser-side code.
+
+### Process model
+
+- **`js/electron.js`** — Electron entry point; spawns `js/app.js` as the Node server and opens a BrowserWindow.
+- **`js/app.js`** — Node process entry: starts the Express/Socket.io server (`js/server.js`), then loads each module's `node_helper.js`.
+- **`js/server.js`** — HTTP(S) server. Serves static files, handles IP whitelist, and passes Socket.io events to node helpers.
+- **`serveronly/`** — Alternative entry for running without Electron (headless/server mode).
+- **`clientonly/`** — Client-only entry for when a remote browser connects to an existing server.
+
+### Browser side
+
+- **`index.html`** → loads `js/main.js` (ES module, browser context).
+- **`js/main.js`** — Bootstraps the DOM: iterates configured modules, creates position wrappers, and calls each module's `getDom()`.
+- **`js/module.js`** — Base `Module` class. All modules extend this. Key lifecycle methods: `init()`, `start()`, `getDom()`, `getHeader()`, `notificationReceived()`, `socketNotificationReceived()`.
+- **`js/loader.js`** — Dynamically loads module JS, CSS, and translation files.
+- **`js/socketclient.js`** — Wraps Socket.io on the browser side; routes incoming socket notifications to modules.
+
+### Module structure
+
+Each module lives in `defaultmodules/<name>/` (built-ins) or `modules/<name>/` (third-party):
+
+| File | Side | Purpose |
+|------|------|---------|
+| `<name>.js` | Browser | Module class — extends `Module`, implements `getDom()` etc. |
+| `node_helper.js` | Server | Extends `NodeHelper`; does I/O, external requests, heavy computation. |
+| `<name>.css` | Browser | Module styles. |
+| `templates/*.njk` | Browser | Nunjucks templates (optional). |
+| `translations/*.json` | Both | i18n strings. |
+
+Communication between the two halves uses **Socket.io notifications**:
+- Browser → Server: `this.sendSocketNotification(notification, payload)`
+- Server → Browser: `this.sendSocketNotification(notification, payload)` (from NodeHelper)
+
+### Configuration
+
+- Copy `config/config.js.sample` → `config/config.js` to configure.
+- Key fields: `address`, `port` (default 8080), `ipWhitelist`, `modules[]`.
+- Override config file path via `MM_CONFIG_FILE` env var; override port via `MM_PORT`.
+- Secrets in config are redacted before sending to the browser; `node_helper.js` instances are only allowed to restore secrets defined in their own module's config.
+
+### Testing
+
+Tests use **Vitest** with three named projects — `unit`, `e2e`, and `electron` — all run sequentially on a single worker (port 8080 is shared). Test files follow the `*_spec.js` naming convention. Test configs live in `tests/configs/`.
+
+### Linting
+
+ESLint (config: `eslint.config.mjs`) covers JS, CSS, and Markdown. Prettier (config: `prettier.config.mjs`) handles formatting. The pre-commit hook (Husky + lint-staged) runs both on staged files automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development workflow
 
 For any non-trivial change or new feature:
+
 1. **Enter plan mode** — explore the codebase, propose an approach, get approval before writing code
 2. **Create a feature branch** — `git checkout -b feature/<name>` off master
 3. **Implement** on the branch
@@ -82,15 +83,16 @@ MagicMirror² is a modular smart mirror platform built on **Electron** (optional
 
 Each module lives in `defaultmodules/<name>/` (built-ins) or `modules/<name>/` (third-party):
 
-| File | Side | Purpose |
-|------|------|---------|
-| `<name>.js` | Browser | Module class — extends `Module`, implements `getDom()` etc. |
-| `node_helper.js` | Server | Extends `NodeHelper`; does I/O, external requests, heavy computation. |
-| `<name>.css` | Browser | Module styles. |
-| `templates/*.njk` | Browser | Nunjucks templates (optional). |
-| `translations/*.json` | Both | i18n strings. |
+| File                  | Side    | Purpose                                                               |
+| --------------------- | ------- | --------------------------------------------------------------------- |
+| `<name>.js`           | Browser | Module class — extends `Module`, implements `getDom()` etc.           |
+| `node_helper.js`      | Server  | Extends `NodeHelper`; does I/O, external requests, heavy computation. |
+| `<name>.css`          | Browser | Module styles.                                                        |
+| `templates/*.njk`     | Browser | Nunjucks templates (optional).                                        |
+| `translations/*.json` | Both    | i18n strings.                                                         |
 
 Communication between the two halves uses **Socket.io notifications**:
+
 - Browser → Server: `this.sendSocketNotification(notification, payload)`
 - Server → Browser: `this.sendSocketNotification(notification, payload)` (from NodeHelper)
 
@@ -108,3 +110,15 @@ Tests use **Vitest** with three named projects — `unit`, `e2e`, and `electron`
 ### Linting
 
 ESLint (config: `eslint.config.mjs`) covers JS, CSS, and Markdown. Prettier (config: `prettier.config.mjs`) handles formatting. The pre-commit hook (Husky + lint-staged) runs both on staged files automatically.
+
+## Devlog
+
+- `DEVLOG.md` records decisions and rationale only — not a changelog. Git owns
+  "what changed"; the devlog owns "why."
+- Do NOT write entries for routine edits. Only architectural choices, dependency
+  changes, accepted tradeoffs, or non-obvious gotchas.
+- When such a decision is made, propose an entry using the schema in
+  `.claude/skills/devlog/SKILL.md` and ask before appending — don't write silently.
+- Commit the entry alongside the code change it describes.
+- Do NOT read the full DEVLOG.md unless asked; it can grow long. Read only recent
+  entries if you need prior context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,17 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Development workflow
+
+For any non-trivial change or new feature:
+1. **Enter plan mode** — explore the codebase, propose an approach, get approval before writing code
+2. **Create a feature branch** — `git checkout -b feature/<name>` off master
+3. **Implement** on the branch
+4. **Commit and push** the branch, open a PR to master via `gh pr create`
+5. **Merge** when approved — master should always be deployable to the Pi
+
+Never commit directly to master for new features.
+
 ## Project intent
 
 This is a personal fork of MagicMirror² for custom improvements and new features. Deployment target is a **Raspberry Pi connected to a monitor**. Keep Pi constraints in mind: ARM architecture, limited RAM, and Raspberry Pi OS (Wayland by default on modern versions, X11 on older).

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -8,6 +8,20 @@ This file records **decisions and rationale** — the _why_ behind non-trivial c
 
 ---
 
+## 2026-07-16 — transit module: Halifax Transit real-time arrivals via GTFS-RT
+
+**Context:** Checking bus arrivals for routes 54/55/56/62 near Crichton Ave, Dartmouth NS required manually consulting Halifax Transit's schedule or app. Adding a mirror module to show upcoming arrivals at a specific stop eliminates that friction.
+
+**Decision:** Use the Halifax Transit GTFS-RT TripUpdates protobuf feed (`gtfs.halifax.ca`) with `gtfs-realtime-bindings` for decoding. The node_helper polls every 30 s, filters by configured `stopId` and `routes`, computes minutes-away from departure timestamps, and sends sorted arrivals to the browser module. `undici` (already a production dep) handles the fetch; no API key is required.
+
+**Alternatives rejected:** Static GTFS schedule parsing — rejected because it requires downloading and parsing a large zip on every deploy, has no real-time delay/cancellation data, and goes stale between feed refreshes. Third-party transit APIs — rejected to avoid API key management and external service dependency; the official HRM open data feed is free and direct.
+
+**Consequences:** Adds `gtfs-realtime-bindings` as a production dependency (Protocol Buffers). The user must look up their exact `stopId` from Halifax Transit's static GTFS `stops.txt` before the module shows data. Route IDs in the feed are strings (e.g. `"56"`) and must match exactly in config.
+
+**Refs:** `defaultmodules/transit/`, `defaultmodules/defaultmodules.js`, `package.json`
+
+---
+
 ## 2026-07-16 — displaypower module: built-in display sleep/wake with driver auto-detection
 
 **Context:** The previous MagicMirror installation required manually maintained cron jobs and shell scripts to sleep/wake the connected monitor on a schedule. These lived outside the mirror, were fragile across Pi OS upgrades (X11 vs Wayland command differences), and had no integration with the mirror itself (e.g. couldn't be triggered by other modules like a PIR sensor).

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -1,0 +1,21 @@
+# Devlog
+
+This file records **decisions and rationale** — the _why_ behind non-trivial choices made in this project.
+
+- It is **not a changelog**. Git owns what changed; this file owns why.
+- Routine edits, config tweaks, and bug fixes do not belong here unless they reveal a non-obvious tradeoff.
+- **Newest entries go on top.**
+
+---
+
+## 2026-07-16 — displaypower module: built-in display sleep/wake with driver auto-detection
+
+**Context:** The previous MagicMirror installation required manually maintained cron jobs and shell scripts to sleep/wake the connected monitor on a schedule. These lived outside the mirror, were fragile across Pi OS upgrades (X11 vs Wayland command differences), and had no integration with the mirror itself (e.g. couldn't be triggered by other modules like a PIR sensor).
+
+**Decision:** Implement display power control as a first-class default module (`displaypower`) with a `node_helper.js` that auto-detects the display driver at startup (`wlopm` → `wlr-randr` → `x11` → `vcgencmd` fallback), manages a cron schedule via the existing `croner` dependency, and exposes `DISPLAY_POWER` / `DISPLAY_POWER_STATE` notifications so future modules (e.g. PIR sensor) can control the display at runtime.
+
+**Alternatives rejected:** External cron jobs — rejected because they break on OS upgrades, can't be triggered by mirror events, and add setup burden on each Pi deployment. A config-level `schedule` option on the server — rejected because it would couple display logic to core server code rather than keeping it modular.
+
+**Consequences:** Future sensor modules can send `DISPLAY_POWER` notifications without knowing the underlying driver. The module must be added to `config.js` to activate — it ships inert. Wayland output name defaults to `HDMI-A-1` which may need overriding via `display` config on some Pi setups.
+
+**Refs:** `e90630e4` — `defaultmodules/displaypower/`

--- a/defaultmodules/defaultmodules.js
+++ b/defaultmodules/defaultmodules.js
@@ -2,7 +2,7 @@
  * Default Modules List
  * Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
  */
-const defaultModules = ["alert", "calendar", "clock", "compliments", "displaypower", "helloworld", "newsfeed", "updatenotification", "weather"];
+const defaultModules = ["alert", "calendar", "clock", "compliments", "displaypower", "helloworld", "newsfeed", "transit", "updatenotification", "weather"];
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {

--- a/defaultmodules/defaultmodules.js
+++ b/defaultmodules/defaultmodules.js
@@ -2,7 +2,7 @@
  * Default Modules List
  * Modules listed below can be loaded without the 'default/' prefix. Omitting the default folder name.
  */
-const defaultModules = ["alert", "calendar", "clock", "compliments", "helloworld", "newsfeed", "updatenotification", "weather"];
+const defaultModules = ["alert", "calendar", "clock", "compliments", "displaypower", "helloworld", "newsfeed", "updatenotification", "weather"];
 
 /*************** DO NOT EDIT THE LINE BELOW ***************/
 if (typeof module !== "undefined") {

--- a/defaultmodules/displaypower/README.md
+++ b/defaultmodules/displaypower/README.md
@@ -1,0 +1,55 @@
+# displaypower
+
+Controls display power (sleep/wake) on a schedule or via notifications from other modules. Useful for turning off the mirror screen at night and waking it in the morning without external cron jobs.
+
+## Configuration
+
+```js
+{
+  module: "displaypower",
+  config: {
+    schedule: [
+      { time: "0 7 * * *",  action: "on"  },  // wake at 7:00am every day
+      { time: "0 23 * * *", action: "off" },  // sleep at 11:00pm every day
+    ]
+  }
+}
+```
+
+`time` uses standard cron syntax (minute hour day month weekday).
+
+## Config options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `schedule` | `[]` | Array of `{ time, action }` entries |
+| `driver` | `"auto"` | Display driver (see below) |
+| `display` | auto-detected | Output name for Wayland drivers (e.g. `"HDMI-A-1"`) |
+
+## Drivers
+
+| Value | When to use |
+|-------|-------------|
+| `"auto"` | Detect from environment (recommended) |
+| `"wlopm"` | Wayland, wlopm installed |
+| `"wlr-randr"` | Wayland, wlr-randr installed |
+| `"x11"` | X11 display server |
+| `"vcgencmd"` | Raspberry Pi firmware fallback |
+
+Auto-detection order: if `WAYLAND_DISPLAY` is set → tries `wlopm`, then `wlr-randr`, then `vcgencmd`. If `DISPLAY` is set → `x11`. Otherwise → `vcgencmd`.
+
+## Notifications
+
+**Incoming** — send from any other module to control the display:
+
+```js
+this.sendNotification("DISPLAY_POWER", { action: "on" });
+this.sendNotification("DISPLAY_POWER", { action: "off" });
+```
+
+**Outgoing** — broadcast after each state change:
+
+```js
+// payload: { on: true | false }
+notificationReceived("DISPLAY_POWER_STATE", payload)
+```

--- a/defaultmodules/displaypower/displaypower.js
+++ b/defaultmodules/displaypower/displaypower.js
@@ -1,0 +1,33 @@
+Module.register("displaypower", {
+
+	defaults: {
+		driver: "auto",
+		display: null,
+		schedule: []
+	},
+
+	start () {
+		Log.info(`Starting module: ${this.name}`);
+		this.sendSocketNotification("CONFIG", this.config);
+	},
+
+	/**
+	 * Accept DISPLAY_POWER notifications from other modules.
+	 * Payload: { action: "on" | "off" }
+	 */
+	notificationReceived (notification, payload) {
+		if (notification === "DISPLAY_POWER") {
+			this.sendSocketNotification("SET_POWER", { action: payload.action });
+		}
+	},
+
+	/**
+	 * Re-broadcast power state changes so other modules can react.
+	 * Emits DISPLAY_POWER_STATE with payload: { on: true | false }
+	 */
+	socketNotificationReceived (notification, payload) {
+		if (notification === "POWER_STATE") {
+			this.sendNotification("DISPLAY_POWER_STATE", payload);
+		}
+	}
+});

--- a/defaultmodules/displaypower/node_helper.js
+++ b/defaultmodules/displaypower/node_helper.js
@@ -1,0 +1,123 @@
+const { exec, execSync } = require("node:child_process");
+const NodeHelper = require("node_helper");
+const Log = require("logger");
+const { Cron } = require("croner");
+
+module.exports = NodeHelper.create({
+	config: {},
+	jobs: [],
+	driver: null,
+	displayOutput: null,
+
+	start () {
+		Log.log("Starting node_helper for: displaypower");
+	},
+
+	socketNotificationReceived (notification, payload) {
+		switch (notification) {
+			case "CONFIG":
+				this.config = payload;
+				this.driver = this.detectDriver();
+				this.displayOutput = this.detectOutput();
+				Log.log(`displaypower: using driver "${this.driver}", output "${this.displayOutput}"`);
+				this.scheduleAll();
+				break;
+			case "SET_POWER":
+				this.setPower(payload.action);
+				break;
+		}
+	},
+
+	detectDriver () {
+		if (this.config.driver && this.config.driver !== "auto") {
+			return this.config.driver;
+		}
+		if (process.env.WAYLAND_DISPLAY) {
+			if (this.commandExists("wlopm")) return "wlopm";
+			if (this.commandExists("wlr-randr")) return "wlr-randr";
+			return "vcgencmd";
+		}
+		if (process.env.DISPLAY) {
+			return "x11";
+		}
+		return "vcgencmd";
+	},
+
+	detectOutput () {
+		if (this.config.display) return this.config.display;
+
+		// Try to auto-detect the first connected output via wlr-randr
+		if (this.driver === "wlr-randr" || this.driver === "wlopm") {
+			try {
+				const raw = execSync("wlr-randr 2>/dev/null", { timeout: 2000 }).toString();
+				const match = raw.match(/^(\S+)/m);
+				if (match) return match[1];
+			} catch (e) {
+				// fall through to default
+			}
+		}
+
+		return "HDMI-A-1";
+	},
+
+	commandExists (cmd) {
+		try {
+			execSync(`which ${cmd}`, { timeout: 1000, stdio: "ignore" });
+			return true;
+		} catch (e) {
+			return false;
+		}
+	},
+
+	scheduleAll () {
+		this.jobs.forEach((job) => job.stop());
+		this.jobs = [];
+
+		if (!Array.isArray(this.config.schedule) || this.config.schedule.length === 0) return;
+
+		for (const entry of this.config.schedule) {
+			const job = new Cron(entry.time, () => {
+				this.setPower(entry.action);
+			});
+			this.jobs.push(job);
+			Log.log(`displaypower: scheduled "${entry.action}" at "${entry.time}"`);
+		}
+	},
+
+	setPower (action) {
+		const cmd = this.buildCommand(action);
+		if (!cmd) {
+			Log.warn(`displaypower: no command available for driver "${this.driver}"`);
+			return;
+		}
+		Log.log(`displaypower: running: ${cmd}`);
+		exec(cmd, (err) => {
+			if (err) {
+				Log.error(`displaypower: command failed — ${err.message}`);
+				return;
+			}
+			this.sendSocketNotification("POWER_STATE", { on: action === "on" });
+		});
+	},
+
+	buildCommand (action) {
+		const on = action === "on";
+		switch (this.driver) {
+			case "wlopm":
+				return `wlopm --${on ? "on" : "off"} "${this.displayOutput}"`;
+			case "wlr-randr":
+				return `wlr-randr --output "${this.displayOutput}" ${on ? "--on" : "--off"}`;
+			case "x11":
+				return `xset -display ${process.env.DISPLAY || ":0"} dpms force ${on ? "on" : "off"}`;
+			case "vcgencmd":
+				return `vcgencmd display_power ${on ? "1" : "0"}`;
+			default:
+				return null;
+		}
+	},
+
+	stop () {
+		this.jobs.forEach((job) => job.stop());
+		this.jobs = [];
+	}
+});

--- a/defaultmodules/transit/node_helper.js
+++ b/defaultmodules/transit/node_helper.js
@@ -1,0 +1,83 @@
+const NodeHelper = require("node_helper");
+const Log = require("logger");
+const { fetch } = require("undici");
+const GtfsRealtimeBindings = require("gtfs-realtime-bindings");
+
+const FEED_URL = "https://gtfs.halifax.ca/realtime/TripUpdate/TripUpdates.pb";
+
+module.exports = NodeHelper.create({
+	start () {
+		Log.log(`Starting node helper for: ${this.name}`);
+		this.config = null;
+		this.timer = null;
+	},
+
+	stop () {
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+	},
+
+	socketNotificationReceived (notification, payload) {
+		if (notification === "CONFIG") {
+			this.config = payload;
+			this.startFetching();
+		}
+	},
+
+	startFetching () {
+		this.fetchArrivals();
+	},
+
+	async fetchArrivals () {
+		try {
+			const response = await fetch(FEED_URL);
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+			const buffer = Buffer.from(await response.arrayBuffer());
+			const feed = GtfsRealtimeBindings.transit_realtime.FeedMessage.decode(buffer);
+
+			const now = Date.now() / 1000;
+			const arrivals = [];
+
+			for (const entity of feed.entity) {
+				const tripUpdate = entity.tripUpdate;
+				if (!tripUpdate) continue;
+
+				const routeId = tripUpdate.trip && tripUpdate.trip.routeId;
+				if (!routeId || !this.config.routes.includes(routeId)) continue;
+
+				for (const stu of tripUpdate.stopTimeUpdate) {
+					if (stu.stopId !== this.config.stopId) continue;
+
+					const departureTime = stu.departure && stu.departure.time
+						? Number(stu.departure.time)
+						: stu.arrival && stu.arrival.time
+							? Number(stu.arrival.time)
+							: null;
+
+					if (departureTime === null) continue;
+
+					const minutesAway = Math.round((departureTime - now) / 60);
+					if (minutesAway < 0) continue;
+
+					arrivals.push({ route: routeId, minutesAway });
+					break; // only first matching stop per trip
+				}
+			}
+
+			arrivals.sort((a, b) => a.minutesAway - b.minutesAway);
+			const top = arrivals.slice(0, this.config.maxArrivals);
+
+			this.sendSocketNotification("TRANSIT_DATA", { arrivals: top });
+			Log.log(`Transit: sent ${top.length} arrivals`);
+		} catch (err) {
+			Log.error("Transit: fetch/parse error:", err.message);
+			this.sendSocketNotification("TRANSIT_DATA", { arrivals: [] });
+		}
+
+		this.timer = setTimeout(() => this.fetchArrivals(), this.config.updateInterval);
+	}
+});

--- a/defaultmodules/transit/templates/transit.njk
+++ b/defaultmodules/transit/templates/transit.njk
@@ -1,0 +1,20 @@
+{% if arrivals === null %}
+  <div class="small dimmed">Loading…</div>
+{% elif arrivals | length === 0 %}
+  <div class="small dimmed">No buses scheduled</div>
+{% else %}
+  <table class="transit-table">
+    {% for bus in arrivals %}
+      <tr>
+        <td class="transit-route bright medium"><span class="transit-bus-label dimmed">Bus </span>{{ bus.route }}</td>
+        <td class="transit-sep dimmed">·</td>
+        {% if bus.minutesAway === 0 %}
+          <td class="transit-minutes bright medium" colspan="2">Now</td>
+        {% else %}
+          <td class="transit-minutes bright medium">{{ bus.minutesAway }}</td>
+          <td class="transit-suffix small dimmed">min</td>
+        {% endif %}
+      </tr>
+    {% endfor %}
+  </table>
+{% endif %}

--- a/defaultmodules/transit/transit.css
+++ b/defaultmodules/transit/transit.css
@@ -1,0 +1,35 @@
+.transit-table {
+  border-collapse: collapse;
+}
+
+.transit-table td {
+  padding: 4px 10px;
+  vertical-align: baseline;
+}
+
+.transit-route {
+  text-align: right;
+  min-width: 2.5em;
+  font-size: 1.2em;
+  letter-spacing: 0.02em;
+}
+
+.transit-minutes {
+  text-align: right;
+  min-width: 2em;
+}
+
+.transit-sep {
+  padding: 4px 12px;
+  text-align: center;
+}
+
+.transit-bus-label {
+  font-size: 0.75em;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.transit-suffix {
+  padding-left: 3px;
+}

--- a/defaultmodules/transit/transit.js
+++ b/defaultmodules/transit/transit.js
@@ -1,0 +1,28 @@
+Module.register("transit", {
+	defaults: {
+		stopId: "",
+		routes: [],
+		maxArrivals: 5,
+		updateInterval: 30 * 1000
+	},
+
+	start () {
+		this.arrivals = null; // null = not yet received; [] = received but empty
+		this.sendSocketNotification("CONFIG", this.config);
+	},
+
+	socketNotificationReceived (notification, payload) {
+		if (notification === "TRANSIT_DATA") {
+			this.arrivals = payload.arrivals;
+			this.updateDom(300);
+		}
+	},
+
+	getTemplate () {
+		return "templates/transit.njk";
+	},
+
+	getTemplateData () {
+		return { arrivals: this.arrivals };
+	}
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
 				"express": "^5.2.1",
 				"feedme": "^2.0.2",
 				"globals": "^17.7.0",
+				"gtfs-realtime-bindings": "^2.1.0",
 				"helmet": "^8.2.0",
 				"html-to-text": "^10.0.0",
 				"iconv-lite": "^0.7.2",
@@ -125,7 +126,6 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
 			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -135,7 +135,6 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
 			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -145,7 +144,6 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
 			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.7"
@@ -161,7 +159,6 @@
 			"version": "7.29.7",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
 			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.29.7",
@@ -1486,6 +1483,18 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/@jsdoc/salty": {
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+			"integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash": "^4.18.1"
+			},
+			"engines": {
+				"node": ">=v12.0.0"
+			}
+		},
 		"node_modules/@mswjs/interceptors": {
 			"version": "0.41.9",
 			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
@@ -2016,6 +2025,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
 		"node_modules/@types/mdast": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -2025,6 +2050,12 @@
 			"dependencies": {
 				"@types/unist": "*"
 			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/ms": {
 			"version": "2.1.0",
@@ -2853,6 +2884,12 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
+		},
 		"node_modules/array-timsort": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
@@ -2928,6 +2965,12 @@
 			"dependencies": {
 				"require-from-string": "^2.0.2"
 			}
+		},
+		"node_modules/bluebird": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+			"license": "MIT"
 		},
 		"node_modules/body-parser": {
 			"version": "2.3.0",
@@ -3014,6 +3057,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/catharsis": {
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+			"integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.15"
+			},
+			"engines": {
+				"node": ">= 10"
 			}
 		},
 		"node_modules/ccount": {
@@ -4016,6 +4071,27 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
 		"node_modules/eslint": {
 			"version": "10.6.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
@@ -4367,7 +4443,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
@@ -4710,6 +4785,12 @@
 				"node": ">= 0.8"
 			}
 		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4834,6 +4915,26 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/glob": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^5.0.1",
+				"once": "^1.3.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4844,6 +4945,33 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+			"integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/global-directory": {
@@ -4890,8 +5018,7 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"license": "ISC",
-			"optional": true
+			"license": "ISC"
 		},
 		"node_modules/graphql": {
 			"version": "16.14.2",
@@ -4901,6 +5028,18 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+			}
+		},
+		"node_modules/gtfs-realtime-bindings": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/gtfs-realtime-bindings/-/gtfs-realtime-bindings-2.1.0.tgz",
+			"integrity": "sha512-++VHaoPiKPC53MJ0rNOq47qCQwj3k26D4pJepSQAmI/eFq+Uv+Kr4NCI4KNu5XsmPapiNPywymKHSfcGupVj/g==",
+			"dependencies": {
+				"protobufjs": "^8.2.1",
+				"protobufjs-cli": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=22"
 			}
 		},
 		"node_modules/has-flag": {
@@ -5160,6 +5299,17 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5320,11 +5470,49 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/js2xmlparser": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+			"integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"xmlcreate": "^2.0.4"
+			}
+		},
 		"node_modules/jsbi": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
 			"integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/jsdoc": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+			"integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@babel/parser": "^7.20.15",
+				"@jsdoc/salty": "^0.2.1",
+				"@types/markdown-it": "^14.1.1",
+				"bluebird": "^3.7.2",
+				"catharsis": "^0.9.0",
+				"escape-string-regexp": "^2.0.0",
+				"js2xmlparser": "^4.0.2",
+				"klaw": "^3.0.0",
+				"markdown-it": "^14.1.0",
+				"markdown-it-anchor": "^8.6.7",
+				"marked": "^4.0.10",
+				"mkdirp": "^1.0.4",
+				"requizzle": "^0.2.3",
+				"strip-json-comments": "^3.1.0",
+				"underscore": "~1.13.2"
+			},
+			"bin": {
+				"jsdoc": "jsdoc.js"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
 			"version": "7.2.0",
@@ -5334,6 +5522,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/jsdoc/node_modules/escape-string-regexp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+			"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/jsdom": {
@@ -5470,6 +5667,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/klaw": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+			"integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.9"
 			}
 		},
 		"node_modules/leac": {
@@ -5755,6 +5961,25 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/lint-staged": {
 			"version": "17.0.8",
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
@@ -5811,6 +6036,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+			"license": "MIT"
 		},
 		"node_modules/log-update": {
 			"version": "6.1.0",
@@ -5892,6 +6123,12 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0"
+		},
 		"node_modules/longest-streak": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -5951,6 +6188,43 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/markdown-it": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+			"integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.5.0",
+				"linkify-it": "^5.0.2",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it-anchor": {
+			"version": "8.6.7",
+			"resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+			"integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+			"license": "Unlicense",
+			"peerDependencies": {
+				"@types/markdown-it": "*",
+				"markdown-it": "*"
+			}
+		},
 		"node_modules/markdown-table": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -5960,6 +6234,18 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/marked": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+			"integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/math-intrinsics": {
@@ -6242,6 +6528,12 @@
 			"integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
 			"dev": true,
 			"license": "CC0-1.0"
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
@@ -6945,6 +7237,27 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/moment": {
 			"version": "2.30.1",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -7555,6 +7868,73 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/protobufjs": {
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+			"integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"long": "^5.3.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/protobufjs-cli": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-2.6.1.tgz",
+			"integrity": "sha512-ty8A5JKY/mRTlV/eW7bRoUmOxgzBL66CIBDv7wq8rQUady60rwPwAgqqumcy+oxIkUV6wWTAcxsZjLZKwNsFog==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"escodegen": "^2.0.0",
+				"espree": "^9.6.1",
+				"estraverse": "^5.1.0",
+				"glob": "^8.1.0",
+				"jsdoc": "^4.0.5",
+				"minimist": "^1.2.8",
+				"tmp": "^0.2.7"
+			},
+			"bin": {
+				"pbjs": "bin/pbjs",
+				"pbts": "bin/pbts",
+				"protoc-gen-pbjs": "bin/protoc-gen-pbjs"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"protobufjs": "^8.7.1"
+			}
+		},
+		"node_modules/protobufjs-cli/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/protobufjs-cli/node_modules/espree": {
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.9.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^3.4.1"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -7581,6 +7961,15 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -7648,6 +8037,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/requizzle": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+			"integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.21"
 			}
 		},
 		"node_modules/reserved-identifiers": {
@@ -8172,6 +8570,16 @@
 				"node": ">=22"
 			}
 		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8310,6 +8718,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/sumchecker": {
@@ -8468,6 +8888,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/tmp": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/to-valid-identifier": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
@@ -8624,6 +9053,18 @@
 			"engines": {
 				"node": ">=14.17"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
+		},
+		"node_modules/underscore": {
+			"version": "1.13.8",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+			"integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+			"license": "MIT"
 		},
 		"node_modules/undici": {
 			"version": "8.5.0",
@@ -9187,6 +9628,12 @@
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/xmlcreate": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+			"integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
 		"express": "^5.2.1",
 		"feedme": "^2.0.2",
 		"globals": "^17.7.0",
+		"gtfs-realtime-bindings": "^2.1.0",
 		"helmet": "^8.2.0",
 		"html-to-text": "^10.0.0",
 		"iconv-lite": "^0.7.2",


### PR DESCRIPTION
## Summary

- New `transit` default module polling the Halifax Transit GTFS-RT TripUpdates feed every 30s
- Filters by stop ID and route, sorts arrivals soonest-first, auto-updates DOM without page refresh
- Adds `gtfs-realtime-bindings` as a production dependency for protobuf decoding

## Test plan

- [ ] `npm install` succeeds with new dependency
- [ ] Add transit block to `config/config.js` with a valid Halifax stop ID
- [ ] Start server — transit node_helper appears in logs
- [ ] Browser shows arrivals (or "Loading…" / "No buses scheduled" when feed is empty)
- [ ] Arrivals refresh automatically every 30s without page reload
- [ ] Pi deployment: `npm run install-mm` picks up `gtfs-realtime-bindings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)