### PR TITLE
refactor(socket): use direct ESM import in main

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,6 +3,7 @@
 // Ensure Module global bridge is initialized before main bootstrap logic runs.
 import "./module.js";
 import { loadModules } from "./loader.js";
+import { io } from "./socketclient.js";
 import { Translator } from "./translator.js";
 
 let modules = [];
@@ -593,17 +594,14 @@ export const MM = {
 		createDomObjects();
 
 		// Setup global socket listener for RELOAD event (watch mode)
-		const ioClient = globalThis.io;
-		if (typeof ioClient !== "undefined") {
-			const socket = ioClient("/", {
-				path: `${config.basePath || "/"}socket.io`
-			});
+		const socket = io("/", {
+			path: `${config.basePath || "/"}socket.io`
+		});
 
-			socket.on("RELOAD", () => {
-				Log.warn("Reload notification received from server");
-				window.location.reload(true);
-			});
-		}
+		socket.on("RELOAD", () => {
+			Log.warn("Reload notification received from server");
+			window.location.reload(true);
+		});
 
 		if (config.reloadAfterServerRestart) {
 			setInterval(async () => {

--- a/js/socketclient.js
+++ b/js/socketclient.js
@@ -1,5 +1,12 @@
 // eslint-disable-next-line import-x/no-unresolved -- Socket.IO serves this module at runtime.
-const { io } = await import(/* @vite-ignore */ "/socket.io/socket.io.esm.min.js");
+const socketIo = await import(/* @vite-ignore */ "/socket.io/socket.io.esm.min.js");
+const { io } = socketIo;
+
+if (typeof io !== "function") {
+	throw new Error("Socket.IO client did not provide a callable io export.");
+}
+
+export { io };
 
 export const MMSocket = function (moduleName) {
 	if (typeof moduleName !== "string") {

--- a/tests/utils/vitest-setup.js
+++ b/tests/utils/vitest-setup.js
@@ -7,6 +7,7 @@ const Module = require("node:module");
 const path = require("node:path");
 
 vi.doMock(path.resolve(__dirname, "../..", "js", "socketclient.js"), () => ({
+	io () {},
 	MMSocket () {}
 }));
 


### PR DESCRIPTION
This is a follow-up to #4224.

The original PR focused on loading Socket.IO as ESM while keeping existing modules compatible. While reviewing that change, I noticed that I missed that `main.js` was still reading the client through the global `io` variable. This PR cleans that up.

