### PR TITLE
style: simplify Electron startup checks

### DIFF
--- a/js/electron.js
+++ b/js/electron.js
@@ -94,7 +94,7 @@ function createWindow () {
 	 */
 
 	let prefix;
-	if ((config.tls !== null && config.tls) || config.useHttps) {
+	if (config.tls || config.useHttps) {
 		prefix = "https://";
 	} else {
 		prefix = "http://";

--- a/js/electron.js
+++ b/js/electron.js
@@ -127,11 +127,11 @@ function createWindow () {
 	//remove response headers that prevent sites of being embedded into iframes if configured
 	mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
 		let curHeaders = details.responseHeaders;
-		if (config.ignoreXOriginHeader || false) {
+		if (config.ignoreXOriginHeader) {
 			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !(/x-frame-options/i).test(header[0])));
 		}
 
-		if (config.ignoreContentSecurityPolicy || false) {
+		if (config.ignoreContentSecurityPolicy) {
 			curHeaders = Object.fromEntries(Object.entries(curHeaders).filter((header) => !(/content-security-policy/i).test(header[0])));
 		}
 

--- a/js/electron.js
+++ b/js/electron.js
@@ -100,9 +100,11 @@ function createWindow () {
 		prefix = "http://";
 	}
 
-	const address = (config.address === void 0) | (config.address === "") | (config.address === "0.0.0.0") | (config.address === "::") ? (config.address = "localhost") : config.address;
+	if (config.address === undefined || config.address === "" || config.address === "0.0.0.0" || config.address === "::") {
+		config.address = "localhost";
+	}
 	const port = getServerPort(config);
-	mainWindow.loadURL(`${prefix}${address}:${port}`);
+	mainWindow.loadURL(`${prefix}${config.address}:${port}`);
 
 	// Open the DevTools if run with "node --run start:dev"
 	if (process.argv.includes("dev")) {


### PR DESCRIPTION
I made a few small readability improvements to the Electron startup code. The redundant checks and bitwise address normalization have been simplified, while keeping the runtime behavior unchanged.