### PR TITLE
refactor: consolidate electron bootstrap into async function

### DIFF
--- a/js/electron.js
+++ b/js/electron.js
@@ -58,14 +58,13 @@ function createWindow () {
 			nodeIntegration: false,
 			zoomFactor: config.zoom
 		},
-		backgroundColor: "#000000"
+		backgroundColor: "#000000",
+		show: false,
+		frame: false,
+		transparent: true,
+		hasShadow: false,
+		fullscreen: true
 	};
-
-	electronOptionsDefaults.show = false;
-	electronOptionsDefaults.frame = false;
-	electronOptionsDefaults.transparent = true;
-	electronOptionsDefaults.hasShadow = false;
-	electronOptionsDefaults.fullscreen = true;
 
 	const electronOptions = Object.assign({}, electronOptionsDefaults, config.electronOptions);
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -30,7 +30,7 @@ const BrowserWindow = electron.BrowserWindow;
 let mainWindow;
 
 /**
- *
+ * Create and show the main browser window.
  */
 function createWindow () {
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -190,23 +190,26 @@ app.on("certificate-error", (event, webContents, url, error, certificate, callba
 	callback(true);
 });
 
-if (process.env.clientonly) {
-	app.whenReady().then(() => {
+/**
+ * Bootstrap Electron: launch the client-only viewer and/or the full core application.
+ */
+async function bootstrapElectron () {
+	if (process.env.clientonly) {
+		await app.whenReady();
 		Log.log("Launching client viewer application.");
 		createWindow();
-	});
+	}
+
+	/*
+	 * Start the core application if server is run on localhost
+	 * This starts all node helpers and starts the webserver.
+	 */
+	if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].includes(config.address)) {
+		config = await core.start();
+		await app.whenReady();
+		Log.log("Launching application.");
+		createWindow();
+	}
 }
 
-/*
- * Start the core application if server is run on localhost
- * This starts all node helpers and starts the webserver.
- */
-if (["localhost", "127.0.0.1", "::1", "::ffff:127.0.0.1", undefined].includes(config.address)) {
-	core.start().then((c) => {
-		config = c;
-		app.whenReady().then(() => {
-			Log.log("Launching application.");
-			createWindow();
-		});
-	});
-}
+bootstrapElectron();

--- a/js/electron.js
+++ b/js/electron.js
@@ -166,8 +166,10 @@ app.on("activate", function () {
 });
 
 /*
- * This method will be called when SIGINT is received and will call
- * each node_helper's stop function if it exists. Added to fix #1056
+ * Electron routes SIGINT (and other quit signals) to the app's quit sequence,
+ * which triggers this "before-quit" event. This handler calls each
+ * node_helper's stop function if it exists.
+ * Added to fix #1056 (no method to gracefully shut down modules on exit).
  *
  * Note: this is only used if running Electron. Otherwise
  * core.stop() is called by process.on("SIGINT"... in `app.js`


### PR DESCRIPTION
Mainly I wanted to replace the two not-so-pretty nested `.then()` promise chains at the bottom of `js/electron.js` with a proper `async` function. While I was at that file, optimized two JSdocs and did a small style optimization.

No functional changes intended.