### PR TITLE
[calendar] Fix sliced multi-day sub-events starting at 23:59 instead of next day 00:00

### DIFF
--- a/defaultmodules/calendar/calendar.js
+++ b/defaultmodules/calendar/calendar.js
@@ -531,7 +531,7 @@ Module.register("calendar", {
 						thisEvent.title += ` (${count}/${maxCount})`;
 						splitEvents.push(thisEvent);
 
-						event.startDate = midnight.format("x");
+						event.startDate = midnight.clone().startOf("day").format("x");
 						count += 1;
 						midnight = midnight.clone().add(1, "day").endOf("day"); // next day
 					}

--- a/tests/configs/modules/calendar/sliceMultiDayEventsStart.js
+++ b/tests/configs/modules/calendar/sliceMultiDayEventsStart.js
@@ -1,0 +1,28 @@
+let config = {
+	address: "0.0.0.0",
+	ipWhitelist: [],
+	timeFormat: 24,
+
+	modules: [
+		{
+			module: "calendar",
+			position: "bottom_bar",
+			config: {
+				hideDuplicates: false,
+				maximumEntries: 100,
+				sliceMultiDayEvents: true,
+				calendars: [
+					{
+						maximumEntries: 100,
+						url: "http://localhost:8080/tests/mocks/sliceMultiDayEvents.ics"
+					}
+				]
+			}
+		}
+	]
+};
+
+/*************** DO NOT EDIT THE LINE BELOW ***************/
+if (typeof module !== "undefined") {
+	module.exports = config;
+}

--- a/tests/electron/modules/calendar_spec.js
+++ b/tests/electron/modules/calendar_spec.js
@@ -181,6 +181,17 @@ describe("Calendar module", () => {
 		});
 	});
 
+	describe("sliceMultiDayEvents sub-event start time", () => {
+		it("Issue #4206 sliced sub-events start at 00:00, not 23:59", async () => {
+			await helpers.startApplication("tests/configs/modules/calendar/sliceMultiDayEventsStart.js", "01 Sept 2024 10:38:00 GMT+02:00", [], "Europe/Berlin");
+			const times = await global.page.locator(".calendar .event .time").allTextContents();
+			expect(times.length).toBeGreaterThan(0);
+			for (const timeText of times) {
+				expect(timeText).not.toContain("23:59");
+			}
+		});
+	});
+
 	describe("germany timezone", () => {
 		it("Issue #unknown fullday timezone East of UTC edge", async () => {
 			await helpers.startApplication("tests/configs/modules/calendar/germany_at_end_of_day_repeating.js", "01 Oct 2024 10:38:00 GMT+02:00", [], "Europe/Berlin");


### PR DESCRIPTION
Fixes #4206

### Problem
With `sliceMultiDayEvents: true`, a multi-day event is split into per-day slices `(1/n)`, `(2/n)`, … Every slice **after the first** was displayed as starting at **23:59** instead of the next day's 00:00.

### Cause
In `defaultmodules/calendar/calendar.js`, the slicing loop advances the day boundary with:

```js
let midnight = eventStartDateMoment.clone().startOf("day").add(1, "day").endOf("day");
...
event.startDate = midnight.format("x");   // start of the NEXT slice
```

`midnight` is `.endOf("day")` (23:59:59.999) but is assigned as the following slice's `startDate`, so each subsequent slice starts at 23:59:59.999 of the previous day rather than 00:00 of its own day.

### Fix
Use the start of the day for the next slice's start:

```diff
- event.startDate = midnight.format("x");
+ event.startDate = midnight.clone().startOf("day").format("x");
```

### Test
Adds an e2e regression test (`sliceMultiDayEvents sub-event start time`) that reuses the existing slice mock with a 24h `timeFormat` and asserts that no sliced sub-event time cell contains `23:59`. It fails on the previous behaviour and passes with the fix.

Note: I could not run the full Electron e2e suite locally (resource-constrained hardware running production services); the fix logic was verified with a standalone reproduction and the test follows the existing `sliceMultiDayEvents` patterns. Happy to adjust based on CI.